### PR TITLE
remove meaningless assert

### DIFF
--- a/src/node.cpp
+++ b/src/node.cpp
@@ -33,7 +33,6 @@ std::vector<uint64_t> node_t::edges(void) const {
                        (uint8_t*)bytes.data()+edge_start(),
                        edge_count()*EDGE_RECORD_LENGTH);
     }
-    assert(res.size() == edge_count);
     return res;
 }
 


### PR DESCRIPTION
This removes an assert that @jeizenga found.

These asserts weren't being touched because of a CMakeLists.txt configuraiton issue (using Release mode).