### PR TITLE
parallelize odgi squeeze

### DIFF
--- a/docs/asciidocs/odgi_docs.html
+++ b/docs/asciidocs/odgi_docs.html
@@ -1914,7 +1914,18 @@ This argument only works when <em>-Y, --path-sgd</em> was specified. Not applica
 </div>
 </div>
 <div class="sect3">
-<h4 id="_processing_information_6">9.4.3. Processing Information</h4>
+<h4 id="_threading_6">9.4.3. Threading</h4>
+<div class="dlist">
+<dl>
+<dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
+<dd>
+<p>Number of threads to use.</p>
+</dd>
+</dl>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_processing_information_6">9.4.4. Processing Information</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-P, --progress</strong></dt>
@@ -1925,7 +1936,7 @@ This argument only works when <em>-Y, --path-sgd</em> was specified. Not applica
 </div>
 </div>
 <div class="sect3">
-<h4 id="_program_information_8">9.4.4. Program Information</h4>
+<h4 id="_program_information_8">9.4.5. Program Information</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-h, --help</strong></dt>
@@ -2048,7 +2059,7 @@ Be careful to use it with very complex graphs.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_threading_6">10.4.3. Threading</h4>
+<h4 id="_threading_7">10.4.3. Threading</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
@@ -2260,7 +2271,7 @@ of furcations at edges or by not considering nodes above a given node degree lim
 </div>
 </div>
 <div class="sect3">
-<h4 id="_threading_7">12.4.3. Threading</h4>
+<h4 id="_threading_8">12.4.3. Threading</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
@@ -2728,7 +2739,7 @@ with [<strong>-H, --haplotypes</strong>]. Prints an additional, first column <st
 </div>
 </div>
 <div class="sect3">
-<h4 id="_threading_8">15.4.3. Threading</h4>
+<h4 id="_threading_9">15.4.3. Threading</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
@@ -2885,7 +2896,7 @@ fitting into these conditions.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_threading_9">16.4.6. Threading</h4>
+<h4 id="_threading_10">16.4.6. Threading</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
@@ -2986,7 +2997,7 @@ fitting into these conditions.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_threading_10">17.4.3. Threading</h4>
+<h4 id="_threading_11">17.4.3. Threading</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
@@ -3447,7 +3458,7 @@ Each value is the coverage of a specific node of a specific path.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_threading_11">21.4.3. Threading</h4>
+<h4 id="_threading_12">21.4.3. Threading</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
@@ -4088,7 +4099,7 @@ between <code>--source</code> and <code>--target</code>].</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_threading_12">27.4.3. Threading</h4>
+<h4 id="_threading_13">27.4.3. Threading</h4>
 <div class="dlist">
 <dl>
 <dt class="hdlist1"><strong>-t, --threads</strong>=<em>N</em></dt>
@@ -4492,7 +4503,7 @@ be selected. odgi test(1) depends on <a href="https://github.com/catchorg/Catch2
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-03-17 18:27:05 +0100
+Last updated 2021-03-17 21:13:35 +0100
 </div>
 </div>
 </body>

--- a/docs/asciidocs/odgi_docs.pdf
+++ b/docs/asciidocs/odgi_docs.pdf
@@ -5,16 +5,16 @@
 /Author (Simon Heumos, Andrea Guarracino, Erik Garrison)
 /Creator (Asciidoctor PDF 1.5.0.alpha.17.dev, based on Prawn 2.2.0)
 /Producer (Simon Heumos, Andrea Guarracino, Erik Garrison)
-/ModDate (D:20210317182705+01'00')
-/CreationDate (D:20210317182706+01'00')
+/ModDate (D:20210317211335+01'00')
+/CreationDate (D:20210317211336+01'00')
 >>
 endobj
 2 0 obj
 << /Type /Catalog
 /Pages 3 0 R
 /Names 14 0 R
-/Outlines 708 0 R
-/PageLabels 741 0 R
+/Outlines 709 0 R
+/PageLabels 742 0 R
 /PageMode /UseOutlines
 /OpenAction [7 0 R /FitH 842.89]
 /ViewerPreferences << /DisplayDocTitle true
@@ -24,7 +24,7 @@ endobj
 3 0 obj
 << /Type /Pages
 /Count 58
-/Kids [7 0 R 10 0 R 12 0 R 43 0 R 59 0 R 69 0 R 76 0 R 93 0 R 105 0 R 116 0 R 131 0 R 136 0 R 150 0 R 155 0 R 171 0 R 177 0 R 180 0 R 186 0 R 197 0 R 209 0 R 219 0 R 231 0 R 243 0 R 257 0 R 271 0 R 278 0 R 291 0 R 303 0 R 313 0 R 326 0 R 339 0 R 344 0 R 350 0 R 361 0 R 369 0 R 382 0 R 391 0 R 404 0 R 417 0 R 430 0 R 441 0 R 446 0 R 460 0 R 473 0 R 485 0 R 497 0 R 509 0 R 520 0 R 534 0 R 550 0 R 566 0 R 579 0 R 585 0 R 603 0 R 617 0 R 621 0 R 627 0 R 641 0 R]
+/Kids [7 0 R 10 0 R 12 0 R 43 0 R 59 0 R 69 0 R 76 0 R 93 0 R 105 0 R 116 0 R 131 0 R 136 0 R 150 0 R 155 0 R 171 0 R 177 0 R 180 0 R 186 0 R 197 0 R 209 0 R 219 0 R 231 0 R 243 0 R 257 0 R 271 0 R 277 0 R 290 0 R 302 0 R 311 0 R 326 0 R 338 0 R 343 0 R 350 0 R 359 0 R 367 0 R 381 0 R 390 0 R 403 0 R 415 0 R 428 0 R 440 0 R 446 0 R 457 0 R 471 0 R 482 0 R 496 0 R 506 0 R 517 0 R 533 0 R 547 0 R 561 0 R 574 0 R 584 0 R 597 0 R 611 0 R 623 0 R 625 0 R 638 0 R]
 >>
 endobj
 4 0 obj
@@ -111,11 +111,11 @@ endobj
 << /Type /Font
 /BaseFont /6f2aa1+NotoSerif
 /Subtype /TrueType
-/FontDescriptor 743 0 R
+/FontDescriptor 744 0 R
 /FirstChar 32
 /LastChar 255
-/Widths 745 0 R
-/ToUnicode 744 0 R
+/Widths 746 0 R
+/ToUnicode 745 0 R
 >>
 endobj
 9 0 obj
@@ -891,7 +891,7 @@ ET
 BT
 535.301 419.216 Td
 /F1.0 10.5 Tf
-<3337> Tj
+<3338> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -1051,7 +1051,7 @@ ET
 BT
 535.301 345.296 Td
 /F1.0 10.5 Tf
-<3434> Tj
+<3435> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -1091,7 +1091,7 @@ ET
 BT
 535.301 326.816 Td
 /F1.0 10.5 Tf
-<3435> Tj
+<3436> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -1211,7 +1211,7 @@ ET
 BT
 535.301 271.376 Td
 /F1.0 10.5 Tf
-<3439> Tj
+<3530> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -1291,7 +1291,7 @@ ET
 BT
 535.301 234.416 Td
 /F1.0 10.5 Tf
-<3532> Tj
+<3533> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -1354,7 +1354,7 @@ endobj
 /F1.0 8 0 R
 >>
 >>
-/Annots [646 0 R 647 0 R 648 0 R 649 0 R 650 0 R 651 0 R 652 0 R 653 0 R 654 0 R 655 0 R 656 0 R 657 0 R 658 0 R 659 0 R 660 0 R 661 0 R 662 0 R 663 0 R 664 0 R 665 0 R 666 0 R 667 0 R 668 0 R 669 0 R 670 0 R 671 0 R 672 0 R 673 0 R 674 0 R 675 0 R 676 0 R 677 0 R 678 0 R 679 0 R 680 0 R 681 0 R 682 0 R 683 0 R 684 0 R 685 0 R 686 0 R 687 0 R 688 0 R 689 0 R 690 0 R 691 0 R 692 0 R 693 0 R 694 0 R 695 0 R 696 0 R 697 0 R 698 0 R 699 0 R 700 0 R 701 0 R 702 0 R 703 0 R 704 0 R 705 0 R]
+/Annots [647 0 R 648 0 R 649 0 R 650 0 R 651 0 R 652 0 R 653 0 R 654 0 R 655 0 R 656 0 R 657 0 R 658 0 R 659 0 R 660 0 R 661 0 R 662 0 R 663 0 R 664 0 R 665 0 R 666 0 R 667 0 R 668 0 R 669 0 R 670 0 R 671 0 R 672 0 R 673 0 R 674 0 R 675 0 R 676 0 R 677 0 R 678 0 R 679 0 R 680 0 R 681 0 R 682 0 R 683 0 R 684 0 R 685 0 R 686 0 R 687 0 R 688 0 R 689 0 R 690 0 R 691 0 R 692 0 R 693 0 R 694 0 R 695 0 R 696 0 R 697 0 R 698 0 R 699 0 R 700 0 R 701 0 R 702 0 R 703 0 R 704 0 R 705 0 R 706 0 R]
 >>
 endobj
 11 0 obj
@@ -2413,7 +2413,7 @@ endobj
 /Font << /F2.0 17 0 R
 /F1.0 8 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 /Annots [20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R]
@@ -2428,7 +2428,7 @@ endobj
 >>
 endobj
 15 0 obj
-<< /Kids [528 0 R 529 0 R]
+<< /Kids [529 0 R 530 0 R]
 >>
 endobj
 16 0 obj
@@ -2438,11 +2438,11 @@ endobj
 << /Type /Font
 /BaseFont /bbfc52+NotoSerif-Bold
 /Subtype /TrueType
-/FontDescriptor 747 0 R
+/FontDescriptor 748 0 R
 /FirstChar 32
 /LastChar 255
-/Widths 749 0 R
-/ToUnicode 748 0 R
+/Widths 750 0 R
+/ToUnicode 749 0 R
 >>
 endobj
 18 0 obj
@@ -4299,7 +4299,7 @@ endobj
 /F1.0 8 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 /Annots [44 0 R 45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 51 0 R 52 0 R 53 0 R 56 0 R 57 0 R]
@@ -4396,11 +4396,11 @@ endobj
 << /Type /Font
 /BaseFont /640789+NotoSerif-Italic
 /Subtype /TrueType
-/FontDescriptor 751 0 R
+/FontDescriptor 752 0 R
 /FirstChar 32
 /LastChar 255
-/Widths 753 0 R
-/ToUnicode 752 0 R
+/Widths 754 0 R
+/ToUnicode 753 0 R
 >>
 endobj
 56 0 obj
@@ -6017,7 +6017,7 @@ endobj
 /F1.0 8 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 /Annots [60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 65 0 R 66 0 R 67 0 R]
@@ -8061,7 +8061,7 @@ endobj
 /F2.0 17 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 /Annots [70 0 R 71 0 R 72 0 R 73 0 R 74 0 R]
@@ -10113,7 +10113,7 @@ endobj
 /F3.0 55 0 R
 /F1.1 80 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 /Annots [77 0 R 78 0 R 79 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 86 0 R 87 0 R 88 0 R 90 0 R]
@@ -10153,11 +10153,11 @@ endobj
 << /Type /Font
 /BaseFont /cfcc73+NotoSerif
 /Subtype /TrueType
-/FontDescriptor 755 0 R
+/FontDescriptor 756 0 R
 /FirstChar 32
 /LastChar 255
-/Widths 757 0 R
-/ToUnicode 756 0 R
+/Widths 758 0 R
+/ToUnicode 757 0 R
 >>
 endobj
 81 0 obj
@@ -10876,7 +10876,7 @@ endobj
 /F2.0 17 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 /Annots [95 0 R 96 0 R 97 0 R 98 0 R]
@@ -11498,7 +11498,7 @@ endobj
 /F4.0 111 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 /Annots [106 0 R 107 0 R 108 0 R]
@@ -11547,11 +11547,11 @@ endobj
 << /Type /Font
 /BaseFont /e3b334+NotoSerif-BoldItalic
 /Subtype /TrueType
-/FontDescriptor 759 0 R
+/FontDescriptor 760 0 R
 /FirstChar 32
 /LastChar 255
-/Widths 761 0 R
-/ToUnicode 760 0 R
+/Widths 762 0 R
+/ToUnicode 761 0 R
 >>
 endobj
 112 0 obj
@@ -12147,7 +12147,7 @@ endobj
 /F3.0 55 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 /Annots [121 0 R]
@@ -12161,12 +12161,12 @@ endobj
 endobj
 119 0 obj
 << /Limits [(__anchor-top) (_authors_16)]
-/Names [(__anchor-top) 13 0 R (_additional_parameters) 184 0 R (_authors) 91 0 R (_authors_10) 282 0 R (_authors_11) 296 0 R (_authors_12) 311 0 R (_authors_13) 330 0 R (_authors_14) 354 0 R (_authors_15) 374 0 R (_authors_16) 395 0 R]
+/Names [(__anchor-top) 13 0 R (_additional_parameters) 184 0 R (_authors) 91 0 R (_authors_10) 283 0 R (_authors_11) 297 0 R (_authors_12) 314 0 R (_authors_13) 331 0 R (_authors_14) 355 0 R (_authors_15) 375 0 R (_authors_16) 396 0 R]
 >>
 endobj
 120 0 obj
 << /Limits [(_graph_files_io_10) (_graph_files_io_19)]
-/Names [(_graph_files_io_10) 288 0 R (_graph_files_io_11) 304 0 R (_graph_files_io_12) 320 0 R (_graph_files_io_13) 337 0 R (_graph_files_io_14) 363 0 R (_graph_files_io_15) 380 0 R (_graph_files_io_16) 401 0 R (_graph_files_io_17) 419 0 R (_graph_files_io_18) 437 0 R (_graph_files_io_19) 458 0 R]
+/Names [(_graph_files_io_10) 291 0 R (_graph_files_io_11) 305 0 R (_graph_files_io_12) 321 0 R (_graph_files_io_13) 340 0 R (_graph_files_io_14) 364 0 R (_graph_files_io_15) 383 0 R (_graph_files_io_16) 404 0 R (_graph_files_io_17) 420 0 R (_graph_files_io_18) 438 0 R (_graph_files_io_19) 461 0 R]
 >>
 endobj
 121 0 obj
@@ -12723,7 +12723,7 @@ endobj
 /F3.0 55 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 >>
@@ -13260,7 +13260,7 @@ endobj
 /F3.0 55 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 /Annots [139 0 R]
@@ -13291,7 +13291,7 @@ endobj
 endobj
 142 0 obj
 << /Limits [(_options_10) (_options_19)]
-/Names [(_options_10) 287 0 R (_options_11) 301 0 R (_options_12) 319 0 R (_options_13) 336 0 R (_options_14) 362 0 R (_options_15) 379 0 R (_options_16) 400 0 R (_options_17) 418 0 R (_options_18) 436 0 R (_options_19) 457 0 R]
+/Names [(_options_10) 288 0 R (_options_11) 304 0 R (_options_12) 320 0 R (_options_13) 339 0 R (_options_14) 363 0 R (_options_15) 382 0 R (_options_16) 401 0 R (_options_17) 419 0 R (_options_18) 437 0 R (_options_19) 460 0 R]
 >>
 endobj
 143 0 obj
@@ -13922,7 +13922,7 @@ endobj
 /F2.0 17 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 >>
@@ -14749,7 +14749,7 @@ endobj
 /F1.0 8 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 /Annots [157 0 R 164 0 R 165 0 R 166 0 R 167 0 R 168 0 R 169 0 R]
@@ -14786,7 +14786,7 @@ endobj
 endobj
 163 0 obj
 << /Limits [(_copying) (_description_15)]
-/Names [(_copying) 99 0 R (_cover_options) 217 0 R (_cycle_options) 530 0 R (_depth_options) 148 0 R (_description) 50 0 R (_description_10) 267 0 R (_description_11) 286 0 R (_description_12) 300 0 R (_description_13) 317 0 R (_description_14) 334 0 R (_description_15) 359 0 R]
+/Names [(_copying) 99 0 R (_cover_options) 217 0 R (_cycle_options) 531 0 R (_depth_options) 148 0 R (_description) 50 0 R (_description_10) 269 0 R (_description_11) 287 0 R (_description_12) 303 0 R (_description_13) 318 0 R (_description_14) 335 0 R (_description_15) 362 0 R]
 >>
 endobj
 164 0 obj
@@ -15409,7 +15409,7 @@ endobj
 /F1.0 8 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 >>
@@ -16367,7 +16367,7 @@ endobj
 /F4.0 111 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 >>
@@ -17124,7 +17124,7 @@ endobj
 /F2.0 17 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 >>
@@ -17134,7 +17134,7 @@ endobj
 endobj
 182 0 obj
 << /Limits [(_resources) (_synopsis_13)]
-/Names [(_resources) 94 0 R (_sgd_options) 494 0 R (_sorting_goodness_evaluation) 132 0 R (_squeeze_options) 254 0 R (_summary_options) 129 0 R (_summary_options_2) 289 0 R (_svg_options) 495 0 R (_synopsis) 19 0 R (_synopsis_10) 266 0 R (_synopsis_11) 285 0 R (_synopsis_12) 299 0 R (_synopsis_13) 316 0 R]
+/Names [(_resources) 94 0 R (_sgd_options) 497 0 R (_sorting_goodness_evaluation) 132 0 R (_squeeze_options) 254 0 R (_summary_options) 129 0 R (_summary_options_2) 292 0 R (_svg_options) 498 0 R (_synopsis) 19 0 R (_synopsis_10) 267 0 R (_synopsis_11) 286 0 R (_synopsis_12) 300 0 R (_synopsis_13) 317 0 R]
 >>
 endobj
 183 0 obj
@@ -17562,7 +17562,7 @@ endobj
 /F1.0 8 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 /Annots [192 0 R]
@@ -18232,7 +18232,7 @@ endobj
 /F3.0 55 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 /Annots [206 0 R]
@@ -18992,7 +18992,7 @@ endobj
 /F3.0 55 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 >>
@@ -19017,7 +19017,7 @@ endobj
 endobj
 216 0 obj
 << /Limits [(_name_5) (_odgi_explode1)]
-/Names [(_name_5) 160 0 R (_name_6) 195 0 R (_name_7) 211 0 R (_name_8) 228 0 R (_name_9) 248 0 R (_node_options) 384 0 R (_odgi_1) 16 0 R (_odgi_bin1) 427 0 R (_odgi_break1) 518 0 R (_odgi_build1) 100 0 R (_odgi_chop1) 468 0 R (_odgi_cover1) 210 0 R (_odgi_depth1) 141 0 R (_odgi_explode1) 227 0 R]
+/Names [(_name_5) 160 0 R (_name_6) 195 0 R (_name_7) 211 0 R (_name_8) 228 0 R (_name_9) 248 0 R (_node_options) 385 0 R (_odgi_1) 16 0 R (_odgi_bin1) 430 0 R (_odgi_break1) 521 0 R (_odgi_build1) 100 0 R (_odgi_chop1) 469 0 R (_odgi_cover1) 210 0 R (_odgi_depth1) 141 0 R (_odgi_explode1) 227 0 R]
 >>
 endobj
 217 0 obj
@@ -19634,7 +19634,7 @@ endobj
 /F2.0 17 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 /Annots [225 0 R]
@@ -20229,7 +20229,7 @@ endobj
 /F3.0 55 0 R
 /F5.0 236 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
 >>
@@ -20250,11 +20250,11 @@ endobj
 << /Type /Font
 /BaseFont /43494f+mplus1mn-regular
 /Subtype /TrueType
-/FontDescriptor 763 0 R
+/FontDescriptor 764 0 R
 /FirstChar 32
 /LastChar 255
-/Widths 765 0 R
-/ToUnicode 764 0 R
+/Widths 766 0 R
+/ToUnicode 765 0 R
 >>
 endobj
 237 0 obj
@@ -20265,7 +20265,7 @@ endobj
 endobj
 239 0 obj
 << /Limits [(_processing_information_10) (_program_information_12)]
-/Names [(_processing_information_10) 498 0 R (_processing_information_2) 188 0 R (_processing_information_3) 202 0 R (_processing_information_4) 221 0 R (_processing_information_5) 238 0 R (_processing_information_6) 255 0 R (_processing_information_7) 275 0 R (_processing_information_8) 402 0 R (_processing_information_9) 478 0 R (_program_debugging) 420 0 R (_program_information) 114 0 R (_program_information_10) 292 0 R (_program_information_11) 307 0 R (_program_information_12) 324 0 R]
+/Names [(_processing_information_10) 499 0 R (_processing_information_2) 188 0 R (_processing_information_3) 202 0 R (_processing_information_4) 221 0 R (_processing_information_5) 238 0 R (_processing_information_6) 258 0 R (_processing_information_7) 278 0 R (_processing_information_8) 405 0 R (_processing_information_9) 479 0 R (_program_debugging) 421 0 R (_program_information) 114 0 R (_program_information_10) 293 0 R (_program_information_11) 308 0 R (_program_information_12) 327 0 R]
 >>
 endobj
 240 0 obj
@@ -20275,7 +20275,7 @@ endobj
 [231 0 R /XYZ 0 209.65 null]
 endobj
 242 0 obj
-<< /Length 7676
+<< /Length 7650
 >>
 stream
 q
@@ -20823,7 +20823,7 @@ ET
 BT
 48.24 82.746 Td
 /F2.0 13 Tf
-<392e342e332e2050726f63657373696e6720496e666f726d6174696f6e> Tj
+<392e342e332e20546872656164696e67> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -20867,7 +20867,7 @@ endobj
 /F3.0 55 0 R
 /F4.0 111 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 /Annots [245 0 R]
@@ -20904,7 +20904,7 @@ endobj
 endobj
 251 0 obj
 << /Limits [(_description_8) (_exit_status_15)]
-/Names [(_description_8) 232 0 R (_description_9) 250 0 R (_edge_options) 385 0 R (_exit_status) 117 0 R (_exit_status_10) 293 0 R (_exit_status_11) 308 0 R (_exit_status_12) 327 0 R (_exit_status_13) 352 0 R (_exit_status_14) 370 0 R (_exit_status_15) 392 0 R]
+/Names [(_description_8) 232 0 R (_description_9) 250 0 R (_edge_options) 386 0 R (_exit_status) 117 0 R (_exit_status_10) 294 0 R (_exit_status_11) 309 0 R (_exit_status_12) 328 0 R (_exit_status_13) 353 0 R (_exit_status_14) 371 0 R (_exit_status_15) 393 0 R]
 >>
 endobj
 252 0 obj
@@ -20920,7 +20920,7 @@ endobj
 [243 0 R /XYZ 0 101.43 null]
 endobj
 256 0 obj
-<< /Length 7341
+<< /Length 6833
 >>
 stream
 q
@@ -20932,7 +20932,29 @@ q
 BT
 48.24 793.926 Td
 /F2.0 10.5 Tf
-[<2d50> 120.1172 <2c202d2d70726f6772657373>] TJ
+<2d742c202d2d74687265616473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.951 793.926 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.8205 793.926 Td
+/F4.0 10.5 Tf
+<4e> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -20943,7 +20965,7 @@ ET
 BT
 63.24 775.146 Td
 /F1.0 10.5 Tf
-<5072696e7420696e666f726d6174696f6e2061626f7574207468652070726f677265737320746f207374646572722e> Tj
+<4e756d626572206f66207468726561647320746f207573652e> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -20954,7 +20976,7 @@ ET
 BT
 48.24 740.646 Td
 /F2.0 13 Tf
-[<392e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+<392e342e342e2050726f63657373696e6720496e666f726d6174696f6e> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -20965,7 +20987,7 @@ ET
 BT
 48.24 714.086 Td
 /F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
+[<2d50> 120.1172 <2c202d2d70726f6772657373>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -20976,6 +20998,39 @@ ET
 BT
 63.24 695.306 Td
 /F1.0 10.5 Tf
+<5072696e7420696e666f726d6174696f6e2061626f7574207468652070726f677265737320746f207374646572722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 660.806 Td
+/F2.0 13 Tf
+[<392e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 634.246 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 615.466 Td
+/F1.0 10.5 Tf
 <5072696e7420612068656c70206d65737361676520666f7220> Tj
 ET
 
@@ -20985,7 +21040,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-186.8565 695.306 Td
+186.8565 615.466 Td
 /F2.0 10.5 Tf
 <6f6467692073717565657a65> Tj
 ET
@@ -20996,7 +21051,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-254.781 695.306 Td
+254.781 615.466 Td
 /F1.0 10.5 Tf
 <2e> Tj
 ET
@@ -21007,7 +21062,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 655.466 Td
+48.24 575.626 Td
 /F2.0 18 Tf
 [<392e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
 ET
@@ -21018,7 +21073,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 627.446 Td
+48.24 547.606 Td
 /F2.0 10.5 Tf
 <30> Tj
 ET
@@ -21029,7 +21084,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 608.666 Td
+63.24 528.826 Td
 /F1.0 10.5 Tf
 <537563636573732e> Tj
 ET
@@ -21040,7 +21095,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 580.886 Td
+48.24 501.046 Td
 /F2.0 10.5 Tf
 <31> Tj
 ET
@@ -21051,7 +21106,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 562.106 Td
+63.24 482.266 Td
 /F1.0 10.5 Tf
 [<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
 ET
@@ -21062,7 +21117,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 522.266 Td
+48.24 442.426 Td
 /F2.0 18 Tf
 <392e362e2042554753> Tj
 ET
@@ -21073,7 +21128,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 494.246 Td
+48.24 414.406 Td
 /F1.0 10.5 Tf
 <526566657220746f2074686520> Tj
 ET
@@ -21084,7 +21139,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-109.056 494.246 Td
+109.056 414.406 Td
 /F2.0 10.5 Tf
 <6f646769> Tj
 ET
@@ -21095,7 +21150,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-131.862 494.246 Td
+131.862 414.406 Td
 /F1.0 10.5 Tf
 [<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
 ET
@@ -21106,7 +21161,7 @@ ET
 0.2588 0.5451 0.7922 SCN
 
 BT
-213.4151 494.246 Td
+213.4151 414.406 Td
 /F1.0 10.5 Tf
 <68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
 ET
@@ -21117,7 +21172,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-401.1446 494.246 Td
+401.1446 414.406 Td
 /F1.0 10.5 Tf
 <2e> Tj
 ET
@@ -21128,7 +21183,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 454.406 Td
+48.24 374.566 Td
 /F2.0 18 Tf
 [<392e372e2041> 20.0195 <5554484f5253>] TJ
 ET
@@ -21139,7 +21194,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 426.386 Td
+48.24 346.546 Td
 /F2.0 10.5 Tf
 <6f6467692073717565657a65> Tj
 ET
@@ -21150,7 +21205,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-116.1645 426.386 Td
+116.1645 346.546 Td
 /F1.0 10.5 Tf
 [<20776173207772697474656e2062> 20.0195 <7920416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
 ET
@@ -21161,7 +21216,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 382.274 Td
+48.24 302.434 Td
 /F2.0 22 Tf
 [<31302e206f6467692065787472> 20.0195 <616374283129>] TJ
 ET
@@ -21172,7 +21227,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 341.026 Td
+48.24 261.186 Td
 /F2.0 18 Tf
 <31302e312e204e414d45> Tj
 ET
@@ -21183,7 +21238,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 313.006 Td
+48.24 233.166 Td
 /F1.0 10.5 Tf
 [<6f6467695f65787472> 20.0195 <616374202d2065787472> 20.0195 <616374207061727473206f6620746865206772> 20.0195 <61706820617320646566696e65642062> 20.0195 <79207175657279206372697465726961>] TJ
 ET
@@ -21194,7 +21249,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 273.166 Td
+48.24 193.326 Td
 /F2.0 18 Tf
 [<31302e322e2053> 20.0195 <594e4f50534953>] TJ
 ET
@@ -21205,7 +21260,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 245.146 Td
+48.24 165.306 Td
 /F2.0 10.5 Tf
 [<6f6467692065787472> 20.0195 <616374>] TJ
 ET
@@ -21216,7 +21271,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-112.0903 245.146 Td
+112.0903 165.306 Td
 /F1.0 10.5 Tf
 <205b> Tj
 ET
@@ -21227,7 +21282,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-118.5793 245.146 Td
+118.5793 165.306 Td
 /F2.0 10.5 Tf
 [<2d662c202d2d696e7075742d6772> 20.0195 <61706873>] TJ
 ET
@@ -21238,7 +21293,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-206.6846 245.146 Td
+206.6846 165.306 Td
 /F1.0 10.5 Tf
 <3d> Tj
 ET
@@ -21249,7 +21304,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-212.5541 245.146 Td
+212.5541 165.306 Td
 /F3.0 10.5 Tf
 <46494c45> Tj
 ET
@@ -21260,7 +21315,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-235.6751 245.146 Td
+235.6751 165.306 Td
 /F1.0 10.5 Tf
 <5d205b> Tj
 ET
@@ -21271,7 +21326,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-245.9336 245.146 Td
+245.9336 165.306 Td
 /F2.0 10.5 Tf
 <2d6f2c202d2d6f7574> Tj
 ET
@@ -21282,7 +21337,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-285.5816 245.146 Td
+285.5816 165.306 Td
 /F1.0 10.5 Tf
 <3d> Tj
 ET
@@ -21293,7 +21348,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-291.4511 245.146 Td
+291.4511 165.306 Td
 /F3.0 10.5 Tf
 <46494c45> Tj
 ET
@@ -21304,7 +21359,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-314.5721 245.146 Td
+314.5721 165.306 Td
 /F1.0 10.5 Tf
 <5d205b> Tj
 ET
@@ -21315,7 +21370,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-324.8306 245.146 Td
+324.8306 165.306 Td
 /F3.0 10.5 Tf
 <4f5054494f4e> Tj
 ET
@@ -21326,7 +21381,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-365.2136 245.146 Td
+365.2136 165.306 Td
 /F1.0 10.5 Tf
 <5dc9> Tj
 ET
@@ -21337,7 +21392,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 205.306 Td
+48.24 125.466 Td
 /F2.0 18 Tf
 <31302e332e204445534352495054494f4e> Tj
 ET
@@ -21348,97 +21403,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 177.286 Td
+48.24 97.446 Td
 /F1.0 10.5 Tf
 [<546865206f6467692065787472> 20.0195 <61637428312920636f6d6d616e642065787472> 20.0195 <61637473207061727473206f6620746865206772> 20.0195 <61706820617320646566696e65642062> 20.0195 <792071756572792063726974657269612e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 137.446 Td
-/F2.0 18 Tf
-<31302e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 102.706 Td
-/F2.0 13 Tf
-[<31302e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 76.146 Td
-/F2.0 10.5 Tf
-[<2d662c202d2d696e7075742d6772> 20.0195 <61706873>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-136.3453 76.146 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-142.2148 76.146 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 57.366 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <6170682e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-448.1908 57.366 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-462.6808 57.366 Td
-/F1.0 10.5 Tf
-<2e> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -21478,14 +21445,14 @@ endobj
 /Contents 256 0 R
 /Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
 /Font << /F2.0 17 0 R
+/F4.0 111 0 R
 /F1.0 8 0 R
 /F3.0 55 0 R
-/F4.0 111 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
-/Annots [261 0 R]
+/Annots [262 0 R]
 >>
 endobj
 258 0 obj
@@ -21495,47 +21462,49 @@ endobj
 [257 0 R /XYZ 0 679.49 null]
 endobj
 260 0 obj
-[257 0 R /XYZ 0 546.29 null]
+[257 0 R /XYZ 0 599.65 null]
 endobj
 261 0 obj
+[257 0 R /XYZ 0 466.45 null]
+endobj
+262 0 obj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
 /URI (https://github.com/vgteam/odgi/issues)
 >>
 /Subtype /Link
-/Rect [213.4151 491.18 401.1446 505.46]
+/Rect [213.4151 411.34 401.1446 425.62]
 /Type /Annot
 >>
 endobj
-262 0 obj
-[257 0 R /XYZ 0 478.43 null]
-endobj
 263 0 obj
-<< /Limits [(_authors_9) (_bugs_16)]
-/Names [(_authors_9) 262 0 R (_bin_options) 439 0 R (_binned_mode_options) 346 0 R (_bugs) 89 0 R (_bugs_10) 280 0 R (_bugs_11) 294 0 R (_bugs_12) 309 0 R (_bugs_13) 328 0 R (_bugs_14) 353 0 R (_bugs_15) 372 0 R (_bugs_16) 393 0 R]
->>
+[257 0 R /XYZ 0 398.59 null]
 endobj
 264 0 obj
-[257 0 R /XYZ 0 410.57 null]
+<< /Limits [(_authors_9) (_bugs_16)]
+/Names [(_authors_9) 263 0 R (_bin_options) 442 0 R (_binned_mode_options) 347 0 R (_bugs) 89 0 R (_bugs_10) 281 0 R (_bugs_11) 295 0 R (_bugs_12) 312 0 R (_bugs_13) 329 0 R (_bugs_14) 354 0 R (_bugs_15) 373 0 R (_bugs_16) 394 0 R]
+>>
 endobj
 265 0 obj
-[257 0 R /XYZ 0 365.05 null]
+[257 0 R /XYZ 0 330.73 null]
 endobj
 266 0 obj
-[257 0 R /XYZ 0 297.19 null]
+[257 0 R /XYZ 0 285.21 null]
 endobj
 267 0 obj
-[257 0 R /XYZ 0 229.33 null]
+[257 0 R /XYZ 0 217.35 null]
 endobj
 268 0 obj
-[257 0 R /XYZ 0 161.47 null]
+<< /Limits [(_synopsis_6) (_threading_13)]
+/Names [(_synopsis_6) 198 0 R (_synopsis_7) 212 0 R (_synopsis_8) 229 0 R (_synopsis_9) 249 0 R (_testing_options) 620 0 R (_threading) 133 0 R (_threading_10) 391 0 R (_threading_11) 406 0 R (_threading_12) 478 0 R (_threading_13) 585 0 R]
+>>
 endobj
 269 0 obj
-[257 0 R /XYZ 0 121.39 null]
+[257 0 R /XYZ 0 149.49 null]
 endobj
 270 0 obj
-<< /Length 8610
+<< /Length 8605
 >>
 stream
 q
@@ -21545,9 +21514,9 @@ q
 0.2 0.2 0.2 SCN
 
 BT
-48.24 793.926 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
+48.24 786.666 Td
+/F2.0 18 Tf
+<31302e342e204f5054494f4e53> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -21556,7 +21525,29 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-87.888 793.926 Td
+48.24 751.926 Td
+/F2.0 13 Tf
+[<31302e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 725.366 Td
+/F2.0 10.5 Tf
+[<2d662c202d2d696e7075742d6772> 20.0195 <61706873>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+136.3453 725.366 Td
 /F2.0 10.5 Tf
 <3d> Tj
 ET
@@ -21567,7 +21558,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-93.7575 793.926 Td
+142.2148 725.366 Td
 /F4.0 10.5 Tf
 <46494c45> Tj
 ET
@@ -21578,9 +21569,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 775.146 Td
+63.24 706.586 Td
 /F1.0 10.5 Tf
-[<53746f726520616c6c207375626772> 20.0195 <61706820696e20746869732066696c652e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <6170682e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -21589,7 +21580,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-374.4808 775.146 Td
+448.1908 706.586 Td
 /F3.0 10.5 Tf
 <2e6f67> Tj
 ET
@@ -21600,7 +21591,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-388.9708 775.146 Td
+462.6808 706.586 Td
 /F1.0 10.5 Tf
 <2e> Tj
 ET
@@ -21611,20 +21602,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 740.646 Td
-/F2.0 13 Tf
-[<31302e342e322e2045787472> 20.0195 <616374204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 714.086 Td
+48.24 678.806 Td
 /F2.0 10.5 Tf
-[<2d732c202d2d73706c69742d7375626772> 20.0195 <61706873>] TJ
+<2d6f2c202d2d6f7574> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -21633,7 +21613,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-150.9193 714.086 Td
+87.888 678.806 Td
 /F2.0 10.5 Tf
 <3d> Tj
 ET
@@ -21644,7 +21624,84 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-156.7888 714.086 Td
+93.7575 678.806 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 660.026 Td
+/F1.0 10.5 Tf
+[<53746f726520616c6c207375626772> 20.0195 <61706820696e20746869732066696c652e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+374.4808 660.026 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+388.9708 660.026 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 625.526 Td
+/F2.0 13 Tf
+[<31302e342e322e2045787472> 20.0195 <616374204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 598.966 Td
+/F2.0 10.5 Tf
+[<2d732c202d2d73706c69742d7375626772> 20.0195 <61706873>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+150.9193 598.966 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+156.7888 598.966 Td
 /F4.0 10.5 Tf
 [<53> 20.0195 <5452494e47>] TJ
 ET
@@ -21657,7 +21714,7 @@ ET
 0.5602 Tw
 
 BT
-63.24 695.306 Td
+63.24 580.186 Td
 /F1.0 10.5 Tf
 [<496e7374656164206f662077726974696e672074686520746172676574207375626772> 20.0195 <6170687320696e746f20612073696e676c65206772> 20.0195 <6170682c207772697465206f6e65207375626772> 20.0195 <6170682070657220676976656e20746172676574>] TJ
 ET
@@ -21670,7 +21727,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 679.526 Td
+63.24 564.406 Td
 /F1.0 10.5 Tf
 [<746f2061207365706172> 20.0195 <6174652066696c65206e616d656420>] TJ
 ET
@@ -21681,7 +21738,7 @@ ET
 0.6941 0.1294 0.2745 SCN
 
 BT
-185.8693 679.526 Td
+185.8693 564.406 Td
 /F5.0 10.5 Tf
 <706174683a73746172742d656e642e6f67> Tj
 ET
@@ -21692,7 +21749,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-275.1193 679.526 Td
+275.1193 564.406 Td
 /F1.0 10.5 Tf
 <2028302d626173656420636f6f7264696e61746573292e> Tj
 ET
@@ -21703,7 +21760,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 651.746 Td
+48.24 536.626 Td
 /F2.0 10.5 Tf
 <2d492c202d2d696e7665727365> Tj
 ET
@@ -21714,7 +21771,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 632.966 Td
+63.24 517.846 Td
 /F1.0 10.5 Tf
 [<45787472> 20.0195 <616374207061727473206f6620746865206772> 20.0195 <617068207468617420646f206e6f74206d656574207468652071756572792063726974657269612e>] TJ
 ET
@@ -21725,7 +21782,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 605.186 Td
+48.24 490.066 Td
 /F2.0 10.5 Tf
 <2d6c2c202d2d6e6f64652d6c697374> Tj
 ET
@@ -21736,7 +21793,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-113.7075 605.186 Td
+113.7075 490.066 Td
 /F2.0 10.5 Tf
 <3a3a5f46494c455f> Tj
 ET
@@ -21747,7 +21804,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 586.406 Td
+63.24 471.286 Td
 /F1.0 10.5 Tf
 [<412066696c652077697468206f6e65206e6f646520696420706572206c696e652e20546865206e6f6465207370656369666965642077696c6c2062652065787472> 20.0195 <61637465642066726f6d2074686520696e707574206772> 20.0195 <6170682e>] TJ
 ET
@@ -21758,7 +21815,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 558.626 Td
+48.24 443.506 Td
 /F2.0 10.5 Tf
 <2d6e2c202d2d6e6f6465> Tj
 ET
@@ -21769,7 +21826,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-97.002 558.626 Td
+97.002 443.506 Td
 /F2.0 10.5 Tf
 [<3a3a5f53> 20.0195 <5452494e475f>] TJ
 ET
@@ -21780,7 +21837,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 539.846 Td
+63.24 424.726 Td
 /F1.0 10.5 Tf
 [<412073696e676c65206e6f64652066726f6d20776869636820746f20626567696e206f7572207472> 20.0195 <6176657273616c2e>] TJ
 ET
@@ -21791,7 +21848,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 512.066 Td
+48.24 396.946 Td
 /F2.0 10.5 Tf
 <2d632c202d2d636f6e74657874> Tj
 ET
@@ -21802,7 +21859,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-109.5075 512.066 Td
+109.5075 396.946 Td
 /F2.0 10.5 Tf
 <3a3a5f4e554d4245525f> Tj
 ET
@@ -21813,7 +21870,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 493.286 Td
+63.24 378.166 Td
 /F1.0 10.5 Tf
 [<546865206e756d626572206f6620737465707320617761> 20.0195 <792066726f6d206f757220696e697469616c207375626772> 20.0195 <61706820746861742077652073686f756c6420636f6c6c6563742e>] TJ
 ET
@@ -21824,7 +21881,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 465.506 Td
+48.24 350.386 Td
 /F2.0 10.5 Tf
 <2d4c2c202d2d7573652d6c656e677468> Tj
 ET
@@ -21835,7 +21892,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 446.726 Td
+63.24 331.606 Td
 /F1.0 10.5 Tf
 <54726561742074686520636f6e746578742073697a652061732061206c656e67746820696e2062617365732028616e64206e6f742061732061206e756d626572206f66207374657073292e> Tj
 ET
@@ -21846,7 +21903,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 418.946 Td
+48.24 303.826 Td
 /F2.0 10.5 Tf
 [<2d722c202d2d706174682d72> 20.0195 <616e6765>] TJ
 ET
@@ -21857,7 +21914,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 400.166 Td
+63.24 285.046 Td
 /F1.0 10.5 Tf
 [<46696e6420746865206e6f646528732920696e207468652073706563696669656420706174682072> 20.0195 <616e67652054> 60.0586 <4152> 20.0195 <4745543d706174685b3a706f73315b2d706f73325d5d2028302d626173656420636f6f7264696e6174657329>] TJ
 ET
@@ -21868,7 +21925,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 372.386 Td
+48.24 257.266 Td
 /F2.0 10.5 Tf
 <2d722c202d2d6265642d66696c65> Tj
 ET
@@ -21879,7 +21936,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-109.7805 372.386 Td
+109.7805 257.266 Td
 /F2.0 10.5 Tf
 <3a3a5f46494c455f> Tj
 ET
@@ -21890,7 +21947,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 353.606 Td
+63.24 238.486 Td
 /F1.0 10.5 Tf
 [<46696e6420746865206e6f646528732920696e2074686520706174682072> 20.0195 <616e67652873292073706563696669656420696e2074686520676976656e204245442046494c45>] TJ
 ET
@@ -21901,7 +21958,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 325.826 Td
+48.24 210.706 Td
 /F2.0 10.5 Tf
 [<2d452c202d2d66756c6c2d72> 20.0195 <616e6765>] TJ
 ET
@@ -21914,7 +21971,7 @@ ET
 0.986 Tw
 
 BT
-63.24 307.046 Td
+63.24 191.926 Td
 /F1.0 10.5 Tf
 [<436f6c6c6563747320616c6c206e6f64657320696e2074686520736f72746564206f72646572206f6620746865206772> 20.0195 <61706820696e20746865206d696e20616e64206d617820706f736974696f6e20746f75636865642062> 20.0195 <7920746865>] TJ
 ET
@@ -21927,7 +21984,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 291.266 Td
+63.24 176.146 Td
 /F1.0 10.5 Tf
 [<676976656e20706174682072> 20.0195 <616e6765732e204265206361726566756c20746f207573652069742077697468207665727920636f6d706c6578206772> 20.0195 <617068732e>] TJ
 ET
@@ -21938,7 +21995,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 256.766 Td
+48.24 141.646 Td
 /F2.0 13 Tf
 <31302e342e332e20546872656164696e67> Tj
 ET
@@ -21949,7 +22006,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 230.206 Td
+48.24 115.086 Td
 /F2.0 10.5 Tf
 <2d742c202d2d74687265616473> Tj
 ET
@@ -21960,7 +22017,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-108.951 230.206 Td
+108.951 115.086 Td
 /F2.0 10.5 Tf
 <3d> Tj
 ET
@@ -21971,7 +22028,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-114.8205 230.206 Td
+114.8205 115.086 Td
 /F4.0 10.5 Tf
 <4e> Tj
 ET
@@ -21982,97 +22039,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 211.426 Td
+63.24 96.306 Td
 /F1.0 10.5 Tf
 [<4e756d626572206f66207468726561647320746f207573652028746f20656d6265642074686520737562706174687320696e20706172> 20.0195 <616c6c656c292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 176.926 Td
-/F2.0 13 Tf
-<31302e342e342e2050726f63657373696e6720496e666f726d6174696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 150.366 Td
-/F2.0 10.5 Tf
-[<2d50> 120.1172 <2c202d2d70726f6772657373>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 131.586 Td
-/F1.0 10.5 Tf
-<5072696e7420696e666f726d6174696f6e20746f207374646572722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 97.086 Td
-/F2.0 13 Tf
-[<31302e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 70.526 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 51.746 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 51.746 Td
-/F2.0 10.5 Tf
-[<6f6467692065787472> 20.0195 <616374>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-250.7068 51.746 Td
-/F1.0 10.5 Tf
-<2e> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -22117,30 +22086,25 @@ endobj
 /F3.0 55 0 R
 /F5.0 236 0 R
 >>
-/XObject << /Stamp1 706 0 R
+/XObject << /Stamp1 707 0 R
 >>
 >>
 >>
 endobj
 272 0 obj
-[271 0 R /XYZ 0 759.33 null]
+[271 0 R /XYZ 0 841.89 null]
 endobj
 273 0 obj
-[271 0 R /XYZ 0 275.45 null]
+[271 0 R /XYZ 0 770.61 null]
 endobj
 274 0 obj
-<< /Limits [(_synopsis_6) (_threading_2)]
-/Names [(_synopsis_6) 198 0 R (_synopsis_7) 212 0 R (_synopsis_8) 229 0 R (_synopsis_9) 249 0 R (_testing_options) 619 0 R (_threading) 133 0 R (_threading_10) 405 0 R (_threading_11) 477 0 R (_threading_12) 582 0 R (_threading_2) 151 0 R]
->>
+[271 0 R /XYZ 0 644.21 null]
 endobj
 275 0 obj
-[271 0 R /XYZ 0 195.61 null]
+[271 0 R /XYZ 0 160.33 null]
 endobj
 276 0 obj
-[271 0 R /XYZ 0 115.77 null]
-endobj
-277 0 obj
-<< /Length 6595
+<< /Length 6060
 >>
 stream
 q
@@ -22150,9 +22114,9 @@ q
 0.2 0.2 0.2 SCN
 
 BT
-48.24 786.666 Td
-/F2.0 18 Tf
-[<31302e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+48.24 792.006 Td
+/F2.0 13 Tf
+<31302e342e342e2050726f63657373696e6720496e666f726d6174696f6e> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -22161,9 +22125,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 758.646 Td
+48.24 765.446 Td
 /F2.0 10.5 Tf
-<30> Tj
+[<2d50> 120.1172 <2c202d2d70726f6772657373>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -22172,9 +22136,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 739.866 Td
+63.24 746.666 Td
 /F1.0 10.5 Tf
-<537563636573732e> Tj
+<5072696e7420696e666f726d6174696f6e20746f207374646572722e> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -22183,9 +22147,20 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 712.086 Td
+48.24 712.166 Td
+/F2.0 13 Tf
+[<31302e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 685.606 Td
 /F2.0 10.5 Tf
-<31> Tj
+<2d682c202d2d68656c70> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -22194,9 +22169,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 693.306 Td
+63.24 666.826 Td
 /F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -22205,84 +22180,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 653.466 Td
-/F2.0 18 Tf
-<31302e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.446 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 625.446 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 625.446 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 625.446 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 625.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 585.606 Td
-/F2.0 18 Tf
-[<31302e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 557.586 Td
+186.8565 666.826 Td
 /F2.0 10.5 Tf
 [<6f6467692065787472> 20.0195 <616374>] TJ
 ET
@@ -22293,7 +22191,161 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-112.0903 557.586 Td
+250.7068 666.826 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 626.986 Td
+/F2.0 18 Tf
+[<31302e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 598.966 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 580.186 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 552.406 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 533.626 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 493.786 Td
+/F2.0 18 Tf
+<31302e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 465.766 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 465.766 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 465.766 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 465.766 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 465.766 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 425.926 Td
+/F2.0 18 Tf
+[<31302e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 397.906 Td
+/F2.0 10.5 Tf
+[<6f6467692065787472> 20.0195 <616374>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+112.0903 397.906 Td
 /F1.0 10.5 Tf
 [<20776173207772697474656e2062> 20.0195 <7920416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
 ET
@@ -22304,7 +22356,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 513.474 Td
+48.24 353.794 Td
 /F2.0 22 Tf
 <31312e206f6467692076696577283129> Tj
 ET
@@ -22315,7 +22367,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 472.226 Td
+48.24 312.546 Td
 /F2.0 18 Tf
 <31312e312e204e414d45> Tj
 ET
@@ -22326,7 +22378,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 444.206 Td
+48.24 284.526 Td
 /F1.0 10.5 Tf
 [<6f6467695f76696577202d2070726f6a656374696f6e206f66206772> 20.0195 <6170687320696e746f206f7468657220666f726d617473>] TJ
 ET
@@ -22337,7 +22389,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 404.366 Td
+48.24 244.686 Td
 /F2.0 18 Tf
 [<31312e322e2053> 20.0195 <594e4f50534953>] TJ
 ET
@@ -22348,7 +22400,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 376.346 Td
+48.24 216.666 Td
 /F2.0 10.5 Tf
 <6f6467692076696577> Tj
 ET
@@ -22359,7 +22411,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-98.7765 376.346 Td
+98.7765 216.666 Td
 /F1.0 10.5 Tf
 <205b> Tj
 ET
@@ -22370,7 +22422,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-105.2655 376.346 Td
+105.2655 216.666 Td
 /F2.0 10.5 Tf
 <2d692c202d2d696478> Tj
 ET
@@ -22381,7 +22433,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-141.795 376.346 Td
+141.795 216.666 Td
 /F1.0 10.5 Tf
 <3d> Tj
 ET
@@ -22392,7 +22444,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-147.6645 376.346 Td
+147.6645 216.666 Td
 /F3.0 10.5 Tf
 <46494c45> Tj
 ET
@@ -22403,7 +22455,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-170.7855 376.346 Td
+170.7855 216.666 Td
 /F1.0 10.5 Tf
 <5d205b> Tj
 ET
@@ -22414,7 +22466,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-181.044 376.346 Td
+181.044 216.666 Td
 /F3.0 10.5 Tf
 <4f5054494f4e> Tj
 ET
@@ -22425,7 +22477,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-221.427 376.346 Td
+221.427 216.666 Td
 /F1.0 10.5 Tf
 <5dc9> Tj
 ET
@@ -22436,7 +22488,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 336.506 Td
+48.24 176.826 Td
 /F2.0 18 Tf
 <31312e332e204445534352495054494f4e> Tj
 ET
@@ -22449,7 +22501,7 @@ ET
 1.4148 Tw
 
 BT
-48.24 308.486 Td
+48.24 148.806 Td
 /F1.0 10.5 Tf
 [<546865206f646769207669657728312920636f6d6d616e642063616e20636f6e766572742061206772> 20.0195 <61706820696e206f64676920666f726d617420746f204746> 69.8242 <41> 60.0586 <76312e2049742063616e2072657665616c2061206772> 20.0195 <617068d573>] TJ
 ET
@@ -22462,7 +22514,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 292.706 Td
+48.24 133.026 Td
 /F1.0 10.5 Tf
 <696e7465726e616c207374727563747572657320666f7220652e672e20646562756767696e672070726f6365737365732e> Tj
 ET
@@ -22473,130 +22525,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 252.866 Td
+48.24 93.186 Td
 /F2.0 18 Tf
 <31312e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 218.126 Td
-/F2.0 13 Tf
-[<31312e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 191.566 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 191.566 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 191.566 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 172.786 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20636f6e766572742066726f6d2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-529.2298 172.786 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-543.7198 172.786 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 145.006 Td
-/F2.0 10.5 Tf
-<2d672c202d2d746f2d676661> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 126.226 Td
-/F1.0 10.5 Tf
-[<577269746520746865206772> 20.0195 <61706820696e204746> 69.8242 <41> 60.0586 <763120666f726d617420746f207374616e64617264206f75747075742e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 91.726 Td
-/F2.0 13 Tf
-<31312e342e322e2053756d6d617279204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 65.166 Td
-/F2.0 10.5 Tf
-[<2d642c202d2d646973706c61> 20.0195 <79>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -22625,7 +22556,7 @@ Q
 
 endstream
 endobj
-278 0 obj
+277 0 obj
 << /Type /Page
 /Parent 3 0 R
 /MediaBox [0 0 595.28 841.89]
@@ -22633,618 +22564,61 @@ endobj
 /BleedBox [0 0 595.28 841.89]
 /TrimBox [0 0 595.28 841.89]
 /ArtBox [0 0 595.28 841.89]
-/Contents 277 0 R
+/Contents 276 0 R
 /Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
 /Font << /F2.0 17 0 R
 /F1.0 8 0 R
 /F3.0 55 0 R
-/F4.0 111 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
-/Annots [281 0 R]
+/Annots [282 0 R]
 >>
+endobj
+278 0 obj
+[277 0 R /XYZ 0 841.89 null]
 endobj
 279 0 obj
-[278 0 R /XYZ 0 841.89 null]
+[277 0 R /XYZ 0 730.85 null]
 endobj
 280 0 obj
-[278 0 R /XYZ 0 677.49 null]
+[277 0 R /XYZ 0 651.01 null]
 endobj
 281 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 622.38 401.1446 636.66]
-/Type /Annot
->>
+[277 0 R /XYZ 0 517.81 null]
 endobj
 282 0 obj
-[278 0 R /XYZ 0 609.63 null]
-endobj
-283 0 obj
-[278 0 R /XYZ 0 541.77 null]
-endobj
-284 0 obj
-[278 0 R /XYZ 0 496.25 null]
-endobj
-285 0 obj
-[278 0 R /XYZ 0 428.39 null]
-endobj
-286 0 obj
-[278 0 R /XYZ 0 360.53 null]
-endobj
-287 0 obj
-[278 0 R /XYZ 0 276.89 null]
-endobj
-288 0 obj
-[278 0 R /XYZ 0 236.81 null]
-endobj
-289 0 obj
-[278 0 R /XYZ 0 110.41 null]
-endobj
-290 0 obj
-<< /Length 6846
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-2.7849 Tw
-
-BT
-63.24 794.676 Td
-/F1.0 10.5 Tf
-[<53686f772074686520696e7465726e616c2073747275637475726573206f662061206772> 20.0195 <6170682e205072696e7420746f207374646f757420746865206d6178696d756d206e6f6465206964656e7469666965722c20746865>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9451 Tw
-
-BT
-63.24 778.896 Td
-/F1.0 10.5 Tf
-<6d696e696d756d206e6f6465206964656e7469666965722c20746865206e6f64657320766563746f722c207468652064656c657465206e6f6465732062697420766563746f7220616e64207468652070617468206d657461646174612c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 763.116 Td
-/F1.0 10.5 Tf
-[<6561636820696e2061207365706172> 20.0195 <617465206c696e652e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 728.616 Td
-/F2.0 13 Tf
-[<31312e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 702.056 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 683.276 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 683.276 Td
-/F2.0 10.5 Tf
-<6f6467692076696577> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-237.393 683.276 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 643.436 Td
-/F2.0 18 Tf
-[<31312e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 615.416 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 596.636 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 568.856 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 550.076 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 510.236 Td
-/F2.0 18 Tf
-<31312e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 482.216 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 482.216 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 482.216 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 482.216 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 482.216 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 442.376 Td
-/F2.0 18 Tf
-[<31312e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 414.356 Td
-/F2.0 10.5 Tf
-<6f6467692076696577> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-98.7765 414.356 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 370.244 Td
-/F2.0 22 Tf
-<31322e206f646769206b6d657273283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 328.996 Td
-/F2.0 18 Tf
-<31322e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 300.976 Td
-/F1.0 10.5 Tf
-[<6f6467695f6b6d657273202d2073686f7720616e642063686172> 20.0195 <6163746572697a6520746865206b6d6572207370616365206f6620746865206772> 20.0195 <617068>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 261.136 Td
-/F2.0 18 Tf
-[<31322e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 233.116 Td
-/F2.0 10.5 Tf
-<6f646769206b6d657273> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-107.3655 233.116 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.8545 233.116 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-150.384 233.116 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-156.2535 233.116 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-179.3745 233.116 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-189.633 233.116 Td
-/F2.0 10.5 Tf
-<2d632c202d2d7374646f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-244.5375 233.116 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-254.796 233.116 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-295.179 233.116 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 193.276 Td
-/F2.0 18 Tf
-<31322e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4137 Tw
-
-BT
-48.24 165.256 Td
-/F1.0 10.5 Tf
-[<476976656e2061206b6d6572206c656e6774682c20746865206f646769206b6d65727328312920636f6d6d616e642063616e20656d697420616c6c206b6d6572732e20546865206f75747075742063616e20626520726566696e65642062> 20.0195 <79>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.7407 Tw
-
-BT
-48.24 149.476 Td
-/F1.0 10.5 Tf
-[<73657474696e6720746865206d6178696d756d206e756d626572206f6620667572636174696f6e73206174206564676573206f722062> 20.0195 <79206e6f7420636f6e7369646572696e67206e6f6465732061626f7665206120676976656e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 133.696 Td
-/F1.0 10.5 Tf
-<6e6f646520646567726565206c696d69742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 93.856 Td
-/F2.0 18 Tf
-<31322e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3235> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-291 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 290 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F1.0 8 0 R
-/F2.0 17 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [295 0 R]
->>
-endobj
-292 0 obj
-[291 0 R /XYZ 0 747.3 null]
-endobj
-293 0 obj
-[291 0 R /XYZ 0 667.46 null]
-endobj
-294 0 obj
-[291 0 R /XYZ 0 534.26 null]
-endobj
-295 0 obj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
 /URI (https://github.com/vgteam/odgi/issues)
 >>
 /Subtype /Link
-/Rect [213.4151 479.15 401.1446 493.43]
+/Rect [213.4151 462.7 401.1446 476.98]
 /Type /Annot
 >>
 endobj
-296 0 obj
-[291 0 R /XYZ 0 466.4 null]
+283 0 obj
+[277 0 R /XYZ 0 449.95 null]
 endobj
-297 0 obj
-[291 0 R /XYZ 0 398.54 null]
+284 0 obj
+[277 0 R /XYZ 0 382.09 null]
 endobj
-298 0 obj
-[291 0 R /XYZ 0 353.02 null]
+285 0 obj
+[277 0 R /XYZ 0 336.57 null]
 endobj
-299 0 obj
-[291 0 R /XYZ 0 285.16 null]
+286 0 obj
+[277 0 R /XYZ 0 268.71 null]
 endobj
-300 0 obj
-[291 0 R /XYZ 0 217.3 null]
+287 0 obj
+[277 0 R /XYZ 0 200.85 null]
 endobj
-301 0 obj
-[291 0 R /XYZ 0 117.88 null]
+288 0 obj
+[277 0 R /XYZ 0 117.21 null]
 endobj
-302 0 obj
-<< /Length 7521
+289 0 obj
+<< /Length 7507
 >>
 stream
 q
@@ -23256,7 +22630,7 @@ q
 BT
 48.24 792.006 Td
 /F2.0 13 Tf
-[<31322e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+[<31312e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23333,18 +22707,7 @@ ET
 BT
 48.24 718.886 Td
 /F2.0 10.5 Tf
-<2d632c202d2d7374646f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-103.1445 718.886 Td
-/F2.0 10.5 Tf
-<3d> Tj
+<2d672c202d2d746f2d676661> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -23355,7 +22718,7 @@ ET
 BT
 63.24 700.106 Td
 /F1.0 10.5 Tf
-[<577269746520746865206b6d65727320746f207374616e64617264206f75747075742e204b6d65727320617265206c696e652d7365706172> 20.0195 <617465642e>] TJ
+[<577269746520746865206772> 20.0195 <61706820696e204746> 69.8242 <41> 60.0586 <763120666f726d617420746f207374616e64617264206f75747075742e>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23366,7 +22729,7 @@ ET
 BT
 48.24 665.606 Td
 /F2.0 13 Tf
-<31322e342e322e204b6d6572204f7074696f6e73> Tj
+<31312e342e322e2053756d6d617279204f7074696f6e73> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -23377,7 +22740,7 @@ ET
 BT
 48.24 639.046 Td
 /F2.0 10.5 Tf
-<2d6b2c202d2d6b6d65722d6c656e677468> Tj
+[<2d642c202d2d646973706c61> 20.0195 <79>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23385,120 +22748,40 @@ ET
 0.2 0.2 0.2 scn
 0.2 0.2 0.2 SCN
 
-BT
-136.0095 639.046 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-141.879 639.046 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
+2.7849 Tw
 
 BT
 63.24 620.266 Td
 /F1.0 10.5 Tf
-[<546865206b6d6572206c656e67746820746f2067656e6572> 20.0195 <617465206b6d6572732066726f6d2e>] TJ
+[<53686f772074686520696e7465726e616c2073747275637475726573206f662061206772> 20.0195 <6170682e205072696e7420746f207374646f757420746865206d6178696d756d206e6f6465206964656e7469666965722c20746865>] TJ
 ET
 
+
+0.0 Tw
 0.0 0.0 0.0 SCN
 0.0 0.0 0.0 scn
 0.2 0.2 0.2 scn
 0.2 0.2 0.2 SCN
 
-BT
-48.24 592.486 Td
-/F2.0 10.5 Tf
-<2d652c202d2d6d61782d667572636174696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
+0.9451 Tw
 
 BT
-151.476 592.486 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-157.3455 592.486 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 573.706 Td
+63.24 604.486 Td
 /F1.0 10.5 Tf
-[<427265616b206174206564676573207468617420776f756c6420696e647563652074686973206d616e> 20.0195 <7920667572636174696f6e73207768656e2067656e6572> 20.0195 <6174696e672061206b6d65722e>] TJ
+<6d696e696d756d206e6f6465206964656e7469666965722c20746865206e6f64657320766563746f722c207468652064656c657465206e6f6465732062697420766563746f7220616e64207468652070617468206d657461646174612c> Tj
 ET
 
+
+0.0 Tw
 0.0 0.0 0.0 SCN
 0.0 0.0 0.0 scn
 0.2 0.2 0.2 scn
 0.2 0.2 0.2 SCN
 
 BT
-48.24 545.926 Td
-/F2.0 10.5 Tf
-<2d442c202d2d6d61782d646567726565> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-134.634 545.926 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-140.5035 545.926 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 527.146 Td
+63.24 588.706 Td
 /F1.0 10.5 Tf
-[<446f6ed5742074616b> 20.0195 <65206e6f64657320696e746f206163636f756e74207468617420686176652061206465677265652067726561746572207468616e20>] TJ
+[<6561636820696e2061207365706172> 20.0195 <617465206c696e652e>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23507,31 +22790,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-373.3783 527.146 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-381.3898 527.146 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 492.646 Td
+48.24 554.206 Td
 /F2.0 13 Tf
-<31322e342e332e20546872656164696e67> Tj
+[<31312e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23540,62 +22801,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 466.086 Td
-/F2.0 10.5 Tf
-<2d742c202d2d74687265616473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.951 466.086 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.8205 466.086 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 447.306 Td
-/F1.0 10.5 Tf
-<4e756d626572206f66207468726561647320746f207573652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 412.806 Td
-/F2.0 13 Tf
-[<31322e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 386.246 Td
+48.24 527.646 Td
 /F2.0 10.5 Tf
 <2d682c202d2d68656c70> Tj
 ET
@@ -23606,7 +22812,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 367.466 Td
+63.24 508.866 Td
 /F1.0 10.5 Tf
 <5072696e7420612068656c70206d65737361676520666f7220> Tj
 ET
@@ -23617,9 +22823,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-186.8565 367.466 Td
+186.8565 508.866 Td
 /F2.0 10.5 Tf
-<6f646769206b6d657273> Tj
+<6f6467692076696577> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -23628,7 +22834,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-245.982 367.466 Td
+237.393 508.866 Td
 /F1.0 10.5 Tf
 <2e> Tj
 ET
@@ -23639,9 +22845,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 327.626 Td
+48.24 469.026 Td
 /F2.0 18 Tf
-[<31322e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+[<31312e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23650,7 +22856,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 299.606 Td
+48.24 441.006 Td
 /F2.0 10.5 Tf
 <30> Tj
 ET
@@ -23661,7 +22867,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 280.826 Td
+63.24 422.226 Td
 /F1.0 10.5 Tf
 <537563636573732e> Tj
 ET
@@ -23672,7 +22878,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 253.046 Td
+48.24 394.446 Td
 /F2.0 10.5 Tf
 <31> Tj
 ET
@@ -23683,7 +22889,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-63.24 234.266 Td
+63.24 375.666 Td
 /F1.0 10.5 Tf
 [<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
 ET
@@ -23694,9 +22900,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 194.426 Td
+48.24 335.826 Td
 /F2.0 18 Tf
-<31322e362e2042554753> Tj
+<31312e362e2042554753> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -23705,7 +22911,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 166.406 Td
+48.24 307.806 Td
 /F1.0 10.5 Tf
 <526566657220746f2074686520> Tj
 ET
@@ -23716,7 +22922,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-109.056 166.406 Td
+109.056 307.806 Td
 /F2.0 10.5 Tf
 <6f646769> Tj
 ET
@@ -23727,7 +22933,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-131.862 166.406 Td
+131.862 307.806 Td
 /F1.0 10.5 Tf
 [<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
 ET
@@ -23738,7 +22944,7 @@ ET
 0.2588 0.5451 0.7922 SCN
 
 BT
-213.4151 166.406 Td
+213.4151 307.806 Td
 /F1.0 10.5 Tf
 <68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
 ET
@@ -23749,7 +22955,7 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-401.1446 166.406 Td
+401.1446 307.806 Td
 /F1.0 10.5 Tf
 <2e> Tj
 ET
@@ -23760,9 +22966,9 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 126.566 Td
+48.24 267.966 Td
 /F2.0 18 Tf
-[<31322e372e2041> 20.0195 <5554484f5253>] TJ
+[<31312e372e2041> 20.0195 <5554484f5253>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23771,7 +22977,73 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-48.24 98.546 Td
+48.24 239.946 Td
+/F2.0 10.5 Tf
+<6f6467692076696577> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+98.7765 239.946 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 195.834 Td
+/F2.0 22 Tf
+<31322e206f646769206b6d657273283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 154.586 Td
+/F2.0 18 Tf
+<31322e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 126.566 Td
+/F1.0 10.5 Tf
+[<6f6467695f6b6d657273202d2073686f7720616e642063686172> 20.0195 <6163746572697a6520746865206b6d6572207370616365206f6620746865206772> 20.0195 <617068>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 86.726 Td
+/F2.0 18 Tf
+[<31322e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 58.706 Td
 /F2.0 10.5 Tf
 <6f646769206b6d657273> Tj
 ET
@@ -23782,9 +23054,690 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-107.3655 98.546 Td
+107.3655 58.706 Td
 /F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.8545 58.706 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+150.384 58.706 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+156.2535 58.706 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+179.3745 58.706 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+189.633 58.706 Td
+/F2.0 10.5 Tf
+<2d632c202d2d7374646f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+244.5375 58.706 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+254.796 58.706 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+295.179 58.706 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3235> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+290 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 289 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [296 0 R]
+>>
+endobj
+291 0 obj
+[290 0 R /XYZ 0 841.89 null]
+endobj
+292 0 obj
+[290 0 R /XYZ 0 684.29 null]
+endobj
+293 0 obj
+[290 0 R /XYZ 0 572.89 null]
+endobj
+294 0 obj
+[290 0 R /XYZ 0 493.05 null]
+endobj
+295 0 obj
+[290 0 R /XYZ 0 359.85 null]
+endobj
+296 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 304.74 401.1446 319.02]
+/Type /Annot
+>>
+endobj
+297 0 obj
+[290 0 R /XYZ 0 291.99 null]
+endobj
+298 0 obj
+[290 0 R /XYZ 0 224.13 null]
+endobj
+299 0 obj
+[290 0 R /XYZ 0 178.61 null]
+endobj
+300 0 obj
+[290 0 R /XYZ 0 110.75 null]
+endobj
+301 0 obj
+<< /Length 7265
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<31322e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4137 Tw
+
+BT
+48.24 758.646 Td
+/F1.0 10.5 Tf
+[<476976656e2061206b6d6572206c656e6774682c20746865206f646769206b6d65727328312920636f6d6d616e642063616e20656d697420616c6c206b6d6572732e20546865206f75747075742063616e20626520726566696e65642062> 20.0195 <79>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.7407 Tw
+
+BT
+48.24 742.866 Td
+/F1.0 10.5 Tf
+[<73657474696e6720746865206d6178696d756d206e756d626572206f6620667572636174696f6e73206174206564676573206f722062> 20.0195 <79206e6f7420636f6e7369646572696e67206e6f6465732061626f7665206120676976656e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 727.086 Td
+/F1.0 10.5 Tf
+<6e6f646520646567726565206c696d69742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 687.246 Td
+/F2.0 18 Tf
+<31322e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 652.506 Td
+/F2.0 13 Tf
+[<31322e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 625.946 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 625.946 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 625.946 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 607.166 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20636f6e766572742066726f6d2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+529.2298 607.166 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+543.7198 607.166 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 579.386 Td
+/F2.0 10.5 Tf
+<2d632c202d2d7374646f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+103.1445 579.386 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 560.606 Td
+/F1.0 10.5 Tf
+[<577269746520746865206b6d65727320746f207374616e64617264206f75747075742e204b6d65727320617265206c696e652d7365706172> 20.0195 <617465642e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 526.106 Td
+/F2.0 13 Tf
+<31322e342e322e204b6d6572204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 499.546 Td
+/F2.0 10.5 Tf
+<2d6b2c202d2d6b6d65722d6c656e677468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+136.0095 499.546 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+141.879 499.546 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 480.766 Td
+/F1.0 10.5 Tf
+[<546865206b6d6572206c656e67746820746f2067656e6572> 20.0195 <617465206b6d6572732066726f6d2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 452.986 Td
+/F2.0 10.5 Tf
+<2d652c202d2d6d61782d667572636174696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+151.476 452.986 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+157.3455 452.986 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 434.206 Td
+/F1.0 10.5 Tf
+[<427265616b206174206564676573207468617420776f756c6420696e647563652074686973206d616e> 20.0195 <7920667572636174696f6e73207768656e2067656e6572> 20.0195 <6174696e672061206b6d65722e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 406.426 Td
+/F2.0 10.5 Tf
+<2d442c202d2d6d61782d646567726565> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+134.634 406.426 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+140.5035 406.426 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 387.646 Td
+/F1.0 10.5 Tf
+[<446f6ed5742074616b> 20.0195 <65206e6f64657320696e746f206163636f756e74207468617420686176652061206465677265652067726561746572207468616e20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+373.3783 387.646 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+381.3898 387.646 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 353.146 Td
+/F2.0 13 Tf
+<31322e342e332e20546872656164696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 326.586 Td
+/F2.0 10.5 Tf
+<2d742c202d2d74687265616473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.951 326.586 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.8205 326.586 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 307.806 Td
+/F1.0 10.5 Tf
+<4e756d626572206f66207468726561647320746f207573652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 273.306 Td
+/F2.0 13 Tf
+[<31322e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 246.746 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 227.966 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 227.966 Td
+/F2.0 10.5 Tf
+<6f646769206b6d657273> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+245.982 227.966 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 188.126 Td
+/F2.0 18 Tf
+[<31322e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 160.106 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 141.326 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 113.546 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 94.766 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -23813,7 +23766,7 @@ Q
 
 endstream
 endobj
-303 0 obj
+302 0 obj
 << /Type /Page
 /Parent 3 0 R
 /MediaBox [0 0 595.28 841.89]
@@ -23821,769 +23774,41 @@ endobj
 /BleedBox [0 0 595.28 841.89]
 /TrimBox [0 0 595.28 841.89]
 /ArtBox [0 0 595.28 841.89]
-/Contents 302 0 R
+/Contents 301 0 R
 /Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
 /Font << /F2.0 17 0 R
-/F4.0 111 0 R
 /F1.0 8 0 R
+/F4.0 111 0 R
 /F3.0 55 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
-/Annots [310 0 R]
 >>
+endobj
+303 0 obj
+[302 0 R /XYZ 0 841.89 null]
 endobj
 304 0 obj
-[303 0 R /XYZ 0 841.89 null]
+[302 0 R /XYZ 0 711.27 null]
 endobj
 305 0 obj
-[303 0 R /XYZ 0 684.29 null]
+[302 0 R /XYZ 0 671.19 null]
 endobj
 306 0 obj
-[303 0 R /XYZ 0 511.33 null]
+[302 0 R /XYZ 0 544.79 null]
 endobj
 307 0 obj
-[303 0 R /XYZ 0 431.49 null]
+[302 0 R /XYZ 0 371.83 null]
 endobj
 308 0 obj
-[303 0 R /XYZ 0 351.65 null]
+[302 0 R /XYZ 0 291.99 null]
 endobj
 309 0 obj
-[303 0 R /XYZ 0 218.45 null]
+[302 0 R /XYZ 0 212.15 null]
 endobj
 310 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 163.34 401.1446 177.62]
-/Type /Annot
->>
-endobj
-311 0 obj
-[303 0 R /XYZ 0 150.59 null]
-endobj
-312 0 obj
-<< /Length 8729
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 782.394 Td
-/F2.0 22 Tf
-<31332e206f64676920756e69746967283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 741.146 Td
-/F2.0 18 Tf
-<31332e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 713.126 Td
-/F1.0 10.5 Tf
-[<6f6467695f756e69746967202d206f757470757420756e6974696773206f6620746865206772> 20.0195 <617068>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 673.286 Td
-/F2.0 18 Tf
-[<31332e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 645.266 Td
-/F2.0 10.5 Tf
-<6f64676920756e69746967> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.2655 645.266 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-111.7545 645.266 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-148.284 645.266 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-154.1535 645.266 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-177.2745 645.266 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-187.533 645.266 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-227.916 645.266 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 605.426 Td
-/F2.0 18 Tf
-<31332e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.3722 Tw
-
-BT
-48.24 577.406 Td
-/F1.0 10.5 Tf
-<546865206f64676920756e6974696728312920636f6d6d616e642063616e207072696e7420616c6c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.3722 Tw
-
-BT
-258.2942 577.406 Td
-/F1.0 10.5 Tf
-<756e6974696773> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.3722 Tw
-
-BT
-292.5032 577.406 Td
-/F1.0 10.5 Tf
-[<206f66206120676976656e206f646769206772> 20.0195 <61706820746f207374616e64617264206f757470757420696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <41>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8795 Tw
-
-BT
-48.24 561.626 Td
-/F1.0 10.5 Tf
-[<666f726d61742e20556e69746967732063616e20616c736f20626520656d697474656420696e20612066697865642073657175656e6365207175616c6974792046> 69.8242 <4153> 20.0195 <54> 20.0195 <5120666f726d61742e2056> 60.0586 <6172696f757320706172> 20.0195 <616d6574657273>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 545.846 Td
-/F1.0 10.5 Tf
-<63616e20726566696e652074686520756e697469677320746f207072696e742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 506.006 Td
-/F2.0 18 Tf
-<31332e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 471.266 Td
-/F2.0 13 Tf
-[<31332e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 444.706 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 444.706 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 444.706 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 425.926 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20636f6e766572742066726f6d2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-529.2298 425.926 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-543.7198 425.926 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 391.426 Td
-/F2.0 13 Tf
-[<31332e342e322e2046> 69.8242 <4153> 20.0195 <54> 20.0195 <51204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 364.866 Td
-/F2.0 10.5 Tf
-[<2d662c202d2d66616b> 20.0195 <652d6661737471>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 346.086 Td
-/F1.0 10.5 Tf
-[<57726974652074686520756e697469677320696e2046> 69.8242 <4153> 20.0195 <54> 20.0195 <5120666f726d617420746f207374646f757420776974682061206669786564207175616c6974792076616c7565206f6620>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-424.6304 346.086 Td
-/F3.0 10.5 Tf
-<49> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-428.4839 346.086 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 311.586 Td
-/F2.0 13 Tf
-<31332e342e332e20556e69746967204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 285.026 Td
-/F2.0 10.5 Tf
-<2d742c202d2d73616d706c652d746f> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-120.165 285.026 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-126.0345 285.026 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 266.246 Td
-/F1.0 10.5 Tf
-[<436f6e74696e756520756e6974696773207769746820612072> 20.0195 <616e646f6d2077616c6b20696e20746865206772> 20.0195 <61706820736f207468617420746865792068617665206174206c656173742074686520676976656e20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-490.4321 266.246 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-498.4436 266.246 Td
-/F1.0 10.5 Tf
-<206c656e6774682e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 238.466 Td
-/F2.0 10.5 Tf
-<2d702c202d2d73616d706c652d706c7573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-134.6025 238.466 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-140.472 238.466 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 219.686 Td
-/F1.0 10.5 Tf
-[<436f6e74696e756520756e6974696773207769746820612072> 20.0195 <616e646f6d2077616c6b20696e20746865206772> 20.0195 <6170682062> 20.0195 <7920>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-330.4119 219.686 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-338.4234 219.686 Td
-/F1.0 10.5 Tf
-[<2070617374207468656972206e61747572> 20.0195 <616c20656e642e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 191.906 Td
-/F2.0 10.5 Tf
-<2d6c2c202d2d6d696e2d626567696e2d6e6f64652d6c656e677468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-187.6485 191.906 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-193.518 191.906 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 173.126 Td
-/F1.0 10.5 Tf
-<4f6e6c7920626567696e20756e697469677320636f6c6c656374696f6e2066726f6d206e6f6465732077686963682068617665206174206c65617374206c656e67746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.3085 173.126 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-409.32 173.126 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 138.626 Td
-/F2.0 13 Tf
-[<31332e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 112.066 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 93.286 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 93.286 Td
-/F2.0 10.5 Tf
-<6f64676920756e69746967> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-243.882 93.286 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3237> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-313 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 312 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [318 0 R]
->>
-endobj
-314 0 obj
-[313 0 R /XYZ 0 841.89 null]
-endobj
-315 0 obj
-[313 0 R /XYZ 0 765.17 null]
-endobj
-316 0 obj
-[313 0 R /XYZ 0 697.31 null]
-endobj
-317 0 obj
-[313 0 R /XYZ 0 629.45 null]
-endobj
-318 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/mcveanlab/mccortex/wiki/unitig)
->>
-/Subtype /Link
-/Rect [258.2942 574.34 292.5032 588.62]
-/Type /Annot
->>
-endobj
-319 0 obj
-[313 0 R /XYZ 0 530.03 null]
-endobj
-320 0 obj
-[313 0 R /XYZ 0 489.95 null]
-endobj
-321 0 obj
-<< /Limits [(_graph_files_io_9) (_name_11)]
-/Names [(_graph_files_io_9) 269 0 R (_graph_sorting) 112 0 R (_haploblocker_options) 442 0 R (_http_options) 604 0 R (_intervals_selection) 341 0 R (_investigation_options) 364 0 R (_kmer_options) 305 0 R (_kmer_options_2) 383 0 R (_matrix_options) 461 0 R (_name) 18 0 R (_name_10) 265 0 R (_name_11) 284 0 R]
->>
-endobj
-322 0 obj
-[313 0 R /XYZ 0 410.11 null]
-endobj
-323 0 obj
-[313 0 R /XYZ 0 330.27 null]
-endobj
-324 0 obj
-[313 0 R /XYZ 0 157.31 null]
-endobj
-325 0 obj
-<< /Length 8068
+<< /Length 8489
 >>
 stream
 q
@@ -24595,19986 +23820,7 @@ q
 BT
 48.24 786.666 Td
 /F2.0 18 Tf
-[<31332e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 739.866 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 712.086 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 693.306 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 653.466 Td
-/F2.0 18 Tf
-<31332e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.446 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 625.446 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 625.446 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 625.446 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 625.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 585.606 Td
-/F2.0 18 Tf
-[<31332e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 557.586 Td
-/F2.0 10.5 Tf
-<6f64676920756e69746967> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.2655 557.586 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 513.474 Td
-/F2.0 22 Tf
-<31342e206f6467692076697a283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 472.226 Td
-/F2.0 18 Tf
-<31342e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 444.206 Td
-/F1.0 10.5 Tf
-[<6f6467695f76697a202d20766172696174696f6e206772> 20.0195 <6170682076697375616c697a6174696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 404.366 Td
-/F2.0 18 Tf
-[<31342e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 376.346 Td
-/F2.0 10.5 Tf
-<6f6467692076697a> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-89.358 376.346 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-95.847 376.346 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-132.3765 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-138.246 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-161.367 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-171.6255 376.346 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-211.2735 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-217.143 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-240.264 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-250.5225 376.346 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-290.9055 376.346 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 336.506 Td
-/F2.0 18 Tf
-<31342e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0576 Tw
-
-BT
-48.24 308.486 Td
-/F1.0 10.5 Tf
-[<546865206f6467692076697a28312920636f6d6d616e642063616e2070726f647563652061206c696e6561722c207374617469632076697375616c697a6174696f6e206f6620616e206f64676920766172696174696f6e206772> 20.0195 <6170682e2049742063616e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1219 Tw
-
-BT
-48.24 292.706 Td
-/F1.0 10.5 Tf
-[<616767726567617465207468652070616e67656e6f6d6520696e746f2062696e7320616e64206469726563746c792072656e6465727320612072> 20.0195 <617374657220696d6167652e205468652062696e6e696e67206c6576656c2063616e206265>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.201 Tw
-
-BT
-48.24 276.926 Td
-/F1.0 10.5 Tf
-<73706563696669656420696e20696e707574206f722069742069732063616c63756c617465642066726f6d2074686520746172676574207769647468206f662074686520504e4720746f20656d69742e2043616e206265207573656420746f> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.969 Tw
-
-BT
-48.24 261.146 Td
-/F1.0 10.5 Tf
-[<70726f647563652076697375616c697a6174696f6e7320666f72206769676162617365207363616c652070616e67656e6f6d65732e2046> 40.0391 <6f72206d6f726520696e666f726d6174696f6e2061626f7574207468652062696e6e696e67>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 245.366 Td
-/F1.0 10.5 Tf
-<70726f636573732c20706c6561736520726566657220746f20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-165.756 245.366 Td
-/F1.0 10.5 Tf
-<6f6467692062696e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-206.5275 245.366 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 205.526 Td
-/F2.0 18 Tf
-<31342e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 170.786 Td
-/F2.0 13 Tf
-[<31342e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 144.226 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 144.226 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 144.226 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 125.446 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20636f6e766572742066726f6d2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-529.2298 125.446 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-543.7198 125.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 97.666 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 97.666 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 97.666 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 78.886 Td
-/F1.0 10.5 Tf
-<5772697465207468652076697375616c697a6174696f6e20696e20504e4720666f726d617420746f20746869732066696c652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3238> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-326 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 325 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [329 0 R 335 0 R]
->>
-endobj
-327 0 obj
-[326 0 R /XYZ 0 841.89 null]
-endobj
-328 0 obj
-[326 0 R /XYZ 0 677.49 null]
-endobj
-329 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 622.38 401.1446 636.66]
-/Type /Annot
->>
-endobj
-330 0 obj
-[326 0 R /XYZ 0 609.63 null]
-endobj
-331 0 obj
-[326 0 R /XYZ 0 541.77 null]
-endobj
-332 0 obj
-[326 0 R /XYZ 0 496.25 null]
-endobj
-333 0 obj
-[326 0 R /XYZ 0 428.39 null]
-endobj
-334 0 obj
-[326 0 R /XYZ 0 360.53 null]
-endobj
-335 0 obj
-<< /Border [0 0 0]
-/Dest (_odgi_bin1)
-/Subtype /Link
-/Rect [165.756 242.3 206.5275 256.58]
-/Type /Annot
->>
-endobj
-336 0 obj
-[326 0 R /XYZ 0 229.55 null]
-endobj
-337 0 obj
-[326 0 R /XYZ 0 189.47 null]
-endobj
-338 0 obj
-<< /Length 11470
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 792.006 Td
-/F2.0 13 Tf
-<31342e342e322e2056697375616c697a6174696f6e204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 765.446 Td
-/F2.0 10.5 Tf
-<2d782c202d2d7769647468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-101.286 765.446 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-107.1555 765.446 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 746.666 Td
-/F1.0 10.5 Tf
-<5365742074686520776964746820696e20706978656c73206f6620746865206f757470757420696d6167652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 718.886 Td
-/F2.0 10.5 Tf
-[<2d79> 89.8438 <2c202d2d686569676874>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-102.7261 718.886 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.5956 718.886 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 700.106 Td
-/F1.0 10.5 Tf
-<536574207468652068656967687420696e20706978656c73206f6620746865206f757470757420696d6167652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 672.326 Td
-/F2.0 10.5 Tf
-[<2d50> 120.1172 <2c202d2d706174682d686569676874>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-130.5798 672.326 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-136.4493 672.326 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 653.546 Td
-/F1.0 10.5 Tf
-<5468652068656967687420696e20706978656c7320666f72206120706174682e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.766 Td
-/F2.0 10.5 Tf
-<2d582c202d2d706174682d782d70616464696e67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-152.295 625.766 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-158.1645 625.766 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 606.986 Td
-/F1.0 10.5 Tf
-<5468652070616464696e6720696e20706978656c73206f6e2074686520782d6178697320666f72206120706174682e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 579.206 Td
-/F2.0 10.5 Tf
-<2d522c202d2d7061636b2d7061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 560.426 Td
-/F1.0 10.5 Tf
-[<5061636b20616c6c2070617468732072> 20.0195 <6174686572207468616e20646973706c61> 20.0195 <79696e6720612073696e676c6520706174682070657220726f77> 69.8242 <2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 532.646 Td
-/F2.0 10.5 Tf
-<2d4c2c202d2d6c696e6b2d706174682d706965636573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-155.6025 532.646 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-161.472 532.646 Td
-/F4.0 10.5 Tf
-[<464c4f> 20.0195 <41> 60.0586 <54>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 513.866 Td
-/F1.0 10.5 Tf
-<53686f77207468696e206c696e6b73206f6620746869732072656c617469766520776964746820746f20636f6e6e6563742070617468207069656365732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 486.086 Td
-/F2.0 10.5 Tf
-<2d412c202d2d616c69676e6d656e742d707265666978> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-162.0495 486.086 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-167.919 486.086 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.4043 Tw
-
-BT
-63.24 467.306 Td
-/F1.0 10.5 Tf
-<4170706c7920616c69676e6d656e742072656c617465642076697375616c206d6f7469667320746f20706174687320776869636820686176652074686973206e616d65207072656669782e204974206166666563747320746865205b> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.4043 Tw
-
-BT
-534.566 467.306 Td
-/F2.0 10.5 Tf
-<2d532c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 451.526 Td
-/F2.0 10.5 Tf
-[<2d2d73686f772d737472> 20.0195 <616e64>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-135.2278 451.526 Td
-/F1.0 10.5 Tf
-<5d20616e64205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-167.3158 451.526 Td
-/F2.0 10.5 Tf
-<2d642c202d2d6368616e67652d6461726b6e657373> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-279.0568 451.526 Td
-/F1.0 10.5 Tf
-<5d206f7074696f6e732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 423.746 Td
-/F2.0 10.5 Tf
-[<2d532c202d2d73686f772d737472> 20.0195 <616e64>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4132 Tw
-
-BT
-63.24 404.966 Td
-/F1.0 10.5 Tf
-[<5573652072656420616e6420626c756520636f6c6f72696e6720746f20646973706c61> 20.0195 <7920666f727761726420616e64207265766572736520616c69676e6d656e74732e205468697320706172> 20.0195 <616d657465722063616e20626520736574>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 389.186 Td
-/F1.0 10.5 Tf
-<696e20636f6d62696e6174696f6e2077697468205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-171.5055 389.186 Td
-/F2.0 10.5 Tf
-<2d412c202d2d616c69676e6d656e742d707265666978> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-285.315 389.186 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-291.1845 389.186 Td
-/F3.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-329.4253 389.186 Td
-/F1.0 10.5 Tf
-<5d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 361.406 Td
-/F2.0 10.5 Tf
-[<2d7a2c202d2d636f6c6f722d62> 20.0195 <792d6d65616e2d696e76657273696f6e2d72> 20.0195 <617465>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8499 Tw
-
-BT
-63.24 342.626 Td
-/F1.0 10.5 Tf
-[<4368616e67652074686520636f6c6f72207265737065637420746f20746865206e6f646520737472> 20.0195 <616e646e6573732028626c61636b20666f7220666f72776172642c2072656420666f722072657665727365293b20696e2062696e6e6564>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1264 Tw
-
-BT
-63.24 326.846 Td
-/F1.0 10.5 Tf
-<6d6f64652028> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1264 Tw
-
-BT
-98.7434 326.846 Td
-/F2.0 10.5 Tf
-<2d622c202d2d62696e6e65642d6d6f6465> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1264 Tw
-
-BT
-192.3224 326.846 Td
-/F1.0 10.5 Tf
-[<292c206368616e67652074686520636f6c6f72207265737065637420746f20746865206d65616e20696e76657273696f6e2072> 20.0195 <617465206f6620746865207061746820666f72>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 311.066 Td
-/F1.0 10.5 Tf
-[<656163682062696e2c2066726f6d20626c61636b20286e6f20696e76657273696f6e732920746f20726564202862696e206d65616e20696e76657273696f6e2072> 20.0195 <61746520657175616c7320746f2031292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 283.286 Td
-/F2.0 10.5 Tf
-[<2d732c202d2d636f6c6f722d62> 20.0195 <792d707265666978>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 264.506 Td
-/F1.0 10.5 Tf
-[<436f6c6f72732070617468732062> 20.0195 <79207468656972206e616d6573206c6f6f6b696e672061742074686520707265666978206265666f72652074686520676976656e2063686172> 20.0195 <616374657220432e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 230.006 Td
-/F2.0 13 Tf
-<31342e342e332e20496e74657276616c732073656c656374696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 203.446 Td
-/F2.0 10.5 Tf
-[<2d722c202d2d706174682d72> 20.0195 <616e6765>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-7.0924 Tw
-
-BT
-63.24 184.666 Td
-/F1.0 10.5 Tf
-[<4e75636c656f746964652072> 20.0195 <616e676520746f2076697375616c697a653a20>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-7.0924 Tw
-
-BT
-242.0954 184.666 Td
-/F5.0 10.5 Tf
-<535452494e473d5b504154483a5d73746172742d656e64> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-7.0924 Tw
-
-BT
-362.8454 184.666 Td
-/F1.0 10.5 Tf
-<2e20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-7.0924 Tw
-
-BT
-375.2824 184.666 Td
-/F5.0 10.5 Tf
-<2a2d656e64> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-7.0924 Tw
-
-BT
-401.5324 184.666 Td
-/F1.0 10.5 Tf
-<20666f7220> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-7.0924 Tw
-
-BT
-436.0347 184.666 Td
-/F5.0 10.5 Tf
-<5b302c656e645d> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-7.0924 Tw
-
-BT
-472.7847 184.666 Td
-/F1.0 10.5 Tf
-<3b20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-7.0924 Tw
-
-BT
-485.5996 184.666 Td
-/F5.0 10.5 Tf
-<73746172742d2a> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-7.0924 Tw
-
-BT
-522.3496 184.666 Td
-/F1.0 10.5 Tf
-<20666f72> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-5.2329 Tw
-
-BT
-63.24 168.886 Td
-/F5.0 10.5 Tf
-<5b73746172742c70616e67656e6f6d655f6c656e6774685d> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-5.2329 Tw
-
-BT
-189.24 168.886 Td
-/F1.0 10.5 Tf
-[<2e204966206e6f2050> 49.8047 <41> 60.0586 <5448206973207370656369666965642c20746865206e75636c656f7469646520706f736974696f6e7320726566657220746f20746865>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.3636 Tw
-
-BT
-63.24 153.106 Td
-/F1.0 10.5 Tf
-[<70616e67656e6f6d65d5732073657175656e63652028692e652e2c207468652073657175656e6365206f627461696e656420617272> 20.0195 <616e67696e6720616c6c20746865206772> 20.0195 <617068d573206e6f64652066726f6d206c65667420746f>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 137.326 Td
-/F1.0 10.5 Tf
-<7269676874292e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 102.826 Td
-/F2.0 13 Tf
-<31342e342e342e2050617468732073656c656374696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 76.266 Td
-/F2.0 10.5 Tf
-[<2d702c202d2d70617468732d746f2d646973706c61> 20.0195 <79>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.2134 Tw
-
-BT
-63.24 57.486 Td
-/F1.0 10.5 Tf
-[<4c697374206f6620706174687320746f20646973706c61> 20.0195 <7920696e2074686520737065636966696564206f726465723b207468652066696c65206d75737420636f6e7461696e206f6e652070617468206e616d6520706572206c696e6520616e642061>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3239> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-339 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 338 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F5.0 236 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
->>
-endobj
-340 0 obj
-[339 0 R /XYZ 0 841.89 null]
-endobj
-341 0 obj
-[339 0 R /XYZ 0 248.69 null]
-endobj
-342 0 obj
-[339 0 R /XYZ 0 121.51 null]
-endobj
-343 0 obj
-<< /Length 10064
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-63.24 794.676 Td
-/F1.0 10.5 Tf
-<737562736574206f6620616c6c2070617468732063616e206265207370656369666965642e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 760.176 Td
-/F2.0 13 Tf
-<31342e342e352e2050617468206e616d65732076697375616c697a6174696f6e204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 733.616 Td
-/F2.0 10.5 Tf
-<2d482c202d2d686964652d706174682d6e616d6573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 714.836 Td
-/F1.0 10.5 Tf
-[<48696465207468652070617468206e616d6573206f6e20746865206c656674206f66207468652067656e6572> 20.0195 <6174656420696d6167652e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 687.056 Td
-/F2.0 10.5 Tf
-[<2d432c202d2d636f6c6f722d706174682d6e616d65732d6261636b> 20.0195 <67726f756e64>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 668.276 Td
-/F1.0 10.5 Tf
-[<436f6c6f722070617468206e616d6573206261636b> 20.0195 <67726f756e642077697468207468652073616d6520636f6c6f72206173207061746873>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 640.496 Td
-/F2.0 10.5 Tf
-[<2d632c202d2d6d61782d6e756d2d6f662d63686172> 20.0195 <616374657273>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0399 Tw
-
-BT
-63.24 621.716 Td
-/F1.0 10.5 Tf
-[<4d6178696d756d206e756d626572206f662063686172> 20.0195 <61637465727320746f20646973706c61> 20.0195 <7920666f7220656163682070617468206e616d6520286d6178203132382063686172> 20.0195 <616374657273292e205468652064656661756c74>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 605.936 Td
-/F1.0 10.5 Tf
-<76616c756520697320> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-104.274 605.936 Td
-/F3.0 10.5 Tf
-<746865206c656e677468206f6620746865206c6f6e676573742070617468206e616d65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-275.739 605.936 Td
-/F1.0 10.5 Tf
-[<2028757020746f2033322063686172> 20.0195 <616374657273292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 571.436 Td
-/F2.0 13 Tf
-<31342e342e362e2042696e6e6564204d6f6465204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 544.876 Td
-/F2.0 10.5 Tf
-<2d622c202d2d62696e6e65642d6d6f6465> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.7917 Tw
-
-BT
-63.24 526.096 Td
-/F1.0 10.5 Tf
-[<54686520766172696174696f6e206772> 20.0195 <6170682069732062696e6e6564206265666f7265206974732076697375616c697a6174696f6e2e204561636820706978656c20696e20746865206f757470757420696d6167652077696c6c>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 510.316 Td
-/F1.0 10.5 Tf
-[<636f72726573706f6e6420746f20612062696e2e2046> 40.0391 <6f72206d6f726520696e666f726d6174696f6e2061626f7574207468652062696e6e696e672070726f636573732c20706c6561736520726566657220746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-487.7756 510.316 Td
-/F1.0 10.5 Tf
-<6f6467692062696e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-528.5471 510.316 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 482.536 Td
-/F2.0 10.5 Tf
-[<2d77> 69.8242 <2c202d2d62696e2d7769647468>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-123.5058 482.536 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.3753 482.536 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5099 Tw
-
-BT
-63.24 463.756 Td
-/F1.0 10.5 Tf
-<5468652062696e20776964746820737065636966696573207468652073697a65206f6620656163682062696e20696e207468652062696e6e6564206d6f64652e204966206974206973206e6f74207370656369666965642c207468652062696e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 447.976 Td
-/F1.0 10.5 Tf
-<77696474682069732063616c63756c617465642066726f6d2074686520776964746820696e20706978656c73206f6620746865206f757470757420696d6167652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 420.196 Td
-/F2.0 10.5 Tf
-<2d672c202d2d6e6f2d6761702d6c696e6b73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 401.416 Td
-/F1.0 10.5 Tf
-[<57> 60.0586 <6520646976696465206c696e6b7320696e746f203220636c61737365733a>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
--0.5 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-67.6765 373.636 Td
-/F1.0 10.5 Tf
-<312e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
-0.0 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.2408 Tw
-
-BT
-81.24 373.636 Td
-/F1.0 10.5 Tf
-[<746865206c696e6b732077686963682068656c7020746f20666f6c6c6f7720636f6d706c657820766172696174696f6e732e2054686579206e65656420746f206265206472> 20.0195 <61776e2c20656c7365206f6e6520636f756c64206e6f74>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-81.24 357.856 Td
-/F1.0 10.5 Tf
-<666f6c6c6f77207468652073657175656e6365206f66206120706174682e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
--0.5 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-67.6765 336.076 Td
-/F1.0 10.5 Tf
-<322e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
-0.0 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9739 Tw
-
-BT
-81.24 336.076 Td
-/F1.0 10.5 Tf
-<746865206c696e6b732068656c70696e6720746f20666f6c6c6f772073696d706c6520766172696174696f6e732e205468657365206c696e6b73206172652063616c6c656420> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9739 Tw
-
-BT
-438.2287 336.076 Td
-/F2.0 10.5 Tf
-<6761702d6c696e6b73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9739 Tw
-
-BT
-486.6022 336.076 Td
-/F1.0 10.5 Tf
-<2e2053756368206c696e6b73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.7733 Tw
-
-BT
-81.24 320.296 Td
-/F1.0 10.5 Tf
-[<736f6c656c7920636f6e6e656374696e67206120706174682066726f6d206c65667420746f207269676874206d61> 20.0195 <79206e6f742062652072656c6576616e7420746f20756e6465727374616e6420612070617468d573>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4291 Tw
-
-BT
-81.24 304.516 Td
-/F1.0 10.5 Tf
-[<7472> 20.0195 <6176657273616c207468726f756768207468652062696e732e205468657265666f72652c207768656e2074686973206f7074696f6e206973207365742c20746865206761702d6c696e6b7320617265206e6f74206472> 20.0195 <61776e20696e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-81.24 288.736 Td
-/F1.0 10.5 Tf
-<62696e6e6564206d6f64652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 260.956 Td
-/F2.0 10.5 Tf
-[<2d6d2c202d2d636f6c6f722d62> 20.0195 <792d6d65616e2d636f766572> 20.0195 <616765>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0891 Tw
-
-BT
-63.24 242.176 Td
-/F1.0 10.5 Tf
-[<4368616e67652074686520636f6c6f72207265737065637420746f20746865206d65616e20636f766572> 20.0195 <616765206f6620746865207061746820666f7220656163682062696e2c2066726f6d20626c61636b20286e6f20636f766572> 20.0195 <61676529>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 226.396 Td
-/F1.0 10.5 Tf
-[<746f20626c756520286d61782062696e206d65616e20636f766572> 20.0195 <61676520696e2074686520656e74697265206772> 20.0195 <617068292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 191.896 Td
-/F2.0 13 Tf
-[<31342e342e372e204772> 20.0195 <616469656e74204d6f64652028616c736f206b6e6f776e20617320506f736974696f6e204d6f646529204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 165.336 Td
-/F2.0 10.5 Tf
-<2d642c202d2d6368616e67652d6461726b6e657373> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9976 Tw
-
-BT
-63.24 146.556 Td
-/F1.0 10.5 Tf
-<4368616e67652074686520636f6c6f72206461726b6e657373206261736564206f6e206e75636c656f7469646520706f736974696f6e20696e2074686520706174682e205768656e206974206973207573656420696e2062696e6e6564> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.3192 Tw
-
-BT
-63.24 130.776 Td
-/F1.0 10.5 Tf
-[<6d6f64652c20746865206d65616e20696e76657273696f6e2072> 20.0195 <617465206f66207468652062696e206e6f646520697320636f6e7369646572656420746f207365742074686520636f6c6f72206772> 20.0195 <616469656e74207374617274696e67>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.1419 Tw
-
-BT
-63.24 114.996 Td
-/F1.0 10.5 Tf
-[<706f736974696f6e3a207768656e20746869732072> 20.0195 <6174652069732067726561746572207468616e20302e352c207468652062696e20697320636f6e7369646572656420696e7665727465642c20616e642074686520636f6c6f72206772> 20.0195 <616469656e74>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.3909 Tw
-
-BT
-63.24 99.216 Td
-/F1.0 10.5 Tf
-[<7374617274732066726f6d207468652072696768742d656e64206f66207468652062696e2e205468697320706172> 20.0195 <616d657465722063616e2062652073657420696e20636f6d62696e6174696f6e2077697468205b>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.3909 Tw
-
-BT
-532.8125 99.216 Td
-/F2.0 10.5 Tf
-<2d412c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 83.436 Td
-/F2.0 10.5 Tf
-<2d2d616c69676e6d656e742d707265666978> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-160.1025 83.436 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-165.972 83.436 Td
-/F3.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-204.2128 83.436 Td
-/F1.0 10.5 Tf
-<5d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3330> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-344 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 343 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F1.0 8 0 R
-/F2.0 17 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [347 0 R]
->>
-endobj
-345 0 obj
-[344 0 R /XYZ 0 778.86 null]
-endobj
-346 0 obj
-[344 0 R /XYZ 0 590.12 null]
-endobj
-347 0 obj
-<< /Border [0 0 0]
-/Dest (_odgi_bin1)
-/Subtype /Link
-/Rect [487.7756 507.25 528.5471 521.53]
-/Type /Annot
->>
-endobj
-348 0 obj
-[344 0 R /XYZ 0 210.58 null]
-endobj
-349 0 obj
-<< /Length 6465
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 793.926 Td
-/F2.0 10.5 Tf
-<2d6c2c202d2d6c6f6e676573742d70617468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 775.146 Td
-/F1.0 10.5 Tf
-<55736520746865206c6f6e676573742070617468206c656e67746820746f206368616e67652074686520636f6c6f72206461726b6e6573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 747.366 Td
-/F2.0 10.5 Tf
-<2d752c202d2d77686974652d746f2d626c61636b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.7053 Tw
-
-BT
-63.24 728.586 Td
-/F1.0 10.5 Tf
-<4368616e67652074686520636f6c6f72206461726b6e6573732066726f6d2077686974652028666f7220746865206669727374206e75636c656f7469646520706f736974696f6e2920746f20626c61636b2028666f7220746865206c617374> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 712.806 Td
-/F1.0 10.5 Tf
-<6e75636c656f7469646520706f736974696f6e292e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 678.306 Td
-/F2.0 13 Tf
-[<31342e342e382e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 651.746 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 632.966 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 632.966 Td
-/F2.0 10.5 Tf
-<6f6467692076697a> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-227.9745 632.966 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 593.126 Td
-/F2.0 18 Tf
-[<31342e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 565.106 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 546.326 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 518.546 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 499.766 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 459.926 Td
-/F2.0 18 Tf
-<31342e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.9608 0.9608 0.9608 scn
-52.24 443.87 m
-543.04 443.87 l
-545.2491 443.87 547.04 442.0791 547.04 439.87 c
-547.04 411.13 l
-547.04 408.9209 545.2491 407.13 543.04 407.13 c
-52.24 407.13 l
-50.0309 407.13 48.24 408.9209 48.24 411.13 c
-48.24 439.87 l
-48.24 442.0791 50.0309 443.87 52.24 443.87 c
-h
-f
-0.8 0.8 0.8 SCN
-0.75 w
-52.24 443.87 m
-543.04 443.87 l
-545.2491 443.87 547.04 442.0791 547.04 439.87 c
-547.04 411.13 l
-547.04 408.9209 545.2491 407.13 543.04 407.13 c
-52.24 407.13 l
-50.0309 407.13 48.24 408.9209 48.24 411.13 c
-48.24 439.87 l
-48.24 442.0791 50.0309 443.87 52.24 443.87 c
-h
-S
-Q
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-59.24 421.045 Td
-/F5.0 11 Tf
-<526566657220746f20746865202a6f6467692a20697373756520747261636b65722061742068747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f6973737565732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 371.106 Td
-/F2.0 18 Tf
-[<31342e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 343.086 Td
-/F2.0 10.5 Tf
-<6f6467692076697a> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-89.358 343.086 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 298.974 Td
-/F2.0 22 Tf
-<31352e206f646769207061746873283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 257.726 Td
-/F2.0 18 Tf
-<31352e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 229.706 Td
-/F1.0 10.5 Tf
-<6f6467695f7061746873202d20656d626564646564207061746820696e746572726f676174696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 189.866 Td
-/F2.0 18 Tf
-[<31352e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 161.846 Td
-/F2.0 10.5 Tf
-<6f646769207061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-103.176 161.846 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.665 161.846 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-146.1945 161.846 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-152.064 161.846 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-175.185 161.846 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-185.4435 161.846 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-225.8265 161.846 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 122.006 Td
-/F2.0 18 Tf
-<31352e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9829 Tw
-
-BT
-48.24 93.986 Td
-/F1.0 10.5 Tf
-[<546865206f64676920706174687328312920636f6d6d616e6420616c6c6f77732074686520696e7665737469676174696f6e206f66207061746873206f66206120676976656e20766172696174696f6e206772> 20.0195 <6170682e2049742063616e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 78.206 Td
-/F1.0 10.5 Tf
-<63616c63756c617465206f7665726c61702073746174697374696373206f662067726f7570696e6773206f662070617468732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3331> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-350 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 349 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F5.0 236 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
->>
-endobj
-351 0 obj
-[350 0 R /XYZ 0 696.99 null]
-endobj
-352 0 obj
-[350 0 R /XYZ 0 617.15 null]
-endobj
-353 0 obj
-[350 0 R /XYZ 0 483.95 null]
-endobj
-354 0 obj
-[350 0 R /XYZ 0 395.13 null]
-endobj
-355 0 obj
-[350 0 R /XYZ 0 327.27 null]
-endobj
-356 0 obj
-<< /Limits [(_odgi_extract1) (_odgi_paths1)]
-/Names [(_odgi_extract1) 264 0 R (_odgi_flatten1) 504 0 R (_odgi_groom1) 194 0 R (_odgi_kmers1) 297 0 R (_odgi_layout1) 486 0 R (_odgi_matrix1) 451 0 R (_odgi_normalize1) 411 0 R (_odgi_panpos1) 556 0 R (_odgi_pathindex1) 538 0 R (_odgi_paths1) 355 0 R]
->>
-endobj
-357 0 obj
-[350 0 R /XYZ 0 281.75 null]
-endobj
-358 0 obj
-[350 0 R /XYZ 0 213.89 null]
-endobj
-359 0 obj
-[350 0 R /XYZ 0 146.03 null]
-endobj
-360 0 obj
-<< /Length 10115
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-<31352e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 751.926 Td
-/F2.0 13 Tf
-[<31352e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 725.366 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 725.366 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 725.366 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.5222 Tw
-
-BT
-63.24 706.586 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20696e766573746967617465207468652070617468732066726f6d2e205468652066696c65206e616d6520757375616c6c79>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 690.806 Td
-/F1.0 10.5 Tf
-<656e6473207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.984 690.806 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.474 690.806 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 663.026 Td
-/F2.0 10.5 Tf
-<2d4f2c202d2d6f7665726c617073> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-118.1805 663.026 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-124.05 663.026 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.2386 Tw
-
-BT
-63.24 644.246 Td
-/F1.0 10.5 Tf
-[<5265616420696e2074686520706174682067726f7570696e672066696c6520746f2067656e6572> 20.0195 <61746520746865206f7665726c617020737461746973746963732066726f6d2e205468652066696c65206d757374206265207461622d>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0934 Tw
-
-BT
-63.24 628.466 Td
-/F1.0 10.5 Tf
-<64656c696d697465642e2054686520666972737420636f6c756d6e206c6973747320612067726f7570696e6720616e6420746865207365636f6e6420746865207061746820697473656c662e2045616368206c696e6520686173206f6e652070617468> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.1998 Tw
-
-BT
-63.24 612.686 Td
-/F1.0 10.5 Tf
-[<656e747279> 89.8438 <2e2046> 40.0391 <6f7220656163682067726f757020746865207061697277697365206f7665726c6170207374617469737469637320666f7220656163682070616972696e672077696c6c2062652063616c63756c6174656420616e64>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 596.906 Td
-/F1.0 10.5 Tf
-<7072696e74656420746f207374646f75742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 562.406 Td
-/F2.0 13 Tf
-<31352e342e322e20496e7665737469676174696f6e204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 535.846 Td
-/F2.0 10.5 Tf
-<2d4c2c202d2d6c6973742d7061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 517.066 Td
-/F1.0 10.5 Tf
-[<5072696e742074686520706174687320696e20746865206772> 20.0195 <61706820746f207374646f75742e20456163682070617468206973207072696e74656420696e20697473206f776e206c696e652e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 489.286 Td
-/F2.0 10.5 Tf
-<2d482c202d2d6861706c6f7479706573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.0046 Tw
-
-BT
-63.24 470.506 Td
-/F1.0 10.5 Tf
-[<5072696e7420746f207374646f75742074686520706174687320696e20616e20617070726f78696d6174652062696e617279206861706c6f74797065206d6174726978206261736564206f6e20746865206772> 20.0195 <617068d57320736f7274>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-63.24 454.726 Td
-/F1.0 10.5 Tf
-<6f726465722e20546865206f7574707574206973207461622d64656c696d697465643a20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-258.3626 454.726 Td
-/F2.0 10.5 Tf
-<706174682e6e616d65> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-315.3461 454.726 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-324.8803 454.726 Td
-/F2.0 10.5 Tf
-<706174682e6c656e677468> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-386.0428 454.726 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-395.5771 454.726 Td
-/F2.0 10.5 Tf
-<6e6f64652e636f756e74> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-455.0386 454.726 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-464.5728 454.726 Td
-/F2.0 10.5 Tf
-<6e6f64652e31> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-499.7268 454.726 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-509.261 454.726 Td
-/F2.0 10.5 Tf
-<6e6f64652e32> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-4.1897 Tw
-
-BT
-544.415 454.726 Td
-/F1.0 10.5 Tf
-<2c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 438.946 Td
-/F2.0 10.5 Tf
-<6e6f64652e6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-99.5175 438.946 Td
-/F1.0 10.5 Tf
-<2e2045616368207061746820656e747279206973207072696e74656420696e20697473206f776e206c696e652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 411.166 Td
-/F2.0 10.5 Tf
-<2d442c202d2d64656c696d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-102.378 411.166 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.2475 411.166 Td
-/F4.0 10.5 Tf
-<43484152> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.3931 Tw
-
-BT
-63.24 392.386 Td
-/F1.0 10.5 Tf
-[<5468652070617274206f6620656163682070617468206e616d65206265666f726520746869732064656c696d6974657220697320612067726f7570206964656e7469666965722e205468697320706172> 20.0195 <616d657465722073686f756c64>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-5.1697 Tw
-
-BT
-63.24 376.606 Td
-/F1.0 10.5 Tf
-<6f6e6c792062652073657420696e20636f6d62696e6174696f6e2077697468205b> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-5.1697 Tw
-
-BT
-258.793 376.606 Td
-/F2.0 10.5 Tf
-<2d482c202d2d6861706c6f7479706573> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-5.1697 Tw
-
-BT
-346.4822 376.606 Td
-/F1.0 10.5 Tf
-<5d2e205072696e747320616e206164646974696f6e616c2c20666972737420636f6c756d6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 360.826 Td
-/F2.0 10.5 Tf
-<67726f75702e6e616d65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-127.479 360.826 Td
-/F1.0 10.5 Tf
-<20746f207374646f75742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 333.046 Td
-/F2.0 10.5 Tf
-<2d642c202d2d64697374616e6365> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.2098 Tw
-
-BT
-63.24 314.266 Td
-/F1.0 10.5 Tf
-<50726f76696465732061207370617273652064697374616e6365206d617472697820666f722070617468732e204966205b> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.2098 Tw
-
-BT
-324.4863 314.266 Td
-/F2.0 10.5 Tf
-<2d442c202d2d64656c696d> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.2098 Tw
-
-BT
-381.8341 314.266 Td
-/F1.0 10.5 Tf
-<5d206973207365742c2069742077696c6c20626520706174682067726f757073> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 298.486 Td
-/F1.0 10.5 Tf
-<64697374616e6365732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 270.706 Td
-/F2.0 10.5 Tf
-<2d662c202d2d6661737461> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 251.926 Td
-/F1.0 10.5 Tf
-[<5072696e7420706174687320696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120666f726d617420746f207374646f75742e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 217.426 Td
-/F2.0 13 Tf
-<31352e342e332e20546872656164696e67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 190.866 Td
-/F2.0 10.5 Tf
-<2d742c202d2d74687265616473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.951 190.866 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.8205 190.866 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 172.086 Td
-/F1.0 10.5 Tf
-<4e756d626572206f66207468726561647320746f207573652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 137.586 Td
-/F2.0 13 Tf
-[<31352e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 111.026 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 92.246 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 92.246 Td
-/F2.0 10.5 Tf
-<6f646769207061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-241.7925 92.246 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3332> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-361 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 360 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
->>
-endobj
-362 0 obj
-[361 0 R /XYZ 0 841.89 null]
-endobj
-363 0 obj
-[361 0 R /XYZ 0 770.61 null]
-endobj
-364 0 obj
-[361 0 R /XYZ 0 581.09 null]
-endobj
-365 0 obj
-[361 0 R /XYZ 0 236.11 null]
-endobj
-366 0 obj
-[361 0 R /XYZ 0 156.27 null]
-endobj
-367 0 obj
-<< /Limits [(_program_information_13) (_program_information_21)]
-/Names [(_program_information_13) 351 0 R (_program_information_14) 366 0 R (_program_information_15) 389 0 R (_program_information_16) 406 0 R (_program_information_17) 421 0 R (_program_information_18) 444 0 R (_program_information_19) 462 0 R (_program_information_2) 134 0 R (_program_information_20) 479 0 R (_program_information_21) 499 0 R]
->>
-endobj
-368 0 obj
-<< /Length 7821
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-[<31352e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 739.866 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 712.086 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 693.306 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 653.466 Td
-/F2.0 18 Tf
-<31352e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.446 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 625.446 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 625.446 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 625.446 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 625.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 585.606 Td
-/F2.0 18 Tf
-[<31352e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 557.586 Td
-/F2.0 10.5 Tf
-<6f646769207061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-103.176 557.586 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 513.474 Td
-/F2.0 22 Tf
-<31362e206f646769207072756e65283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 472.226 Td
-/F2.0 18 Tf
-<31362e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 444.206 Td
-/F1.0 10.5 Tf
-[<6f6467695f7072756e65202d2072656d6f766520636f6d706c6578207061727473206f6620746865206772> 20.0195 <617068>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 404.366 Td
-/F2.0 18 Tf
-[<31362e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 376.346 Td
-/F2.0 10.5 Tf
-<6f646769207072756e65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.99 376.346 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-112.479 376.346 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-149.0085 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-154.878 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-177.999 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-188.2575 376.346 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-227.9055 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-233.775 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-256.896 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-267.1545 376.346 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-307.5375 376.346 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 336.506 Td
-/F2.0 18 Tf
-<31362e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4057 Tw
-
-BT
-48.24 308.486 Td
-/F1.0 10.5 Tf
-[<546865206f646769207072756e6528312920636f6d6d616e642063616e2072656d6f766520636f6d706c6578207061727473206f662061206772> 20.0195 <6170682e204f6e652063616e2064726f702070617468732c206e6f6465732062> 20.0195 <792061>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9375 Tw
-
-BT
-48.24 292.706 Td
-/F1.0 10.5 Tf
-[<6365727461696e206b696e64206f66206564676520636f766572> 20.0195 <6167652c20656467657320616e64206772> 20.0195 <61706820746970732e2053706563696679696e672061206b6d6572206c656e67746820616e642061206d6178696d756d>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 276.926 Td
-/F1.0 10.5 Tf
-[<6e756d626572206f6620667572636174696f6e732c20746865206772> 20.0195 <6170682063616e2062652062726f6b> 20.0195 <656e206174206564676573206e6f742066697474696e6720696e746f20746865736520636f6e646974696f6e732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 237.086 Td
-/F2.0 18 Tf
-<31362e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 202.346 Td
-/F2.0 13 Tf
-[<31362e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 175.786 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 175.786 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 175.786 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 157.006 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206c6f616420696e2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-497.8768 157.006 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-512.3668 157.006 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 129.226 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 129.226 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 129.226 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 110.446 Td
-/F1.0 10.5 Tf
-[<577269746520746865207072756e6564206772> 20.0195 <61706820746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-197.3983 110.446 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-220.5193 110.446 Td
-/F1.0 10.5 Tf
-<2e205468652066696c65206e616d652073686f756c6420656e64207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-380.5498 110.446 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-395.0398 110.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3333> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-369 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 368 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [373 0 R]
->>
-endobj
-370 0 obj
-[369 0 R /XYZ 0 841.89 null]
-endobj
-371 0 obj
-<< /Limits [(_exit_status_4) (_graph_files_io)]
-/Names [(_exit_status_4) 190 0 R (_exit_status_5) 204 0 R (_exit_status_6) 223 0 R (_exit_status_7) 241 0 R (_exit_status_8) 259 0 R (_exit_status_9) 279 0 R (_explode_options) 235 0 R (_extract_options) 272 0 R (_fasta_options) 438 0 R (_fastq_options) 322 0 R (_gradient_mode_also_known_as_position_mode_options) 348 0 R (_graph_files_io) 110 0 R]
->>
-endobj
-372 0 obj
-[369 0 R /XYZ 0 677.49 null]
-endobj
-373 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 622.38 401.1446 636.66]
-/Type /Annot
->>
-endobj
-374 0 obj
-[369 0 R /XYZ 0 609.63 null]
-endobj
-375 0 obj
-[369 0 R /XYZ 0 541.77 null]
-endobj
-376 0 obj
-[369 0 R /XYZ 0 496.25 null]
-endobj
-377 0 obj
-[369 0 R /XYZ 0 428.39 null]
-endobj
-378 0 obj
-[369 0 R /XYZ 0 360.53 null]
-endobj
-379 0 obj
-[369 0 R /XYZ 0 261.11 null]
-endobj
-380 0 obj
-[369 0 R /XYZ 0 221.03 null]
-endobj
-381 0 obj
-<< /Length 9476
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 792.006 Td
-/F2.0 13 Tf
-<31362e342e322e204b6d6572204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 765.446 Td
-/F2.0 10.5 Tf
-<2d6b2c202d2d6b6d65722d6c656e677468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-136.0095 765.446 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-141.879 765.446 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 746.666 Td
-/F1.0 10.5 Tf
-<546865206c656e677468206f6620746865206b6d65727320746f20636f6e73696465722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 718.886 Td
-/F2.0 10.5 Tf
-<2d652c202d2d6d61782d667572636174696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-151.476 718.886 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-157.3455 718.886 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 700.106 Td
-/F1.0 10.5 Tf
-<427265616b206174206564676573207468617420776f756c6420696e6475636520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-232.059 700.106 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-240.0705 700.106 Td
-/F1.0 10.5 Tf
-[<206d616e> 20.0195 <7920667572636174696f6e7320696e2061206b6d65722e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 665.606 Td
-/F2.0 13 Tf
-<31362e342e332e204e6f6465204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 639.046 Td
-/F2.0 10.5 Tf
-<2d642c202d2d6d61782d646567726565> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-133.3845 639.046 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-139.254 639.046 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 620.266 Td
-/F1.0 10.5 Tf
-<52656d6f7665206e6f64657320746861742068617665206120686967686572206e6f646520646567726565207468616e20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-322.275 620.266 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-330.2865 620.266 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 592.486 Td
-/F2.0 10.5 Tf
-[<2d632c202d2d6d696e2d636f766572> 20.0195 <616765>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-141.3223 592.486 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-147.1918 592.486 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 573.706 Td
-/F1.0 10.5 Tf
-[<52656d6f7665206e6f6465736520636f76657265642062> 20.0195 <79206665776572207468616e20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-259.1488 573.706 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-267.1603 573.706 Td
-/F1.0 10.5 Tf
-<206e756d626572206f6620706174682073746570732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 545.926 Td
-/F2.0 10.5 Tf
-[<2d432c202d2d6d61782d636f766572> 20.0195 <616765>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-145.1758 545.926 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-151.0453 545.926 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 527.146 Td
-/F1.0 10.5 Tf
-[<52656d6f7665206e6f64657320636f76657265642062> 20.0195 <79206d6f7265207468616e20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-250.9693 527.146 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-258.9808 527.146 Td
-/F1.0 10.5 Tf
-<206e756d626572206f6620706174682073746570732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 499.366 Td
-/F2.0 10.5 Tf
-[<2d54> 89.8438 <2c202d2d6375742d74697073>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.5406 499.366 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-115.4101 499.366 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 480.586 Td
-/F1.0 10.5 Tf
-[<52656d6f7665206e6f64657320776869636820617265206772> 20.0195 <61706820746970732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 446.086 Td
-/F2.0 13 Tf
-<31362e342e342e2045646765204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 419.526 Td
-/F2.0 10.5 Tf
-[<2d452c202d2d656467652d636f766572> 20.0195 <616765>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4637 Tw
-
-BT
-63.24 400.746 Td
-/F1.0 10.5 Tf
-[<52656d6f7665206564676573206f757473696465206f6620746865206d696e696d756d20616e64206d6178696d756d20636f766572> 20.0195 <6167652072> 20.0195 <6174686572207468616e206e6f6465732e204f6e6c79207365742074686973>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 384.966 Td
-/F1.0 10.5 Tf
-<617267756d656e7420696e20636f6d62696e6174696f6e2077697468205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-223.3755 384.966 Td
-/F2.0 10.5 Tf
-[<2d632c202d2d6d696e2d636f766572> 20.0195 <616765>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-316.4578 384.966 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-322.3273 384.966 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-330.3388 384.966 Td
-/F1.0 10.5 Tf
-<5d20616e64205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-362.4268 384.966 Td
-/F2.0 10.5 Tf
-[<2d432c202d2d6d61782d636f766572> 20.0195 <616765>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-459.3626 384.966 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-465.2321 384.966 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-473.2436 384.966 Td
-/F1.0 10.5 Tf
-<5d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 357.186 Td
-/F2.0 10.5 Tf
-<2d622c202d2d626573742d6564676573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-125.772 357.186 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.6415 357.186 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 338.406 Td
-/F1.0 10.5 Tf
-[<4f6e6c79206b> 20.0195 <6565702074686520>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-134.7028 338.406 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-142.7143 338.406 Td
-/F1.0 10.5 Tf
-<206d6f737420636f766572656420696e626f756e6420616e64206f7574707574206564676573206f662065616368206e6f64652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 303.906 Td
-/F2.0 13 Tf
-<31362e342e352e2050617468204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 277.346 Td
-/F2.0 10.5 Tf
-<2d442c202d2d64726f702d7061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 258.566 Td
-/F1.0 10.5 Tf
-[<52656d6f7665207468652070617468732066726f6d20746865206772> 20.0195 <6170682e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 224.066 Td
-/F2.0 13 Tf
-<31362e342e362e20546872656164696e67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 197.506 Td
-/F2.0 10.5 Tf
-<2d742c202d2d74687265616473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.951 197.506 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.8205 197.506 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 178.726 Td
-/F1.0 10.5 Tf
-<4e756d626572206f66207468726561647320746f207573652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 144.226 Td
-/F2.0 13 Tf
-[<31362e342e372e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 117.666 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 98.886 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 98.886 Td
-/F2.0 10.5 Tf
-<6f646769207072756e65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-244.6065 98.886 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3334> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-382 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 381 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
->>
-endobj
-383 0 obj
-[382 0 R /XYZ 0 841.89 null]
-endobj
-384 0 obj
-[382 0 R /XYZ 0 684.29 null]
-endobj
-385 0 obj
-[382 0 R /XYZ 0 464.77 null]
-endobj
-386 0 obj
-[382 0 R /XYZ 0 322.59 null]
-endobj
-387 0 obj
-<< /Limits [(_options_6) (_processing_information)]
-/Names [(_options_6) 214 0 R (_options_7) 233 0 R (_options_8) 252 0 R (_options_9) 268 0 R (_output_options) 512 0 R (_path_guided_1d_linear_sgd_sort) 178 0 R (_path_names_visualization_options) 345 0 R (_path_options) 386 0 R (_path_sorting_options) 181 0 R (_paths_selection) 342 0 R (_pipeline_sorting) 183 0 R (_position_options) 564 0 R (_position_options_2) 581 0 R (_processing_information) 113 0 R]
->>
-endobj
-388 0 obj
-[382 0 R /XYZ 0 242.75 null]
-endobj
-389 0 obj
-[382 0 R /XYZ 0 162.91 null]
-endobj
-390 0 obj
-<< /Length 7430
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-[<31362e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 739.866 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 712.086 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 693.306 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 653.466 Td
-/F2.0 18 Tf
-<31362e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.446 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 625.446 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 625.446 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 625.446 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 625.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 585.606 Td
-/F2.0 18 Tf
-[<31362e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 557.586 Td
-/F2.0 10.5 Tf
-<6f646769207072756e65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.99 557.586 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 513.474 Td
-/F2.0 22 Tf
-<31372e206f64676920756e63686f70283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 472.226 Td
-/F2.0 18 Tf
-<31372e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 444.206 Td
-/F1.0 10.5 Tf
-<6f6467695f756e63686f70202d206d6572676520756e697469677320696e746f2073696e676c65206e6f646573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 404.366 Td
-/F2.0 18 Tf
-[<31372e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 376.346 Td
-/F2.0 10.5 Tf
-<6f64676920756e63686f70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.466 376.346 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-119.955 376.346 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-156.4845 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-162.354 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-185.475 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-195.7335 376.346 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-235.3815 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-241.251 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-264.372 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-274.6305 376.346 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-315.0135 376.346 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 336.506 Td
-/F2.0 18 Tf
-<31372e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 308.486 Td
-/F1.0 10.5 Tf
-<546865206f64676920756e63686f7028312920636f6d6d616e64206d6572676573206561636820756e6974696720696e746f20612073696e676c65206e6f64652070726573657276696e6720746865206e6f6465206f726465722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 268.646 Td
-/F2.0 18 Tf
-<31372e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 233.906 Td
-/F2.0 13 Tf
-[<31372e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 207.346 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 207.346 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 207.346 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 188.566 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20756e63686f702e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-501.1318 188.566 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-515.6218 188.566 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 160.786 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 160.786 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 160.786 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.1519 Tw
-
-BT
-63.24 142.006 Td
-/F1.0 10.5 Tf
-[<57726974652074686520756e63686f707065642064796e616d69632073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20746869732066696c652e20412066696c6520656e64696e67207769746820>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.1519 Tw
-
-BT
-519.5936 142.006 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.1519 Tw
-
-BT
-534.0836 142.006 Td
-/F1.0 10.5 Tf
-<206973> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 126.226 Td
-/F1.0 10.5 Tf
-<7265636f6d6d656e6465642e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 91.726 Td
-/F2.0 13 Tf
-<31372e342e322e2050726f63657373696e6720496e666f726d6174696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 65.166 Td
-/F2.0 10.5 Tf
-<2d642c202d2d6465627567> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3335> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-391 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 390 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [394 0 R]
->>
-endobj
-392 0 obj
-[391 0 R /XYZ 0 841.89 null]
-endobj
-393 0 obj
-[391 0 R /XYZ 0 677.49 null]
-endobj
-394 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 622.38 401.1446 636.66]
-/Type /Annot
->>
-endobj
-395 0 obj
-[391 0 R /XYZ 0 609.63 null]
-endobj
-396 0 obj
-[391 0 R /XYZ 0 541.77 null]
-endobj
-397 0 obj
-[391 0 R /XYZ 0 496.25 null]
-endobj
-398 0 obj
-[391 0 R /XYZ 0 428.39 null]
-endobj
-399 0 obj
-[391 0 R /XYZ 0 360.53 null]
-endobj
-400 0 obj
-[391 0 R /XYZ 0 292.67 null]
-endobj
-401 0 obj
-[391 0 R /XYZ 0 252.59 null]
-endobj
-402 0 obj
-[391 0 R /XYZ 0 110.41 null]
-endobj
-403 0 obj
-<< /Length 7068
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-63.24 794.676 Td
-/F1.0 10.5 Tf
-<5072696e7420696e666f726d6174696f6e2061626f7574207468652070726f6365737320746f207374646572722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 760.176 Td
-/F2.0 13 Tf
-<31372e342e332e20546872656164696e67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 733.616 Td
-/F2.0 10.5 Tf
-<2d742c202d2d74687265616473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.951 733.616 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.8205 733.616 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 714.836 Td
-/F1.0 10.5 Tf
-[<4e756d626572206f66207468726561647320746f2075736520666f722074686520706172> 20.0195 <616c6c656c206f706572> 20.0195 <6174696f6e732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 680.336 Td
-/F2.0 13 Tf
-[<31372e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 653.776 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 634.996 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 634.996 Td
-/F2.0 10.5 Tf
-<6f64676920756e63686f70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-252.0825 634.996 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 595.156 Td
-/F2.0 18 Tf
-[<31372e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 567.136 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 548.356 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 520.576 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 501.796 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 461.956 Td
-/F2.0 18 Tf
-<31372e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 433.936 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 433.936 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 433.936 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 433.936 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 433.936 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 394.096 Td
-/F2.0 18 Tf
-[<31372e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 366.076 Td
-/F2.0 10.5 Tf
-<6f64676920756e63686f70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.466 366.076 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 321.964 Td
-/F2.0 22 Tf
-<31382e206f646769206e6f726d616c697a65283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 280.716 Td
-/F2.0 18 Tf
-<31382e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 252.696 Td
-/F1.0 10.5 Tf
-<6f6467695f6e6f726d616c697a65202d20636f6d7061637420756e697469677320616e642073696d706c69667920726564756e64616e7420667572636174696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 212.856 Td
-/F2.0 18 Tf
-[<31382e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 184.836 Td
-/F2.0 10.5 Tf
-<6f646769206e6f726d616c697a65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-128.2185 184.836 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-134.7075 184.836 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-171.237 184.836 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-177.1065 184.836 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-200.2275 184.836 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-210.486 184.836 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-250.134 184.836 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-256.0035 184.836 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-279.1245 184.836 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-289.383 184.836 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-329.766 184.836 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 144.996 Td
-/F2.0 18 Tf
-<31382e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.8161 Tw
-
-BT
-48.24 116.976 Td
-/F1.0 10.5 Tf
-<546865206f646769206e6f726d616c697a6528312920636f6d6d616e6420> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-3.8161 Tw
-
-BT
-229.0473 116.976 Td
-/F1.0 10.5 Tf
-<756e63686f7073> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.8161 Tw
-
-BT
-271.5303 116.976 Td
-/F1.0 10.5 Tf
-[<206120676976656e20766172696174696f6e206772> 20.0195 <61706820616e642073696d706c696669657320726564756e64616e74>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 101.196 Td
-/F1.0 10.5 Tf
-<667572636174696f6e732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3336> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-404 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 403 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F1.0 8 0 R
-/F2.0 17 0 R
-/F4.0 111 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [409 0 R 415 0 R]
->>
-endobj
-405 0 obj
-[404 0 R /XYZ 0 778.86 null]
-endobj
-406 0 obj
-[404 0 R /XYZ 0 699.02 null]
-endobj
-407 0 obj
-[404 0 R /XYZ 0 619.18 null]
-endobj
-408 0 obj
-[404 0 R /XYZ 0 485.98 null]
-endobj
-409 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 430.87 401.1446 445.15]
-/Type /Annot
->>
-endobj
-410 0 obj
-[404 0 R /XYZ 0 418.12 null]
-endobj
-411 0 obj
-[404 0 R /XYZ 0 350.26 null]
-endobj
-412 0 obj
-[404 0 R /XYZ 0 304.74 null]
-endobj
-413 0 obj
-[404 0 R /XYZ 0 236.88 null]
-endobj
-414 0 obj
-[404 0 R /XYZ 0 169.02 null]
-endobj
-415 0 obj
-<< /Border [0 0 0]
-/Dest (_odgi_unchop1)
-/Subtype /Link
-/Rect [229.0473 113.91 271.5303 128.19]
-/Type /Annot
->>
-endobj
-416 0 obj
-<< /Length 7536
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-<31382e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 751.926 Td
-/F2.0 13 Tf
-[<31382e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 725.366 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 725.366 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 725.366 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 706.586 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206e6f726d616c697a652e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-514.5613 706.586 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-529.0513 706.586 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 678.806 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 678.806 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 678.806 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0602 Tw
-
-BT
-63.24 660.026 Td
-/F1.0 10.5 Tf
-[<577269746520746865206e6f726d616c697a65642064796e616d69632073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20746869732066696c652e20412066696c6520656e64696e67207769746820>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0602 Tw
-
-BT
-519.6853 660.026 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0602 Tw
-
-BT
-534.1753 660.026 Td
-/F1.0 10.5 Tf
-<206973> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 644.246 Td
-/F1.0 10.5 Tf
-<7265636f6d6d656e6465642e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 616.466 Td
-/F2.0 10.5 Tf
-[<2d492c202d2d6d61782d69746572> 20.0195 <6174696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-146.6143 616.466 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-152.4838 616.466 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 597.686 Td
-/F1.0 10.5 Tf
-[<49746572> 20.0195 <61746520746865206e6f726d616c697a6174696f6e20757020746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-220.1098 597.686 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-228.1213 597.686 Td
-/F1.0 10.5 Tf
-[<206d616e> 20.0195 <792074696d65732e205468652064656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-364.8941 597.686 Td
-/F3.0 10.5 Tf
-<3130> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-376.6331 597.686 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 563.186 Td
-/F2.0 13 Tf
-[<31382e342e322e2050726f6772> 20.0195 <616d20446562756767696e67>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 536.626 Td
-/F2.0 10.5 Tf
-<2d642c202d2d6465627567> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 517.846 Td
-/F1.0 10.5 Tf
-<5072696e7420696e666f726d6174696f6e2061626f757420746865206e6f726d616c697a6174696f6e2070726f6365737320746f207374646f75742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 483.346 Td
-/F2.0 13 Tf
-[<31382e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 456.786 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 438.006 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 438.006 Td
-/F2.0 10.5 Tf
-<6f646769206e6f726d616c697a65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-266.835 438.006 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 398.166 Td
-/F2.0 18 Tf
-[<31382e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 370.146 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 351.366 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 323.586 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 304.806 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 264.966 Td
-/F2.0 18 Tf
-<31382e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 236.946 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 236.946 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 236.946 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 236.946 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 236.946 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 197.106 Td
-/F2.0 18 Tf
-[<31382e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 169.086 Td
-/F2.0 10.5 Tf
-<6f646769206e6f726d616c697a65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-128.2185 169.086 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 124.974 Td
-/F2.0 22 Tf
-<31392e206f6467692062696e283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 83.726 Td
-/F2.0 18 Tf
-<31392e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 55.706 Td
-/F1.0 10.5 Tf
-[<6f6467695f62696e202d2062696e6e696e67206f662070616e67656e6f6d652073657175656e636520616e64207061746820696e666f726d6174696f6e20696e20746865206772> 20.0195 <617068>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3337> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-417 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 416 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [425 0 R]
->>
-endobj
-418 0 obj
-[417 0 R /XYZ 0 841.89 null]
-endobj
-419 0 obj
-[417 0 R /XYZ 0 770.61 null]
-endobj
-420 0 obj
-[417 0 R /XYZ 0 581.87 null]
-endobj
-421 0 obj
-[417 0 R /XYZ 0 502.03 null]
-endobj
-422 0 obj
-[417 0 R /XYZ 0 422.19 null]
-endobj
-423 0 obj
-[417 0 R /XYZ 0 288.99 null]
-endobj
-424 0 obj
-<< /Limits [(_bugs_17) (_bugs_25)]
-/Names [(_bugs_17) 408 0 R (_bugs_18) 423 0 R (_bugs_19) 448 0 R (_bugs_2) 118 0 R (_bugs_20) 464 0 R (_bugs_21) 481 0 R (_bugs_22) 501 0 R (_bugs_23) 515 0 R (_bugs_24) 535 0 R (_bugs_25) 553 0 R]
->>
-endobj
-425 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 233.88 401.1446 248.16]
-/Type /Annot
->>
-endobj
-426 0 obj
-[417 0 R /XYZ 0 221.13 null]
-endobj
-427 0 obj
-[417 0 R /XYZ 0 153.27 null]
-endobj
-428 0 obj
-[417 0 R /XYZ 0 107.75 null]
-endobj
-429 0 obj
-<< /Length 15287
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-[<31392e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F2.0 10.5 Tf
-<6f6467692062696e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-91.2585 758.646 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-97.7475 758.646 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-134.277 758.646 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-140.1465 758.646 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-163.2675 758.646 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-173.526 758.646 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-213.909 758.646 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 718.806 Td
-/F2.0 18 Tf
-<31392e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.8268 Tw
-
-BT
-48.24 690.786 Td
-/F1.0 10.5 Tf
-[<546865206f6467692062696e28312920636f6d6d616e642062696e73206120676976656e20766172696174696f6e206772> 20.0195 <6170682e205468652070616e67656e6f6d652073657175656e63652c20746865206f6e652d74696d65>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.6768 Tw
-
-BT
-48.24 675.006 Td
-/F1.0 10.5 Tf
-[<7472> 20.0195 <6176657273616c206f6620616c6c206e6f6465732066726f6d20736d616c6c65737420746f206c617267657374206e6f6465206964656e7469666965722c2063616e2062652073756d6d656420757020696e746f2062696e73206f662061>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.894 Tw
-
-BT
-48.24 659.226 Td
-/F1.0 10.5 Tf
-[<7370656369666965642073697a652e2046> 40.0391 <6f7220656163682062696e2c207468652070617468206d657461696e666f726d6174696f6e2069732073756d6d6172697a65642e205468697320656e61626c657320612073756d6d6172697a6564>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.2295 Tw
-
-BT
-48.24 643.446 Td
-/F1.0 10.5 Tf
-[<76696577206f66206769676162617365207363616c65206772> 20.0195 <617068732e20456163682073746570206f662061207061746820697320612062696e20616e6420636f6e6e656374656420746f20697473206e6578742062696e207669612061206c696e6b2e2041>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 627.666 Td
-/F1.0 10.5 Tf
-<6c696e6b2068617320612073746172742062696e206964656e74696669657220616e6420616e20656e642062696e206964656e7469666965722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0911 Tw
-
-BT
-48.24 611.886 Td
-/F1.0 10.5 Tf
-<54686520636f6e63657074206f66206f6467692062696e20697320616c736f206170706c69656420696e206f64676920> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.0911 Tw
-
-BT
-279.0271 611.886 Td
-/F1.0 10.5 Tf
-<76697a> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0911 Tw
-
-BT
-293.8216 611.886 Td
-/F1.0 10.5 Tf
-[<2e20412064656d6f6e737472> 20.0195 <6174696f6e206f6620686f7720746865206f6467692062696e204a534f4e206f7574707574>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7804 Tw
-
-BT
-48.24 596.106 Td
-/F1.0 10.5 Tf
-[<63616e206265207573656420666f7220616e20696e746572> 20.0195 <6163746976652076697375616c697a6174696f6e206973207265616c697a656420696e2074686520>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.7804 Tw
-
-BT
-360.7463 596.106 Td
-/F1.0 10.5 Tf
-[<50616e746f6772> 20.0195 <617068>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7804 Tw
-
-BT
-418.8951 596.106 Td
-/F1.0 10.5 Tf
-<2070726f6a6563742e205065722064656661756c742c206f646769> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-48.24 580.326 Td
-/F1.0 10.5 Tf
-<62696e20777269746573207468652062696e7320746f207374646f757420696e2061207461622d64656c696d6974656420666f726d61743a20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-334.0731 580.326 Td
-/F2.0 10.5 Tf
-<706174682e6e616d65> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-391.0566 580.326 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-397.6036 580.326 Td
-/F2.0 10.5 Tf
-<706174682e707265666978> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-457.9576 580.326 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-464.5045 580.326 Td
-/F2.0 10.5 Tf
-<706174682e737566666978> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-523.0 580.326 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-529.547 580.326 Td
-/F2.0 10.5 Tf
-<62696e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2025 Tw
-
-BT
-547.04 580.326 Td
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7469 Tw
-
-BT
-48.24 564.546 Td
-/F1.0 10.5 Tf
-<2862696e206964656e746966696572292c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7469 Tw
-
-BT
-128.6307 564.546 Td
-/F2.0 10.5 Tf
-<6d65616e2e636f76> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7469 Tw
-
-BT
-179.6187 564.546 Td
-/F1.0 10.5 Tf
-[<20286d65616e20636f766572> 20.0195 <616765206f6620746865207061746820696e20746869732062696e292c20>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7469 Tw
-
-BT
-387.4467 564.546 Td
-/F2.0 10.5 Tf
-<6d65616e2e696e76> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7469 Tw
-
-BT
-437.1747 564.546 Td
-/F1.0 10.5 Tf
-[<20286d65616e20696e76657273696f6e2072> 20.0195 <617465>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.588 Tw
-
-BT
-48.24 548.766 Td
-/F1.0 10.5 Tf
-<6f662074686973207061746820696e20746869732062696e292c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.588 Tw
-
-BT
-176.5228 548.766 Td
-/F2.0 10.5 Tf
-<6d65616e2e706f73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.588 Tw
-
-BT
-227.5213 548.766 Td
-/F1.0 10.5 Tf
-<20286d65616e206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e20746869732062696e292c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.588 Tw
-
-BT
-497.9525 548.766 Td
-/F2.0 10.5 Tf
-<66697273742e6e75636c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.588 Tw
-
-BT
-547.04 548.766 Td
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9015 Tw
-
-BT
-48.24 532.986 Td
-/F1.0 10.5 Tf
-<286669727374206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e20746869732062696e292c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9015 Tw
-
-BT
-300.5838 532.986 Td
-/F2.0 10.5 Tf
-<6c6173742e6e75636c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9015 Tw
-
-BT
-346.2063 532.986 Td
-/F1.0 10.5 Tf
-<20286c617374206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.6541 Tw
-
-BT
-48.24 517.206 Td
-/F1.0 10.5 Tf
-[<746869732062696e292e205468657365206e75636c656f746964652072> 20.0195 <616e676573206d69676874207370616e20706f736974696f6e73207468617420617265206e6f742070726573656e7420696e207468652062696e2e204578616d706c653a2041>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0047 Tw
-
-BT
-48.24 501.426 Td
-/F1.0 10.5 Tf
-[<72> 20.0195 <616e6765206f6620312d313030206d65616e73207468617420746865206669727374206e75636c656f746964652068617320706f736974696f6e203120616e6420746865206c6173742068617320706f736974696f6e203130302c20627574>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.8143 Tw
-
-BT
-48.24 485.646 Td
-/F1.0 10.5 Tf
-[<6e75636c656f7469646520343520636f756c64206265206c6f636174656420696e20616e6f746865722062696e2e2046> 40.0391 <6f7220616e20657861637420706f736974696f6e616c206f75747075742c20706c656173652073706563696679205b>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.8143 Tw
-
-BT
-537.086 485.646 Td
-/F2.0 10.5 Tf
-<2d6a2c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 469.866 Td
-/F2.0 10.5 Tf
-<2d2d6a736f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-76.905 469.866 Td
-/F1.0 10.5 Tf
-<5d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.6706 Tw
-
-BT
-48.24 454.086 Td
-/F1.0 10.5 Tf
-<52756e6e696e67206f6467692062696e20696e20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-2.6706 Tw
-
-BT
-160.825 454.086 Td
-/F1.0 10.5 Tf
-[<4861706c6f426c6f636b> 20.0195 <6572>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.6706 Tw
-
-BT
-228.6128 454.086 Td
-/F1.0 10.5 Tf
-<206d6f64652c206f6e6c7920617267756d656e7473205b> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.6706 Tw
-
-BT
-360.4863 454.086 Td
-/F2.0 10.5 Tf
-[<2d622c202d2d6861706c6f2d626c6f636b> 20.0195 <6572>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.6706 Tw
-
-BT
-459.3367 454.086 Td
-/F1.0 10.5 Tf
-<5d2c205b> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.6706 Tw
-
-BT
-474.8909 454.086 Td
-/F2.0 10.5 Tf
-<2d705b4e5d2c202d2d6861706c6f> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.4372 Tw
-
-BT
-48.24 438.306 Td
-/F2.0 10.5 Tf
-[<2d626c6f636b> 20.0195 <65722d6d696e2d70617468735b4e5d>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.4372 Tw
-
-BT
-165.7978 438.306 Td
-/F1.0 10.5 Tf
-<5d2c20616e64205b> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.4372 Tw
-
-BT
-207.3852 438.306 Td
-/F2.0 10.5 Tf
-[<2d635b4e5d2c202d2d6861706c6f2d626c6f636b> 20.0195 <65722d6d696e2d636f766572> 20.0195 <6167655b4e5d>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.4372 Tw
-
-BT
-414.9106 438.306 Td
-/F1.0 10.5 Tf
-[<5d206172652072657175697265642e2041205453> 20.0195 <56206973>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.492 Tw
-
-BT
-48.24 422.526 Td
-/F1.0 10.5 Tf
-<7072696e74656420746f207374646f75743a204561636820726f7720636f72726573706f6e647320746f2061206e6f64652e204561636820636f6c756d6e20636f72726573706f6e647320746f206120706174682e20456163682076616c7565> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 406.746 Td
-/F1.0 10.5 Tf
-[<69732074686520636f766572> 20.0195 <616765206f662061207370656369666963206e6f6465206f66206120737065636966696320706174682e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 366.906 Td
-/F2.0 18 Tf
-<31392e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 332.166 Td
-/F2.0 13 Tf
-[<31392e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 305.606 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 305.606 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 305.606 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2984 Tw
-
-BT
-63.24 286.826 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20696e766573746967617465207468652062696e2066726f6d2e205468652066696c65206e616d6520757375616c6c79>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 271.046 Td
-/F1.0 10.5 Tf
-<656e6473207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.984 271.046 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.474 271.046 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 236.546 Td
-/F2.0 13 Tf
-[<31392e342e322e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <41204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 209.986 Td
-/F2.0 10.5 Tf
-<2d662c202d2d6661737461> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-94.2825 209.986 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-100.152 209.986 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 191.206 Td
-/F1.0 10.5 Tf
-<5772697465207468652070616e67656e6f6d652073657175656e636520746f20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-236.511 191.206 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-259.632 191.206 Td
-/F1.0 10.5 Tf
-[<20696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120666f726d61742e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 156.706 Td
-/F2.0 13 Tf
-<31392e342e332e2042696e204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 130.146 Td
-/F2.0 10.5 Tf
-<2d6e2c202d2d6e756d6265722d62696e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-139.254 130.146 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-145.1235 130.146 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 111.366 Td
-/F1.0 10.5 Tf
-<546865206e756d626572206f662062696e73207468652070616e67656e6f6d652073657175656e63652073686f756c642062652063686f7070656420757020746f2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 83.586 Td
-/F2.0 10.5 Tf
-[<2d77> 69.8242 <2c202d2d62696e2d7769647468>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-123.5058 83.586 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.3753 83.586 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 64.806 Td
-/F1.0 10.5 Tf
-<5468652062696e20776964746820737065636966696573207468652073697a65206f6620656163682062696e2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3338> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-430 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 429 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [433 0 R 434 0 R 435 0 R]
->>
-endobj
-431 0 obj
-[430 0 R /XYZ 0 841.89 null]
-endobj
-432 0 obj
-[430 0 R /XYZ 0 742.83 null]
-endobj
-433 0 obj
-<< /Border [0 0 0]
-/Dest (_odgi_viz1)
-/Subtype /Link
-/Rect [279.0271 608.82 293.8216 623.1]
-/Type /Annot
->>
-endobj
-434 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://graph-genome.github.io/)
->>
-/Subtype /Link
-/Rect [360.7463 593.04 418.8951 607.32]
-/Type /Annot
->>
-endobj
-435 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/tpook92/HaploBlocker)
->>
-/Subtype /Link
-/Rect [160.825 451.02 228.6128 465.3]
-/Type /Annot
->>
-endobj
-436 0 obj
-[430 0 R /XYZ 0 390.93 null]
-endobj
-437 0 obj
-[430 0 R /XYZ 0 350.85 null]
-endobj
-438 0 obj
-[430 0 R /XYZ 0 255.23 null]
-endobj
-439 0 obj
-[430 0 R /XYZ 0 175.39 null]
-endobj
-440 0 obj
-<< /Length 11240
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 793.926 Td
-/F2.0 10.5 Tf
-<2d442c202d2d706174682d64656c696d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.93 793.926 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-135.7995 793.926 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 775.146 Td
-/F1.0 10.5 Tf
-[<416e6e6f7461746520726f77732062> 20.0195 <792070726566697820616e6420737566666978206f6620746869732064656c696d697465722e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 747.366 Td
-/F2.0 10.5 Tf
-<2d612c202d2d6167677265676174652d64656c696d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 728.586 Td
-/F1.0 10.5 Tf
-[<41> 20.0195 <6767726567617465206f6e2070617468207072656669782064656c696d697465722e20417267756d656e7420646570656e6473206f6e205b>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-358.8358 728.586 Td
-/F2.0 10.5 Tf
-<2d442c202d2d706174682d64656c696d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-440.5258 728.586 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-446.3953 728.586 Td
-/F3.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-484.6361 728.586 Td
-/F1.0 10.5 Tf
-<5d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 700.806 Td
-/F2.0 10.5 Tf
-<2d6a2c202d2d6a736f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.263 Tw
-
-BT
-63.24 682.026 Td
-/F1.0 10.5 Tf
-<5072696e742062696e7320616e64206c696e6b7320746f207374646f757420696e2070736575646f204a534f4e20666f726d61742e2045616368206c696e6520697320612076616c6964204a534f4e206f626a6563742c2062757420746865> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5134 Tw
-
-BT
-63.24 666.246 Td
-/F1.0 10.5 Tf
-<77686f6c652066696c65206973206e6f7420612076616c6964204a534f4e212046697273742c20656163682062696e20696e636c7564696e67206974732070616e67656e6f6d652073657175656e6365206973207072696e74656420746f> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0984 Tw
-
-BT
-63.24 650.466 Td
-/F1.0 10.5 Tf
-[<7374646f757420706572206c696e652e205365636f6e642c20666f722065616368207061746820696e20746865206772> 20.0195 <6170682c20697473207472> 20.0195 <617665727365642062696e7320696e636c7564696e67206d657461696e666f726d6174696f6e3a>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7164 Tw
-
-BT
-63.24 634.686 Td
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7164 Tw
-
-BT
-63.24 634.686 Td
-/F2.0 10.5 Tf
-<62696e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7164 Tw
-
-BT
-80.733 634.686 Td
-/F1.0 10.5 Tf
-<202862696e206964656e746966696572292c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7164 Tw
-
-BT
-173.4986 634.686 Td
-/F2.0 10.5 Tf
-<6d65616e2e636f76> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7164 Tw
-
-BT
-224.4866 634.686 Td
-/F1.0 10.5 Tf
-[<20286d65616e20636f766572> 20.0195 <616765206f6620746865207061746820696e20746869732062696e292c20>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7164 Tw
-
-BT
-459.0401 634.686 Td
-/F2.0 10.5 Tf
-<6d65616e2e696e76> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7164 Tw
-
-BT
-508.7681 634.686 Td
-/F1.0 10.5 Tf
-<20286d65616e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9176 Tw
-
-BT
-63.24 618.906 Td
-/F1.0 10.5 Tf
-[<696e76657273696f6e2072> 20.0195 <617465206f662074686973207061746820696e20746869732062696e292c20>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9176 Tw
-
-BT
-262.4049 618.906 Td
-/F2.0 10.5 Tf
-<6d65616e2e706f73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9176 Tw
-
-BT
-313.4034 618.906 Td
-/F1.0 10.5 Tf
-<20286d65616e206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e2074686973> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.3574 Tw
-
-BT
-63.24 603.126 Td
-/F1.0 10.5 Tf
-[<62696e292c20616e6420616e20617272> 20.0195 <61> 20.0195 <79206f662072> 20.0195 <616e6765732064657465726d696e696e6720746865206e75636c656f7469646520706f736974696f6e206f6620746865207061746820696e20746869732062696e2e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.4902 Tw
-
-BT
-63.24 587.346 Td
-/F1.0 10.5 Tf
-[<53> 9.7656 <7769746368696e6720666972737420616e64206c617374206e75636c656f7469646520696e20612072> 20.0195 <616e676520726570726573656e7473206120636f6d706c656d656e742072657665727365206f7269656e746174696f6e206f66>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 571.566 Td
-/F1.0 10.5 Tf
-<7468617420706172746963756c61722073657175656e63652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 543.786 Td
-/F2.0 10.5 Tf
-<2d732c202d2d6e6f2d73657173> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 525.006 Td
-/F1.0 10.5 Tf
-<4966205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-77.457 525.006 Td
-/F2.0 10.5 Tf
-<2d6a2c202d2d6a736f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-118.7955 525.006 Td
-/F1.0 10.5 Tf
-<5d206973207365742c206e6f206e75636c656f746964652073657175656e6365732077696c6c206265207072696e74656420746f207374646f757420696e206f7264657220746f2073617665206469736b2073706163652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 497.226 Td
-/F2.0 10.5 Tf
-<2d672c202d2d6e6f2d6761702d6c696e6b73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 478.446 Td
-/F1.0 10.5 Tf
-[<57> 60.0586 <6520646976696465206c696e6b7320696e746f203220636c61737365733a>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
--0.5 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-67.6765 450.666 Td
-/F1.0 10.5 Tf
-<312e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
-0.0 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.2408 Tw
-
-BT
-81.24 450.666 Td
-/F1.0 10.5 Tf
-[<746865206c696e6b732077686963682068656c7020746f20666f6c6c6f7720636f6d706c657820766172696174696f6e732e2054686579206e65656420746f206265206472> 20.0195 <61776e2c20656c7365206f6e6520636f756c64206e6f74>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-81.24 434.886 Td
-/F1.0 10.5 Tf
-<666f6c6c6f77207468652073657175656e6365206f66206120706174682e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
--0.5 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-67.6765 413.106 Td
-/F1.0 10.5 Tf
-<322e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-
-0.0 Tc
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9739 Tw
-
-BT
-81.24 413.106 Td
-/F1.0 10.5 Tf
-<746865206c696e6b732068656c70696e6720746f20666f6c6c6f772073696d706c6520766172696174696f6e732e205468657365206c696e6b73206172652063616c6c656420> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9739 Tw
-
-BT
-438.2287 413.106 Td
-/F2.0 10.5 Tf
-<6761702d6c696e6b73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9739 Tw
-
-BT
-486.6022 413.106 Td
-/F1.0 10.5 Tf
-<2e2053756368206c696e6b73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.7733 Tw
-
-BT
-81.24 397.326 Td
-/F1.0 10.5 Tf
-[<736f6c656c7920636f6e6e656374696e67206120706174682066726f6d206c65667420746f207269676874206d61> 20.0195 <79206e6f742062652072656c6576616e7420746f20756e6465727374616e6420612070617468d573>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.0419 Tw
-
-BT
-81.24 381.546 Td
-/F1.0 10.5 Tf
-[<7472> 20.0195 <6176657273616c207468726f756768207468652062696e732e205468657265666f72652c207768656e2074686973206f7074696f6e206973207365742c20746865206761702d6c696e6b7320617265206c656674206f757420736176696e67>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-81.24 365.766 Td
-/F1.0 10.5 Tf
-<6469736b207370616365> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 331.266 Td
-/F2.0 13 Tf
-[<31392e342e342e204861706c6f426c6f636b> 20.0195 <6572204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 304.706 Td
-/F2.0 10.5 Tf
-[<2d622c202d2d6861706c6f2d626c6f636b> 20.0195 <6572>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.4118 Tw
-
-BT
-63.24 285.926 Td
-/F1.0 10.5 Tf
-[<57726974652061205453> 20.0195 <5620746f207374646f757420666f726d617474656420696e2061207761> 20.0195 <7920726561647920666f72204861706c6f426c6f636b> 20.0195 <65723a204561636820726f7720636f72726573706f6e647320746f2061>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.7759 Tw
-
-BT
-63.24 270.146 Td
-/F1.0 10.5 Tf
-[<6e6f64652e204561636820636f6c756d6e20636f72726573706f6e647320746f206120706174682e20456163682076616c75652069732074686520636f766572> 20.0195 <616765206f662061207370656369666963206e6f6465206f662061>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 254.366 Td
-/F1.0 10.5 Tf
-<737065636966696320706174682e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 226.586 Td
-/F2.0 10.5 Tf
-[<2d705b4e5d2c202d2d6861706c6f2d626c6f636b> 20.0195 <65722d6d696e2d70617468735b4e5d>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.5961 Tw
-
-BT
-63.24 207.806 Td
-/F1.0 10.5 Tf
-<5370656369667920746865206d696e696d756d206e756d626572206f662070617468732074686174206e65656420746f2062652070726573656e7420696e207468652062696e20746f2061637475616c6c79207265706f72742074686174> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 192.026 Td
-/F1.0 10.5 Tf
-<62696e2e205468652064656661756c742076616c756520697320312e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 164.246 Td
-/F2.0 10.5 Tf
-[<2d635b4e5d2c202d2d6861706c6f2d626c6f636b> 20.0195 <65722d6d696e2d636f766572> 20.0195 <6167655b4e5d>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.614 Tw
-
-BT
-63.24 145.466 Td
-/F1.0 10.5 Tf
-[<5370656369667920746865206d696e696d756d20636f766572> 20.0195 <61676520612070617468206e6565647320746f206861766520696e20612062696e20746f2061637475616c6c79207265706f727420746861742062696e2e20546865>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 129.686 Td
-/F1.0 10.5 Tf
-<64656661756c742076616c756520697320312e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 95.186 Td
-/F2.0 13 Tf
-[<31392e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 68.626 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3339> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-441 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 440 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
->>
-endobj
-442 0 obj
-[441 0 R /XYZ 0 349.95 null]
-endobj
-443 0 obj
-<< /Limits [(_name_12) (_name_20)]
-/Names [(_name_12) 298 0 R (_name_13) 315 0 R (_name_14) 332 0 R (_name_15) 357 0 R (_name_16) 376 0 R (_name_17) 397 0 R (_name_18) 412 0 R (_name_19) 428 0 R (_name_2) 101 0 R (_name_20) 452 0 R]
->>
-endobj
-444 0 obj
-[441 0 R /XYZ 0 113.87 null]
-endobj
-445 0 obj
-<< /Length 6759
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-63.24 794.676 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 794.676 Td
-/F2.0 10.5 Tf
-<6f6467692062696e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-229.875 794.676 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 766.896 Td
-/F2.0 10.5 Tf
-[<2d50> 120.1172 <2c202d2d70726f6772657373>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 748.116 Td
-/F1.0 10.5 Tf
-<5772697465207468652063757272656e742070726f677265737320746f207374646572722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 708.276 Td
-/F2.0 18 Tf
-[<31392e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 680.256 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 661.476 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 633.696 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 614.916 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 575.076 Td
-/F2.0 18 Tf
-<31392e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 547.056 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 547.056 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 547.056 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 547.056 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 547.056 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 507.216 Td
-/F2.0 18 Tf
-[<31392e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 479.196 Td
-/F2.0 10.5 Tf
-<6f6467692062696e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-91.2585 479.196 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e642053696d6f6e204865756d6f73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 435.084 Td
-/F2.0 22 Tf
-<32302e206f646769206d6174726978283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 393.836 Td
-/F2.0 18 Tf
-<32302e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 365.816 Td
-/F1.0 10.5 Tf
-[<6f6467695f6d6174726978202d20777269746520746865206772> 20.0195 <61706820746f706f6c6f677920696e20737061727365206d617472697820666f726d617473>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 325.976 Td
-/F2.0 18 Tf
-[<32302e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 297.956 Td
-/F2.0 10.5 Tf
-<6f646769206d6174726978> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-110.589 297.956 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-117.078 297.956 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-153.6075 297.956 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-159.477 297.956 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-182.598 297.956 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-192.8565 297.956 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-233.2395 297.956 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 258.116 Td
-/F2.0 18 Tf
-<32302e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.3077 Tw
-
-BT
-48.24 230.096 Td
-/F1.0 10.5 Tf
-[<546865206f646769206d617472697828312920636f6d6d616e642067656e6572> 20.0195 <61746573206120737061727365206d617472697820666f726d6174206f7574206f6620746865206772> 20.0195 <61706820746f706f6c6f6779206f66206120676976656e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 214.316 Td
-/F1.0 10.5 Tf
-[<766172696174696f6e206772> 20.0195 <6170682e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 174.476 Td
-/F2.0 18 Tf
-<32302e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 139.736 Td
-/F2.0 13 Tf
-[<32302e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 113.176 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 113.176 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 113.176 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0282 Tw
-
-BT
-63.24 94.396 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206372656174652074686520737061727365206d61747269782066726f6d2e205468652066696c65206e616d65>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 78.616 Td
-/F1.0 10.5 Tf
-<757375616c6c7920656e6473207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-154.086 78.616 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-168.576 78.616 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3430> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-446 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 445 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F1.0 8 0 R
-/F2.0 17 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [449 0 R]
->>
-endobj
-447 0 obj
-[446 0 R /XYZ 0 732.3 null]
-endobj
-448 0 obj
-[446 0 R /XYZ 0 599.1 null]
-endobj
-449 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 543.99 401.1446 558.27]
-/Type /Annot
->>
-endobj
-450 0 obj
-[446 0 R /XYZ 0 531.24 null]
-endobj
-451 0 obj
-[446 0 R /XYZ 0 463.38 null]
-endobj
-452 0 obj
-[446 0 R /XYZ 0 417.86 null]
-endobj
-453 0 obj
-[446 0 R /XYZ 0 350 null]
-endobj
-454 0 obj
-<< /Limits [(_synopsis_14) (_synopsis_22)]
-/Names [(_synopsis_14) 333 0 R (_synopsis_15) 358 0 R (_synopsis_16) 377 0 R (_synopsis_17) 398 0 R (_synopsis_18) 413 0 R (_synopsis_19) 431 0 R (_synopsis_2) 102 0 R (_synopsis_20) 453 0 R (_synopsis_21) 470 0 R (_synopsis_22) 488 0 R]
->>
-endobj
-455 0 obj
-[446 0 R /XYZ 0 282.14 null]
-endobj
-456 0 obj
-<< /Limits [(_description_16) (_description_24)]
-/Names [(_description_16) 378 0 R (_description_17) 399 0 R (_description_18) 414 0 R (_description_19) 432 0 R (_description_2) 103 0 R (_description_20) 455 0 R (_description_21) 471 0 R (_description_22) 489 0 R (_description_23) 507 0 R (_description_24) 523 0 R]
->>
-endobj
-457 0 obj
-[446 0 R /XYZ 0 198.5 null]
-endobj
-458 0 obj
-[446 0 R /XYZ 0 158.42 null]
-endobj
-459 0 obj
-<< /Length 7085
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 792.006 Td
-/F2.0 13 Tf
-<32302e342e322e204d6174726978204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 765.446 Td
-/F2.0 10.5 Tf
-<2d652c202d2d656467652d64657074682d776569676874> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 746.666 Td
-/F1.0 10.5 Tf
-[<57> 60.0586 <656967682065646765732062> 20.0195 <7920746865697220706174682064657074682e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 718.886 Td
-/F2.0 10.5 Tf
-<2d642c202d2d64656c74612d776569676874> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 700.106 Td
-/F1.0 10.5 Tf
-[<57> 60.0586 <656967682065646765732062> 20.0195 <7920746865697220696e76657273652069642064656c74612e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 665.606 Td
-/F2.0 13 Tf
-[<32302e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 639.046 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 620.266 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 620.266 Td
-/F2.0 10.5 Tf
-<6f646769206d6174726978> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-249.2055 620.266 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 580.426 Td
-/F2.0 18 Tf
-[<32302e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 552.406 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 533.626 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 505.846 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 487.066 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 447.226 Td
-/F2.0 18 Tf
-<32302e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 419.206 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 419.206 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 419.206 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 419.206 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 419.206 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 379.366 Td
-/F2.0 18 Tf
-[<32302e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 351.346 Td
-/F2.0 10.5 Tf
-<6f646769206d6174726978> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-110.589 351.346 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 307.234 Td
-/F2.0 22 Tf
-<32312e206f6467692063686f70283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 265.986 Td
-/F2.0 18 Tf
-<32312e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 237.966 Td
-/F1.0 10.5 Tf
-<6f6467695f63686f70202d20646976696465206e6f64657320696e746f20736d616c6c657220706965636573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 198.126 Td
-/F2.0 18 Tf
-[<32312e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 170.106 Td
-/F2.0 10.5 Tf
-<6f6467692063686f70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-99.48 170.106 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.969 170.106 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-142.4985 170.106 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-148.368 170.106 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-171.489 170.106 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-181.7475 170.106 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-221.3955 170.106 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-227.265 170.106 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-250.386 170.106 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-260.6445 170.106 Td
-/F2.0 10.5 Tf
-<2d632c202d2d63686f702d746f> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-321.366 170.106 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-327.2355 170.106 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-335.247 170.106 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-345.5055 170.106 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-385.8885 170.106 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 130.266 Td
-/F2.0 18 Tf
-<32312e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9148 Tw
-
-BT
-48.24 102.246 Td
-/F1.0 10.5 Tf
-[<546865206f6467692063686f7028312920636f6d6d616e642063686f7073206c6f6e67206e6f64657320696e746f2073686f7274206f6e6573207768696c652070726573657276696e6720746865206772> 20.0195 <61706820746f706f6c6f6779>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 86.466 Td
-/F1.0 10.5 Tf
-<616e64206e6f6465206f726465722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3431> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-460 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 459 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [465 0 R]
->>
-endobj
-461 0 obj
-[460 0 R /XYZ 0 841.89 null]
-endobj
-462 0 obj
-[460 0 R /XYZ 0 684.29 null]
-endobj
-463 0 obj
-[460 0 R /XYZ 0 604.45 null]
-endobj
-464 0 obj
-[460 0 R /XYZ 0 471.25 null]
-endobj
-465 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 416.14 401.1446 430.42]
-/Type /Annot
->>
-endobj
-466 0 obj
-[460 0 R /XYZ 0 403.39 null]
-endobj
-467 0 obj
-<< /Limits [(_authors_17) (_authors_25)]
-/Names [(_authors_17) 410 0 R (_authors_18) 426 0 R (_authors_19) 450 0 R (_authors_2) 122 0 R (_authors_20) 466 0 R (_authors_21) 483 0 R (_authors_22) 503 0 R (_authors_23) 517 0 R (_authors_24) 537 0 R (_authors_25) 555 0 R]
->>
-endobj
-468 0 obj
-[460 0 R /XYZ 0 335.53 null]
-endobj
-469 0 obj
-[460 0 R /XYZ 0 290.01 null]
-endobj
-470 0 obj
-[460 0 R /XYZ 0 222.15 null]
-endobj
-471 0 obj
-[460 0 R /XYZ 0 154.29 null]
-endobj
-472 0 obj
-<< /Length 7927
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-<32312e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 751.926 Td
-/F2.0 13 Tf
-[<32312e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 725.366 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 725.366 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 725.366 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 706.586 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f2063686f702e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-487.7023 706.586 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-502.1923 706.586 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 678.806 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 678.806 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 678.806 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 660.026 Td
-/F1.0 10.5 Tf
-[<5772697465207468652063686f7065642073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-289.1053 660.026 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-312.2263 660.026 Td
-/F1.0 10.5 Tf
-<2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-479.5753 660.026 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-494.0653 660.026 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.526 Td
-/F2.0 13 Tf
-<32312e342e322e2043686f70204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 598.966 Td
-/F2.0 10.5 Tf
-<2d632c202d2d63686f702d746f> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.9615 598.966 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.831 598.966 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 580.186 Td
-/F1.0 10.5 Tf
-<446976696465206e6f6465732074686174206c6f6e676572207468616e20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-214.1985 580.186 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-222.21 580.186 Td
-/F1.0 10.5 Tf
-<20696e746f206e6f646573206e6f206c6f6e676572207468616e20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-356.1795 580.186 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-364.191 580.186 Td
-/F1.0 10.5 Tf
-[<207768696c65206d61696e7461696e696e67206772> 20.0195 <61706820746f706f6c6f6779> 89.8438 <2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 545.686 Td
-/F2.0 13 Tf
-<32312e342e332e20546872656164696e67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 519.126 Td
-/F2.0 10.5 Tf
-<2d742c202d2d74687265616473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.951 519.126 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.8205 519.126 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 500.346 Td
-/F1.0 10.5 Tf
-[<4e756d626572206f66207468726561647320746f2075736520666f722074686520706172> 20.0195 <616c6c656c206f706572> 20.0195 <6174696f6e732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 465.846 Td
-/F2.0 13 Tf
-<32312e342e342e2050726f63657373696e6720496e666f726d6174696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 439.286 Td
-/F2.0 10.5 Tf
-<2d642c202d2d6465627567> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 420.506 Td
-/F1.0 10.5 Tf
-<5072696e7420696e666f726d6174696f6e2061626f7574207468652070726f6365737320746f207374646572722e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 386.006 Td
-/F2.0 13 Tf
-[<32312e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 359.446 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 340.666 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 340.666 Td
-/F2.0 10.5 Tf
-<6f6467692063686f70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-238.0965 340.666 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 300.826 Td
-/F2.0 18 Tf
-[<32312e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 272.806 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 254.026 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 226.246 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 207.466 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 167.626 Td
-/F2.0 18 Tf
-<32312e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 139.606 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 139.606 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 139.606 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 139.606 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 139.606 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 99.766 Td
-/F2.0 18 Tf
-[<32312e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 71.746 Td
-/F2.0 10.5 Tf
-<6f6467692063686f70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-99.48 71.746 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3432> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-473 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 472 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [482 0 R]
->>
-endobj
-474 0 obj
-[473 0 R /XYZ 0 841.89 null]
-endobj
-475 0 obj
-[473 0 R /XYZ 0 770.61 null]
-endobj
-476 0 obj
-[473 0 R /XYZ 0 644.21 null]
-endobj
-477 0 obj
-[473 0 R /XYZ 0 564.37 null]
-endobj
-478 0 obj
-[473 0 R /XYZ 0 484.53 null]
-endobj
-479 0 obj
-[473 0 R /XYZ 0 404.69 null]
-endobj
-480 0 obj
-[473 0 R /XYZ 0 324.85 null]
-endobj
-481 0 obj
-[473 0 R /XYZ 0 191.65 null]
-endobj
-482 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 136.54 401.1446 150.82]
-/Type /Annot
->>
-endobj
-483 0 obj
-[473 0 R /XYZ 0 123.79 null]
-endobj
-484 0 obj
-<< /Length 10565
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 782.394 Td
-/F2.0 22 Tf
-[<32322e206f646769206c61> 20.0195 <796f7574283129>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 741.146 Td
-/F2.0 18 Tf
-<32322e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 713.126 Td
-/F1.0 10.5 Tf
-[<6f6467695f6c61> 20.0195 <796f7574202d207573652053474420746f206d616b> 20.0195 <65203244206c61> 20.0195 <796f757473206f6620746865206772> 20.0195 <617068>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 673.286 Td
-/F2.0 18 Tf
-[<32322e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 645.266 Td
-/F2.0 10.5 Tf
-[<6f646769206c61> 20.0195 <796f7574>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-107.2813 645.266 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.7703 645.266 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-150.2998 645.266 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-156.1693 645.266 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-179.2903 645.266 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-189.5488 645.266 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-229.1968 645.266 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-235.0663 645.266 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-258.1873 645.266 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-268.4458 645.266 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-308.8288 645.266 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 605.426 Td
-/F2.0 18 Tf
-<32322e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.2196 Tw
-
-BT
-48.24 577.406 Td
-/F1.0 10.5 Tf
-[<546865206f646769206c61> 20.0195 <796f757428312920636f6d6d616e64206472> 20.0195 <617773203244206c61> 20.0195 <796f757473206f6620746865206772> 20.0195 <617068207573696e672073746f63686173746963206772> 20.0195 <616469656e742064657363656e742028534744292e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.6579 Tw
-
-BT
-48.24 561.626 Td
-/F1.0 10.5 Tf
-[<54686520696e707574206772> 20.0195 <617068206d75737420626520736f7274656420616e642069642d636f6d7061637465642e2054686520616c676f726974686d20697473656c662069732064657363726962656420696e20>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-2.6579 Tw
-
-BT
-515.8237 561.626 Td
-/F1.0 10.5 Tf
-[<4772> 20.0195 <617068>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-1.8458 Tw
-
-BT
-48.24 545.846 Td
-/F1.0 10.5 Tf
-[<4472> 20.0195 <6177696e672062> 20.0195 <792053746f63686173746963204772> 20.0195 <616469656e742044657363656e74>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.8458 Tw
-
-BT
-255.0909 545.846 Td
-/F1.0 10.5 Tf
-[<2e2054686520666f7263652d6469726563746564206772> 20.0195 <617068206472> 20.0195 <6177696e6720616c676f726974686d206d696e696d697a6573>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.7338 Tw
-
-BT
-48.24 530.066 Td
-/F1.0 10.5 Tf
-[<746865206772> 20.0195 <617068d57320656e657267792066756e6374696f6e206f7220737472657373206c6576656c2e204974206170706c6965732053474420746f206d6f766520612073696e676c652070616972206f66206e6f64657320617420612074696d652e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 514.286 Td
-/F1.0 10.5 Tf
-[<5468652072656e6465726564206772> 20.0195 <617068206973207772697474656e20696e2053> 20.0195 <56> 20.0195 <4720666f726d61742e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 474.446 Td
-/F2.0 18 Tf
-<32322e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 439.706 Td
-/F2.0 13 Tf
-[<32322e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 413.146 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 413.146 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 413.146 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 394.366 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206c61> 20.0195 <796f75742e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-494.6636 394.366 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-509.1536 394.366 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 366.586 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 366.586 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 366.586 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 347.806 Td
-/F1.0 10.5 Tf
-[<5772697465207468652072656e6465726564206c61> 20.0195 <796f757420696e2053> 20.0195 <56> 20.0195 <4720666f726d617420746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-281.3349 347.806 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-304.4559 347.806 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 313.306 Td
-/F2.0 13 Tf
-<32322e342e322e20534744204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 286.746 Td
-/F2.0 10.5 Tf
-<2d6d2c202d2d697465722d6d6178> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-120.207 286.746 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-126.0765 286.746 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 267.966 Td
-/F1.0 10.5 Tf
-[<546865206d6178696d756d206e756d626572206f662069746572> 20.0195 <6174696f6e7320746f2072756e20746865206c61> 20.0195 <796f75742e2044656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-384.4766 267.966 Td
-/F3.0 10.5 Tf
-<3330> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-396.2156 267.966 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 240.186 Td
-/F2.0 10.5 Tf
-<2d702c202d2d6e2d7069766f7473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.424 240.186 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-119.2935 240.186 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 221.406 Td
-/F1.0 10.5 Tf
-[<546865206e756d626572206f66207069766f747320666f7220737061727365206c61> 20.0195 <796f75742e2044656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-312.9193 221.406 Td
-/F3.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-318.7888 221.406 Td
-/F1.0 10.5 Tf
-[<206c656164696e6720746f2061206e6f6e2d737061727365206c61> 20.0195 <796f75742e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 193.626 Td
-/F2.0 10.5 Tf
-<2d652c202d2d657073> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.657 193.626 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.5265 193.626 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 174.846 Td
-/F1.0 10.5 Tf
-[<546865206c6561726e696e672072> 20.0195 <61746520666f7220534744206c61> 20.0195 <796f75742e2044656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-280.2326 174.846 Td
-/F3.0 10.5 Tf
-<302e3031> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-300.4661 174.846 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 140.346 Td
-/F2.0 13 Tf
-[<32322e342e332e2053> 20.0195 <56> 20.0195 <47204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 113.786 Td
-/F2.0 10.5 Tf
-<2d782c202d2d782d70616464696e67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-123.84 113.786 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.7095 113.786 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 95.006 Td
-/F1.0 10.5 Tf
-[<5468652070616464696e67206265747765656e2074686520636f6e6e656374656420636f6d706f6e656e74206c61> 20.0195 <796f7574732e2044656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-397.3183 95.006 Td
-/F3.0 10.5 Tf
-<31302e30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-417.5518 95.006 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 67.226 Td
-/F2.0 10.5 Tf
-<2d522c202d2d72656e6465722d7363616c65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-137.8155 67.226 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-143.685 67.226 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3433> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-485 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 484 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [490 0 R 491 0 R]
->>
-endobj
-486 0 obj
-[485 0 R /XYZ 0 841.89 null]
-endobj
-487 0 obj
-[485 0 R /XYZ 0 765.17 null]
-endobj
-488 0 obj
-[485 0 R /XYZ 0 697.31 null]
-endobj
-489 0 obj
-[485 0 R /XYZ 0 629.45 null]
-endobj
-490 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://arxiv.org/abs/1710.04626)
->>
-/Subtype /Link
-/Rect [515.8237 558.56 547.04 572.84]
-/Type /Annot
->>
-endobj
-491 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://arxiv.org/abs/1710.04626)
->>
-/Subtype /Link
-/Rect [48.24 542.78 255.0909 557.06]
-/Type /Annot
->>
-endobj
-492 0 obj
-[485 0 R /XYZ 0 498.47 null]
-endobj
-493 0 obj
-[485 0 R /XYZ 0 458.39 null]
-endobj
-494 0 obj
-[485 0 R /XYZ 0 331.99 null]
-endobj
-495 0 obj
-[485 0 R /XYZ 0 159.03 null]
-endobj
-496 0 obj
-<< /Length 6203
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-63.24 794.676 Td
-/F1.0 10.5 Tf
-[<53> 20.0195 <56> 20.0195 <47207363616c696e672044656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-173.5106 794.676 Td
-/F3.0 10.5 Tf
-<352e30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-187.8746 794.676 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 760.176 Td
-/F2.0 13 Tf
-<32322e342e342e2050726f63657373696e6720496e666f726d6174696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 733.616 Td
-/F2.0 10.5 Tf
-<2d642c202d2d6465627567> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 714.836 Td
-/F1.0 10.5 Tf
-<5072696e7420696e666f726d6174696f6e2061626f75742074686520636f6d706f6e656e747320746f207374646f75742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 680.336 Td
-/F2.0 13 Tf
-[<32322e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 653.776 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 634.996 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 634.996 Td
-/F2.0 10.5 Tf
-[<6f646769206c61> 20.0195 <796f7574>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-245.8978 634.996 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 595.156 Td
-/F2.0 18 Tf
-[<32322e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 567.136 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 548.356 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 520.576 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 501.796 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 461.956 Td
-/F2.0 18 Tf
-<32322e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 433.936 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 433.936 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 433.936 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 433.936 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 433.936 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 394.096 Td
-/F2.0 18 Tf
-[<32322e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 366.076 Td
-/F2.0 10.5 Tf
-[<6f646769206c61> 20.0195 <796f7574>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-107.2813 366.076 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2c20416e64726561204775617272> 20.0195 <6163696e6f2c20616e642053696d6f6e204865756d6f732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 321.964 Td
-/F2.0 22 Tf
-<32332e206f64676920666c617474656e283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 280.716 Td
-/F2.0 18 Tf
-<32332e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 252.696 Td
-/F1.0 10.5 Tf
-[<6f6467695f666c617474656e202d2067656e6572> 20.0195 <617465206c696e656172697a6174696f6e206f6620746865206772> 20.0195 <617068>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 212.856 Td
-/F2.0 18 Tf
-[<32332e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 184.836 Td
-/F2.0 10.5 Tf
-<6f64676920666c617474656e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.4865 184.836 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-115.9755 184.836 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-152.505 184.836 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-158.3745 184.836 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-181.4955 184.836 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-191.754 184.836 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-232.137 184.836 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 144.996 Td
-/F2.0 18 Tf
-<32332e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 116.976 Td
-/F1.0 10.5 Tf
-[<546865206f64676920666c617474656e28312920636f6d6d616e642070726f6a6563747320746865206772> 20.0195 <6170682073657175656e636520616e6420706174687320696e746f2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120616e64204245442e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3434> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-497 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 496 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F1.0 8 0 R
-/F3.0 55 0 R
-/F2.0 17 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [502 0 R]
->>
-endobj
-498 0 obj
-[497 0 R /XYZ 0 778.86 null]
-endobj
-499 0 obj
-[497 0 R /XYZ 0 699.02 null]
-endobj
-500 0 obj
-[497 0 R /XYZ 0 619.18 null]
-endobj
-501 0 obj
-[497 0 R /XYZ 0 485.98 null]
-endobj
-502 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 430.87 401.1446 445.15]
-/Type /Annot
->>
-endobj
-503 0 obj
-[497 0 R /XYZ 0 418.12 null]
-endobj
-504 0 obj
-[497 0 R /XYZ 0 350.26 null]
-endobj
-505 0 obj
-[497 0 R /XYZ 0 304.74 null]
-endobj
-506 0 obj
-[497 0 R /XYZ 0 236.88 null]
-endobj
-507 0 obj
-[497 0 R /XYZ 0 169.02 null]
-endobj
-508 0 obj
-<< /Length 7709
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-<32332e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 751.926 Td
-/F2.0 13 Tf
-[<32332e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 725.366 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 725.366 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 725.366 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 706.586 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20666c617474656e2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-496.1968 706.586 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-510.6868 706.586 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 672.086 Td
-/F2.0 13 Tf
-<32332e342e322e204f7574707574204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 645.526 Td
-/F2.0 10.5 Tf
-<2d662c202d2d6661737461> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-94.2825 645.526 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-100.152 645.526 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 626.746 Td
-/F1.0 10.5 Tf
-[<57726974652074686520636f6e636174656e61746564206e6f64652073657175656e63657320696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120666f726d617420746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-361.126 626.746 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-384.247 626.746 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 598.966 Td
-/F2.0 10.5 Tf
-<2d6e2c202d2d6e616d652d736571> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-121.551 598.966 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-127.4205 598.966 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0339 Tw
-
-BT
-63.24 580.186 Td
-/F1.0 10.5 Tf
-[<546865206e616d6520746f2075736520666f722074686520636f6e636174656e61746564206772> 20.0195 <6170682073657175656e63652e2044656661756c7420697320746865206e616d65206f662074686520696e7075742066696c65>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 564.406 Td
-/F1.0 10.5 Tf
-<7768696368207761732073706563696669656420766961205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-188.3475 564.406 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-224.877 564.406 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-230.7465 564.406 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-253.8675 564.406 Td
-/F1.0 10.5 Tf
-<5d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 536.626 Td
-/F2.0 10.5 Tf
-<2d622c202d2d626564> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.198 536.626 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-96.0675 536.626 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2826 Tw
-
-BT
-63.24 517.846 Td
-/F1.0 10.5 Tf
-[<577269746520746865206d617070696e67206265747765656e206772> 20.0195 <61706820706174687320616e6420746865206c696e656172697a65642046> 69.8242 <4153> 20.0195 <54> 60.0586 <412073657175656e636520696e2042454420666f726d617420746f>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 502.066 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-86.361 502.066 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 467.566 Td
-/F2.0 13 Tf
-[<32332e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 441.006 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 422.226 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 422.226 Td
-/F2.0 10.5 Tf
-<6f64676920666c617474656e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-248.103 422.226 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 382.386 Td
-/F2.0 18 Tf
-[<32332e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 354.366 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 335.586 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 307.806 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 289.026 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 249.186 Td
-/F2.0 18 Tf
-<32332e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 221.166 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 221.166 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 221.166 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 221.166 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 221.166 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 181.326 Td
-/F2.0 18 Tf
-[<32332e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 153.306 Td
-/F2.0 10.5 Tf
-<6f64676920666c617474656e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.4865 153.306 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 109.194 Td
-/F2.0 22 Tf
-<32342e206f64676920627265616b283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3435> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-509 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 508 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [516 0 R]
->>
-endobj
-510 0 obj
-[509 0 R /XYZ 0 841.89 null]
-endobj
-511 0 obj
-[509 0 R /XYZ 0 770.61 null]
-endobj
-512 0 obj
-[509 0 R /XYZ 0 690.77 null]
-endobj
-513 0 obj
-[509 0 R /XYZ 0 486.25 null]
-endobj
-514 0 obj
-[509 0 R /XYZ 0 406.41 null]
-endobj
-515 0 obj
-[509 0 R /XYZ 0 273.21 null]
-endobj
-516 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 218.1 401.1446 232.38]
-/Type /Annot
->>
-endobj
-517 0 obj
-[509 0 R /XYZ 0 205.35 null]
-endobj
-518 0 obj
-[509 0 R /XYZ 0 137.49 null]
-endobj
-519 0 obj
-<< /Length 8699
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-<32342e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F1.0 10.5 Tf
-[<6f6467695f627265616b202d20627265616b206379636c657320696e20746865206772> 20.0195 <61706820616e642064726f7020697473207061746873>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 718.806 Td
-/F2.0 18 Tf
-[<32342e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 690.786 Td
-/F2.0 10.5 Tf
-<6f64676920627265616b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.003 690.786 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-111.492 690.786 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-148.0215 690.786 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-153.891 690.786 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-177.012 690.786 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-187.2705 690.786 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-226.9185 690.786 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-232.788 690.786 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-255.909 690.786 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-266.1675 690.786 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-306.5505 690.786 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 650.946 Td
-/F2.0 18 Tf
-<32342e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.3841 Tw
-
-BT
-48.24 622.926 Td
-/F1.0 10.5 Tf
-[<546865206f64676920627265616b28312920636f6d6d616e642066696e6473206379636c657320696e2061206772> 20.0195 <6170682076696120>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.3841 Tw
-
-BT
-327.5593 622.926 Td
-/F1.0 10.5 Tf
-<627265616474682d666972737420736561726368202842465329> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.3841 Tw
-
-BT
-456.3436 622.926 Td
-/F1.0 10.5 Tf
-<20616e6420627265616b73207468656d2c> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 607.146 Td
-/F1.0 10.5 Tf
-[<616c736f2064726f7070696e6720746865206772> 20.0195 <617068d5732070617468732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 567.306 Td
-/F2.0 18 Tf
-<32342e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 532.566 Td
-/F2.0 13 Tf
-[<32342e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 506.006 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 506.006 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 506.006 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 487.226 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20627265616b2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-492.4168 487.226 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-506.9068 487.226 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 459.446 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 459.446 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 459.446 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 440.666 Td
-/F1.0 10.5 Tf
-[<5772697465207468652062726f6b> 20.0195 <656e206772> 20.0195 <61706820746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-196.2851 440.666 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-219.4061 440.666 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 406.166 Td
-/F2.0 13 Tf
-<32342e342e322e204379636c65204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 379.606 Td
-/F2.0 10.5 Tf
-<2d632c202d2d6379636c652d6d61782d6270> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-139.6215 379.606 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-145.491 379.606 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 360.826 Td
-/F1.0 10.5 Tf
-<546865206d6178696d756d206379636c65206c656e67746820617420776869636820746f20627265616b2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 333.046 Td
-/F2.0 10.5 Tf
-<2d732c202d2d6d61782d7365617263682d6270> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-147.7905 333.046 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-153.66 333.046 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 314.266 Td
-/F1.0 10.5 Tf
-<546865206d6178696d756d20736561726368207370616365206f6620656163682042465320676976656e20696e206e756d626572206f6620626173652070616972732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 286.486 Td
-/F2.0 10.5 Tf
-<2d752c202d2d7265706561742d75702d746f> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-136.4925 286.486 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-142.362 286.486 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 267.706 Td
-/F1.0 10.5 Tf
-[<49746572> 20.0195 <617465206379636c6520627265616b696e6720757020746f20>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-202.7323 267.706 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-210.7438 267.706 Td
-/F1.0 10.5 Tf
-<2074696d6573206f722073746f70206966206e6f206e6577206564676573206172652072656d6f7665642e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 239.926 Td
-/F2.0 10.5 Tf
-<2d642c202d2d73686f77> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 221.146 Td
-/F1.0 10.5 Tf
-<5072696e742074686520656467657320776520776f756c642072656d6f766520746f207374646f75742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 186.646 Td
-/F2.0 13 Tf
-[<32342e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 160.086 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 141.306 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 141.306 Td
-/F2.0 10.5 Tf
-<6f64676920627265616b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-243.6195 141.306 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 101.466 Td
-/F2.0 18 Tf
-[<32342e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 73.446 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 54.666 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3436> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-520 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 519 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [524 0 R]
->>
-endobj
-521 0 obj
-[520 0 R /XYZ 0 841.89 null]
-endobj
-522 0 obj
-[520 0 R /XYZ 0 742.83 null]
-endobj
-523 0 obj
-[520 0 R /XYZ 0 674.97 null]
-endobj
-524 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://en.wikipedia.org/wiki/Breadth-first_search)
->>
-/Subtype /Link
-/Rect [327.5593 619.86 456.3436 634.14]
-/Type /Annot
->>
-endobj
-525 0 obj
-[520 0 R /XYZ 0 591.33 null]
-endobj
-526 0 obj
-[520 0 R /XYZ 0 551.25 null]
-endobj
-527 0 obj
-<< /Limits [(_graph_files_io_2) (_graph_files_io_8)]
-/Names [(_graph_files_io_2) 128 0 R (_graph_files_io_20) 475 0 R (_graph_files_io_21) 493 0 R (_graph_files_io_22) 511 0 R (_graph_files_io_23) 526 0 R (_graph_files_io_24) 546 0 R (_graph_files_io_25) 563 0 R (_graph_files_io_26) 580 0 R (_graph_files_io_27) 601 0 R (_graph_files_io_3) 147 0 R (_graph_files_io_4) 173 0 R (_graph_files_io_5) 201 0 R (_graph_files_io_6) 215 0 R (_graph_files_io_7) 234 0 R (_graph_files_io_8) 253 0 R]
->>
-endobj
-528 0 obj
-<< /Limits [(__anchor-top) (_graph_files_io_8)]
-/Kids [119 0 R 467 0 R 645 0 R 263 0 R 424 0 R 588 0 R 163 0 R 456 0 R 634 0 R 251 0 R 552 0 R 371 0 R 120 0 R 527 0 R]
->>
-endobj
-529 0 obj
-<< /Limits [(_graph_files_io_9) (_visualization_options)]
-/Kids [321 0 R 443 0 R 612 0 R 216 0 R 356 0 R 592 0 R 142 0 R 577 0 R 387 0 R 239 0 R 367 0 R 548 0 R 182 0 R 454 0 R 632 0 R 274 0 R 637 0 R]
->>
-endobj
-530 0 obj
-[520 0 R /XYZ 0 424.85 null]
-endobj
-531 0 obj
-[520 0 R /XYZ 0 205.33 null]
-endobj
-532 0 obj
-[520 0 R /XYZ 0 125.49 null]
-endobj
-533 0 obj
-<< /Length 9830
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 793.926 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 775.146 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 735.306 Td
-/F2.0 18 Tf
-<32342e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 707.286 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 707.286 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 707.286 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 707.286 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 707.286 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 667.446 Td
-/F2.0 18 Tf
-[<32342e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 639.426 Td
-/F2.0 10.5 Tf
-<6f64676920627265616b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.003 639.426 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 595.314 Td
-/F2.0 22 Tf
-<32352e206f6467692070617468696e646578283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 554.066 Td
-/F2.0 18 Tf
-<32352e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 526.046 Td
-/F1.0 10.5 Tf
-<6f6467695f70617468696e646578202d206372656174652061207061746820696e64657820666f72206120676976656e2070617468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 486.206 Td
-/F2.0 18 Tf
-[<32352e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 458.186 Td
-/F2.0 10.5 Tf
-<6f6467692070617468696e646578> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-128.313 458.186 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-134.802 458.186 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-171.3315 458.186 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-177.201 458.186 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-200.322 458.186 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-210.5805 458.186 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-250.2285 458.186 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-256.098 458.186 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-279.219 458.186 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-289.4775 458.186 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-329.8605 458.186 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 418.346 Td
-/F2.0 18 Tf
-<32352e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.5186 Tw
-
-BT
-48.24 390.326 Td
-/F1.0 10.5 Tf
-[<546865206f6467692070617468696e64657828312920636f6d6d616e642067656e6572> 20.0195 <617465732061207061746820696e646578206f662061206772> 20.0195 <6170682e20497420757365732073756363696e637420646174612073747275637475726573>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4572 Tw
-
-BT
-48.24 374.546 Td
-/F1.0 10.5 Tf
-<746f20656e636f64652074686520696e6465782e20546865207061746820696e64657820726570726573656e7473206120737562736574206f6620746865206665617475726573206f6620612066756c6c79207265616c697a656420> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.4572 Tw
-
-BT
-501.2753 374.546 Td
-/F1.0 10.5 Tf
-<786720696e646578> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4572 Tw
-
-BT
-544.415 374.546 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5733 Tw
-
-BT
-48.24 358.766 Td
-/F1.0 10.5 Tf
-<486176696e672061207061746820696e6465782c2077652063616e20757365206f64676920> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-1.5733 Tw
-
-BT
-249.1126 358.766 Td
-/F1.0 10.5 Tf
-<70616e706f73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5733 Tw
-
-BT
-285.4531 358.766 Td
-/F1.0 10.5 Tf
-<20746f20676f2066726f6d20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5733 Tw
-
-BT
-348.8769 358.766 Td
-/F2.0 10.5 Tf
-<706174683a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5733 Tw
-
-BT
-419.7309 358.766 Td
-/F1.0 10.5 Tf
-<20> Tj
-/F1.1 10.5 Tf
-<2120> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5733 Tw
-
-BT
-438.8165 358.766 Td
-/F2.0 10.5 Tf
-<70616e67656e6f6d653a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.5733 Tw
-
-BT
-547.04 358.766 Td
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8024 Tw
-
-BT
-48.24 342.986 Td
-/F1.0 10.5 Tf
-[<776869636820697320696d706f7274616e74207768656e206e617669676174696e67206c61726765206772> 20.0195 <6170687320696e20616e20696e746572> 20.0195 <616374697665206d616e6e6572206c696b> 20.0195 <6520696e2074686520>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.8024 Tw
-
-BT
-488.8912 342.986 Td
-/F1.0 10.5 Tf
-[<50616e746f6772> 20.0195 <617068>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8024 Tw
-
-BT
-547.04 342.986 Td
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 327.206 Td
-/F1.0 10.5 Tf
-<70726f6a6563742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 287.366 Td
-/F2.0 18 Tf
-<32352e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 252.626 Td
-/F2.0 13 Tf
-[<32352e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 226.066 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 226.066 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 226.066 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.1339 Tw
-
-BT
-63.24 207.286 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f2067656e6572> 20.0195 <6174652061207061746820696e6465782066726f6d2e205468652066696c65206e616d6520757375616c6c79>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 191.506 Td
-/F1.0 10.5 Tf
-<656e6473207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.984 191.506 Td
-/F3.0 10.5 Tf
-<2e6f67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.474 191.506 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 163.726 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 163.726 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 163.726 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 144.946 Td
-/F1.0 10.5 Tf
-<577269746520746865207061746820696e64657820746f20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-182.0895 144.946 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-205.2105 144.946 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 110.446 Td
-/F2.0 13 Tf
-[<32352e342e322e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 83.886 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 65.106 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 65.106 Td
-/F2.0 10.5 Tf
-<6f6467692070617468696e646578> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-266.9295 65.106 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3437> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-534 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 533 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F1.1 80 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [536 0 R 542 0 R 543 0 R 544 0 R]
->>
-endobj
-535 0 obj
-[534 0 R /XYZ 0 759.33 null]
-endobj
-536 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 704.22 401.1446 718.5]
-/Type /Annot
->>
-endobj
-537 0 obj
-[534 0 R /XYZ 0 691.47 null]
-endobj
-538 0 obj
-[534 0 R /XYZ 0 623.61 null]
-endobj
-539 0 obj
-[534 0 R /XYZ 0 578.09 null]
-endobj
-540 0 obj
-[534 0 R /XYZ 0 510.23 null]
-endobj
-541 0 obj
-[534 0 R /XYZ 0 442.37 null]
-endobj
-542 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/xg)
->>
-/Subtype /Link
-/Rect [501.2753 371.48 544.415 385.76]
-/Type /Annot
->>
-endobj
-543 0 obj
-<< /Border [0 0 0]
-/Dest (_odgi_panpos1)
-/Subtype /Link
-/Rect [249.1126 355.7 285.4531 369.98]
-/Type /Annot
->>
-endobj
-544 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://graph-genome.github.io/)
->>
-/Subtype /Link
-/Rect [488.8912 339.92 547.04 354.2]
-/Type /Annot
->>
-endobj
-545 0 obj
-[534 0 R /XYZ 0 311.39 null]
-endobj
-546 0 obj
-[534 0 R /XYZ 0 271.31 null]
-endobj
-547 0 obj
-[534 0 R /XYZ 0 129.13 null]
-endobj
-548 0 obj
-<< /Limits [(_program_information_22) (_random_sort)]
-/Names [(_program_information_22) 513 0 R (_program_information_23) 531 0 R (_program_information_24) 547 0 R (_program_information_25) 567 0 R (_program_information_26) 583 0 R (_program_information_27) 605 0 R (_program_information_28) 622 0 R (_program_information_29) 638 0 R (_program_information_3) 152 0 R (_program_information_4) 189 0 R (_program_information_5) 203 0 R (_program_information_6) 222 0 R (_program_information_7) 240 0 R (_program_information_8) 258 0 R (_program_information_9) 276 0 R (_random_sort) 175 0 R]
->>
-endobj
-549 0 obj
-<< /Length 9245
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-[<32352e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 739.866 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 712.086 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 693.306 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 653.466 Td
-/F2.0 18 Tf
-<32352e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.446 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 625.446 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 625.446 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 625.446 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 625.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 585.606 Td
-/F2.0 18 Tf
-[<32352e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 557.586 Td
-/F2.0 10.5 Tf
-<6f6467692070617468696e646578> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-128.313 557.586 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <792053696d6f6e204865756d6f732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 513.474 Td
-/F2.0 22 Tf
-<32362e206f6467692070616e706f73283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 472.226 Td
-/F2.0 18 Tf
-<32362e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 444.206 Td
-/F1.0 10.5 Tf
-<6f6467695f70616e706f73202d20676574207468652070616e67656e6f6d6520706f736974696f6e206f66206120676976656e207061746820616e64206e75636c656f7469646520706f736974696f6e2028312d626173656429> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 404.366 Td
-/F2.0 18 Tf
-[<32362e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 376.346 Td
-/F2.0 10.5 Tf
-<6f6467692070616e706f73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-112.1325 376.346 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-118.6215 376.346 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-155.151 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-161.0205 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-184.1415 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-194.4 376.346 Td
-/F2.0 10.5 Tf
-<2d702c202d2d70617468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-241.0305 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-246.9 376.346 Td
-/F3.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-285.1408 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-295.3993 376.346 Td
-/F2.0 10.5 Tf
-<2d6e2c202d2d6e75632d706f73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-359.0293 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-364.8988 376.346 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-372.9103 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-383.1688 376.346 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-423.5518 376.346 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 336.506 Td
-/F2.0 18 Tf
-<32362e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.6681 Tw
-
-BT
-48.24 308.486 Td
-/F1.0 10.5 Tf
-<546865206f6467692070616e706f7328312920636f6d6d616e64206769766520612070616e67656e6f6d6520706f736974696f6e20666f72206120676976656e207061746820616e64206e75636c656f7469646520706f736974696f6e2e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1527 Tw
-
-BT
-48.24 292.706 Td
-/F1.0 10.5 Tf
-<49742072657175697265732061207061746820696e6465782c2077686963682063616e20626520637265617465642077697468206f64676920> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-1.1527 Tw
-
-BT
-342.5301 292.706 Td
-/F1.0 10.5 Tf
-<70617468696e646578> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1527 Tw
-
-BT
-393.4656 292.706 Td
-/F1.0 10.5 Tf
-<2e20476f696e672066726f6d20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1527 Tw
-
-BT
-461.8138 292.706 Td
-/F2.0 10.5 Tf
-<706174683a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1527 Tw
-
-BT
-532.6678 292.706 Td
-/F1.0 10.5 Tf
-<20> Tj
-/F1.1 10.5 Tf
-<21> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1198 Tw
-
-BT
-48.24 276.926 Td
-/F2.0 10.5 Tf
-<70616e67656e6f6d653a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1198 Tw
-
-BT
-156.4635 276.926 Td
-/F1.0 10.5 Tf
-[<20697320696d706f7274616e74207768656e206e617669676174696e67206c61726765206772> 20.0195 <6170687320696e20616e20696e746572> 20.0195 <616374697665206d616e6e6572206c696b> 20.0195 <6520696e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 261.146 Td
-/F1.0 10.5 Tf
-<74686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-66.93 261.146 Td
-/F1.0 10.5 Tf
-[<50616e746f6772> 20.0195 <617068>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-125.0788 261.146 Td
-/F1.0 10.5 Tf
-<2070726f6a6563742e20416c6c20696e70757420616e64206f757470757420706f736974696f6e732061726520312d62617365642e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 221.306 Td
-/F2.0 18 Tf
-<32362e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 186.566 Td
-/F2.0 13 Tf
-[<32362e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 160.006 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 160.006 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 160.006 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.4702 Tw
-
-BT
-63.24 141.226 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820696e64657820746f2066696e64207468652070616e67656e6f6d6520706f736974696f6e20696e2e205468652066696c65>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 125.446 Td
-/F1.0 10.5 Tf
-<6e616d6520757375616c6c7920656e6473207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-185.0085 125.446 Td
-/F3.0 10.5 Tf
-<2e7870> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-199.4145 125.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 90.946 Td
-/F2.0 13 Tf
-<32362e342e322e20506f736974696f6e204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 64.386 Td
-/F2.0 10.5 Tf
-<2d702c202d2d70617468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-94.8705 64.386 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-100.74 64.386 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3438> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-550 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 549 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F1.1 80 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [554 0 R 560 0 R 561 0 R]
->>
-endobj
-551 0 obj
-[550 0 R /XYZ 0 841.89 null]
-endobj
-552 0 obj
-<< /Limits [(_exit_status_16) (_exit_status_3)]
-/Names [(_exit_status_16) 407 0 R (_exit_status_17) 422 0 R (_exit_status_18) 447 0 R (_exit_status_19) 463 0 R (_exit_status_2) 137 0 R (_exit_status_20) 480 0 R (_exit_status_21) 500 0 R (_exit_status_22) 514 0 R (_exit_status_23) 532 0 R (_exit_status_24) 551 0 R (_exit_status_25) 568 0 R (_exit_status_26) 586 0 R (_exit_status_27) 606 0 R (_exit_status_28) 623 0 R (_exit_status_29) 639 0 R (_exit_status_3) 153 0 R]
->>
-endobj
-553 0 obj
-[550 0 R /XYZ 0 677.49 null]
-endobj
-554 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 622.38 401.1446 636.66]
-/Type /Annot
->>
-endobj
-555 0 obj
-[550 0 R /XYZ 0 609.63 null]
-endobj
-556 0 obj
-[550 0 R /XYZ 0 541.77 null]
-endobj
-557 0 obj
-[550 0 R /XYZ 0 496.25 null]
-endobj
-558 0 obj
-[550 0 R /XYZ 0 428.39 null]
-endobj
-559 0 obj
-[550 0 R /XYZ 0 360.53 null]
-endobj
-560 0 obj
-<< /Border [0 0 0]
-/Dest (_odgi_pathindex1)
-/Subtype /Link
-/Rect [342.5301 289.64 393.4656 303.92]
-/Type /Annot
->>
-endobj
-561 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://graph-genome.github.io/)
->>
-/Subtype /Link
-/Rect [66.93 258.08 125.0788 272.36]
-/Type /Annot
->>
-endobj
-562 0 obj
-[550 0 R /XYZ 0 245.33 null]
-endobj
-563 0 obj
-[550 0 R /XYZ 0 205.25 null]
-endobj
-564 0 obj
-[550 0 R /XYZ 0 109.63 null]
-endobj
-565 0 obj
-<< /Length 6098
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-63.24 794.676 Td
-/F1.0 10.5 Tf
-[<5468652070617468206e616d65206f6620746865207175657279> 89.8438 <2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 766.896 Td
-/F2.0 10.5 Tf
-<2d6e2c202d2d6e75632d706f73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-111.87 766.896 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-117.7395 766.896 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 748.116 Td
-/F1.0 10.5 Tf
-[<546865206e75636c656f746964652073657175656e6365206f6620746865207175657279> 89.8438 <2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 713.616 Td
-/F2.0 13 Tf
-[<32362e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 687.056 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 668.276 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 668.276 Td
-/F2.0 10.5 Tf
-<6f6467692070616e706f73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-250.749 668.276 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 628.436 Td
-/F2.0 18 Tf
-[<32362e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 600.416 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 581.636 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 553.856 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 535.076 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 495.236 Td
-/F2.0 18 Tf
-<32362e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 467.216 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 467.216 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 467.216 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 467.216 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 467.216 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 427.376 Td
-/F2.0 18 Tf
-[<32362e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 399.356 Td
-/F2.0 10.5 Tf
-<6f6467692070616e706f73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-112.1325 399.356 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <792053696d6f6e204865756d6f732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 355.244 Td
-/F2.0 22 Tf
-<32372e206f64676920706f736974696f6e283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 313.996 Td
-/F2.0 18 Tf
-<32372e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 285.976 Td
-/F1.0 10.5 Tf
-[<6f6467695f706f736974696f6e202d20706f736974696f6e207061727473206f6620746865206772> 20.0195 <61706820617320646566696e65642062> 20.0195 <79207175657279206372697465726961>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 246.136 Td
-/F2.0 18 Tf
-[<32372e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 218.116 Td
-/F2.0 10.5 Tf
-<6f64676920706f736974696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-117.1305 218.116 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-123.6195 218.116 Td
-/F2.0 10.5 Tf
-<2d692c202d2d746172676574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-174.996 218.116 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-180.8655 218.116 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-203.9865 218.116 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-214.245 218.116 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-254.628 218.116 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 178.276 Td
-/F2.0 18 Tf
-<32372e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 150.256 Td
-/F1.0 10.5 Tf
-[<546865206f64676920706f736974696f6e28312920636f6d6d616e6420706f736974696f6e207061727473206f6620746865206772> 20.0195 <61706820617320646566696e65642062> 20.0195 <792071756572792063726974657269612e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 110.416 Td
-/F2.0 18 Tf
-<32372e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3439> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-566 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 565 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F1.0 8 0 R
-/F2.0 17 0 R
-/F4.0 111 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [570 0 R]
->>
-endobj
-567 0 obj
-[566 0 R /XYZ 0 732.3 null]
-endobj
-568 0 obj
-[566 0 R /XYZ 0 652.46 null]
-endobj
-569 0 obj
-[566 0 R /XYZ 0 519.26 null]
-endobj
-570 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 464.15 401.1446 478.43]
-/Type /Annot
->>
-endobj
-571 0 obj
-[566 0 R /XYZ 0 451.4 null]
-endobj
-572 0 obj
-[566 0 R /XYZ 0 383.54 null]
-endobj
-573 0 obj
-[566 0 R /XYZ 0 338.02 null]
-endobj
-574 0 obj
-[566 0 R /XYZ 0 270.16 null]
-endobj
-575 0 obj
-[566 0 R /XYZ 0 202.3 null]
-endobj
-576 0 obj
-[566 0 R /XYZ 0 134.44 null]
-endobj
-577 0 obj
-<< /Limits [(_options_2) (_options_5)]
-/Names [(_options_2) 127 0 R (_options_20) 474 0 R (_options_21) 492 0 R (_options_22) 510 0 R (_options_23) 525 0 R (_options_24) 545 0 R (_options_25) 562 0 R (_options_26) 576 0 R (_options_27) 600 0 R (_options_28) 618 0 R (_options_29) 635 0 R (_options_3) 146 0 R (_options_4) 172 0 R (_options_5) 200 0 R]
->>
-endobj
-578 0 obj
-<< /Length 11060
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 792.006 Td
-/F2.0 13 Tf
-[<32372e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 765.446 Td
-/F2.0 10.5 Tf
-<2d692c202d2d746172676574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-99.6165 765.446 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.486 765.446 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 746.666 Td
-/F1.0 10.5 Tf
-[<446573637269626520706f736974696f6e7320696e2074686973206772> 20.0195 <6170682e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 718.886 Td
-/F2.0 10.5 Tf
-<2d782c202d2d736f75726365> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-106.095 718.886 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-111.9645 718.886 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9383 Tw
-
-BT
-63.24 700.106 Td
-/F1.0 10.5 Tf
-[<5472> 20.0195 <616e736c61746520706f736974696f6e732066726f6d2074686973206772> 20.0195 <61706820696e746f2074686520746172676574206772> 20.0195 <617068207573696e6720636f6d6d6f6e20>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-1.9383 Tw
-
-BT
-445.0892 700.106 Td
-/F5.0 10.5 Tf
-<2d2d6c6966742d7061746873> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.9383 Tw
-
-BT
-508.0892 700.106 Td
-/F1.0 10.5 Tf
-<20736861726564> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 684.326 Td
-/F1.0 10.5 Tf
-[<6265747765656e20626f7468206772> 20.0195 <61706873205b64656661756c743a20757365207468652073616d6520736f757263652f746172676574206772> 20.0195 <6170685d>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 649.826 Td
-/F2.0 13 Tf
-<32372e342e322e20506f736974696f6e204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 623.266 Td
-/F2.0 10.5 Tf
-<2d722c202d2d7265662d7061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-117.687 623.266 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-123.5565 623.266 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 604.486 Td
-/F1.0 10.5 Tf
-[<5472> 20.0195 <616e736c6174652074686520676976656e20706f736974696f6e7320696e746f20706f736974696f6e732072656c617469766520746f2074686973207265666572656e636520706174682e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 576.706 Td
-/F2.0 10.5 Tf
-<2d522c202d2d7265662d7061746873> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-119.6295 576.706 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-125.499 576.706 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 557.926 Td
-/F1.0 10.5 Tf
-<55736520746865207265662d706174687320696e2046494c452e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 530.146 Td
-/F2.0 10.5 Tf
-<2d6c2c202d2d6c6966742d70617468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-110.9565 530.146 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-116.826 530.146 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0439 Tw
-
-BT
-63.24 511.366 Td
-/F1.0 10.5 Tf
-<4c69667420706f736974696f6e732066726f6d20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-2.0439 Tw
-
-BT
-164.9742 511.366 Td
-/F5.0 10.5 Tf
-<2d2d736f75726365> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0439 Tw
-
-BT
-206.9742 511.366 Td
-/F1.0 10.5 Tf
-<20746f20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-2.0439 Tw
-
-BT
-226.2555 511.366 Td
-/F5.0 10.5 Tf
-<2d2d746172676574> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.0439 Tw
-
-BT
-268.2555 511.366 Td
-/F1.0 10.5 Tf
-[<2076696120636f6f7264696e6174657320696e2074686973207061746820636f6d6d6f6e20746f20626f7468206772> 20.0195 <61706873>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 495.586 Td
-/F1.0 10.5 Tf
-<5b64656661756c743a20616c6c20636f6d6d6f6e207061746873206265747765656e20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-BT
-245.562 495.586 Td
-/F5.0 10.5 Tf
-<2d2d736f75726365> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-287.562 495.586 Td
-/F1.0 10.5 Tf
-<20616e6420> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-BT
-312.111 495.586 Td
-/F5.0 10.5 Tf
-<2d2d746172676574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-354.111 495.586 Td
-/F1.0 10.5 Tf
-<5d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 467.806 Td
-/F2.0 10.5 Tf
-[<2d672c202d2d6772> 20.0195 <6170682d706f73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-122.4538 467.806 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-128.3233 467.806 Td
-/F4.0 10.5 Tf
-<5b5b6e6f64655f69645d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-183.0073 467.806 Td
-/F4.0 10.5 Tf
-<5d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-187.3543 467.806 Td
-/F4.0 10.5 Tf
-<5d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 449.026 Td
-/F1.0 10.5 Tf
-[<41206772> 20.0195 <61706820706f736974696f6e2c20652e672e2034322c31302c2b206f72203330322c302c2d2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 421.246 Td
-/F2.0 10.5 Tf
-<2d462c202d2d706174682d706f732d66696c65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-137.091 421.246 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-142.9605 421.246 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 402.466 Td
-/F1.0 10.5 Tf
-<412066696c652077697468206f6e65207061746820706f736974696f6e20706572206c696e652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 374.686 Td
-/F2.0 10.5 Tf
-<2d622c202d2d6265642d696e707574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-122.1495 374.686 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-128.019 374.686 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8664 Tw
-
-BT
-63.24 355.906 Td
-/F1.0 10.5 Tf
-[<41204245442066696c65206f662072> 20.0195 <616e67657320696e20706174687320696e20746865206772> 20.0195 <61706820746f206c69667420696e746f2074686520746172676574206772> 20.0195 <61706820>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-0.8664 Tw
-
-BT
-420.1682 355.906 Td
-/F5.0 10.5 Tf
-<2d76> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8664 Tw
-
-BT
-430.6682 355.906 Td
-/F1.0 10.5 Tf
-<2c20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.6941 0.1294 0.2745 scn
-0.6941 0.1294 0.2745 SCN
-
-0.8664 Tw
-
-BT
-436.8791 355.906 Td
-/F5.0 10.5 Tf
-<2d2d676976652d67726170682d706f73> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8664 Tw
-
-BT
-520.8791 355.906 Td
-/F1.0 10.5 Tf
-<20656d6974> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 340.126 Td
-/F1.0 10.5 Tf
-[<6772> 20.0195 <61706820706f736974696f6e732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 312.346 Td
-/F2.0 10.5 Tf
-[<2d76> 49.8047 <2c202d2d676976652d6772> 20.0195 <6170682d706f73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 293.566 Td
-/F1.0 10.5 Tf
-[<456d6974206772> 20.0195 <61706820706f736974696f6e7320286e6f64652c6f66667365742c737472> 20.0195 <616e64292072> 20.0195 <6174686572207468616e207061746820706f736974696f6e732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 265.786 Td
-/F2.0 10.5 Tf
-[<2d642c202d2d7365617263682d72> 20.0195 <6164697573>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-143.4118 265.786 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-149.2813 265.786 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2707 Tw
-
-BT
-63.24 247.006 Td
-/F1.0 10.5 Tf
-[<4c696d697420636f6f7264696e61746520636f6e76657273696f6e20627265616474682d66697273742073656172636820757020746f20444953> 20.0195 <54> 60.0586 <414e43452062702066726f6d206561636820676976656e20706f736974696f6e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 231.226 Td
-/F1.0 10.5 Tf
-<5b64656661756c743a2031303030305d2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 196.726 Td
-/F2.0 13 Tf
-<32372e342e332e20546872656164696e67> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 170.166 Td
-/F2.0 10.5 Tf
-<2d742c202d2d74687265616473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.951 170.166 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.8205 170.166 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 151.386 Td
-/F1.0 10.5 Tf
-<4e756d626572206f66207468726561647320746f207573652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 116.886 Td
-/F2.0 13 Tf
-[<32372e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 90.326 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 71.546 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 71.546 Td
-/F2.0 10.5 Tf
-<6f64676920706f736974696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-255.747 71.546 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3530> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-579 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 578 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F5.0 236 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
->>
-endobj
-580 0 obj
-[579 0 R /XYZ 0 841.89 null]
-endobj
-581 0 obj
-[579 0 R /XYZ 0 668.51 null]
-endobj
-582 0 obj
-[579 0 R /XYZ 0 215.41 null]
-endobj
-583 0 obj
-[579 0 R /XYZ 0 135.57 null]
-endobj
-584 0 obj
-<< /Length 10085
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-[<32372e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 739.866 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 712.086 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 693.306 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 653.466 Td
-/F2.0 18 Tf
-<32372e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 625.446 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 625.446 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 625.446 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 625.446 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 625.446 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 585.606 Td
-/F2.0 18 Tf
-[<32372e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 557.586 Td
-/F2.0 10.5 Tf
-<6f64676920706f736974696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-117.1305 557.586 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 513.474 Td
-/F2.0 22 Tf
-<32382e206f64676920736572766572283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 472.226 Td
-/F2.0 18 Tf
-<32382e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 444.206 Td
-/F1.0 10.5 Tf
-<6f6467695f736572766572202d20737461727420612048545450207365727665722077697468206120676976656e20696e6465782066696c6520746f20717565727920612070616e67656e6f6d6520706f736974696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 404.366 Td
-/F2.0 18 Tf
-[<32382e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 376.346 Td
-/F2.0 10.5 Tf
-<6f64676920736572766572> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.1635 376.346 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-114.6525 376.346 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-151.182 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-157.0515 376.346 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-180.1725 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-190.431 376.346 Td
-/F2.0 10.5 Tf
-<2d702c202d2d706f7274> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-235.686 376.346 Td
-/F1.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-241.5555 376.346 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-249.567 376.346 Td
-/F1.0 10.5 Tf
-<5d205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-259.8255 376.346 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-300.2085 376.346 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 336.506 Td
-/F2.0 18 Tf
-<32382e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.2938 Tw
-
-BT
-48.24 308.486 Td
-/F1.0 10.5 Tf
-<546865206f6467692073657276657228312920636f6d6d616e642073746172747320616e2048545450207365727665722077697468206120676976656e207061746820696e64657820617320696e7075742e205468652069646561206973> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1556 Tw
-
-BT
-48.24 292.706 Td
-/F1.0 10.5 Tf
-<746861742077652063616e20676f2066726f6d20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1556 Tw
-
-BT
-156.5609 292.706 Td
-/F2.0 10.5 Tf
-<706174683a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1556 Tw
-
-BT
-227.4149 292.706 Td
-/F1.0 10.5 Tf
-<20> Tj
-/F1.1 10.5 Tf
-<2120> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1556 Tw
-
-BT
-245.665 292.706 Td
-/F2.0 10.5 Tf
-<70616e67656e6f6d653a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1556 Tw
-
-BT
-353.8885 292.706 Td
-/F1.0 10.5 Tf
-<207669612047455420726571756573747320746f207468652048545450207365727665722e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.9352 Tw
-
-BT
-48.24 276.926 Td
-/F1.0 10.5 Tf
-<54686520736572766572206865616465727320646f206e6f7420626c6f636b2063726f7373206f726967696e2072657175657374732e204578616d706c652047455420726571756573743a20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.9352 Tw
-
-BT
-444.4445 276.926 Td
-/F2.0 10.5 Tf
-<687474703a2f2f6c6f63616c6f73743a333030302f> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-48.24 261.146 Td
-/F2.0 10.5 Tf
-<706174685f6e616d652f6e75636c656f746964655f706f736974696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-214.497 261.146 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7903 Tw
-
-BT
-48.24 245.366 Td
-/F1.0 10.5 Tf
-<546865207265717569726564207061746820696e6465782063616e20626520637265617465642077697468206f64676920> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-3.7903 Tw
-
-BT
-331.9798 245.366 Td
-/F1.0 10.5 Tf
-<70617468696e646578> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7903 Tw
-
-BT
-382.9153 245.366 Td
-/F1.0 10.5 Tf
-<2e20476f696e672066726f6d20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7903 Tw
-
-BT
-459.1762 245.366 Td
-/F2.0 10.5 Tf
-<706174683a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-3.7903 Tw
-
-BT
-530.0302 245.366 Td
-/F1.0 10.5 Tf
-<20> Tj
-/F1.1 10.5 Tf
-<21> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1198 Tw
-
-BT
-48.24 229.586 Td
-/F2.0 10.5 Tf
-<70616e67656e6f6d653a706f736974696f6e> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-1.1198 Tw
-
-BT
-156.4635 229.586 Td
-/F1.0 10.5 Tf
-[<20697320696d706f7274616e74207768656e206e617669676174696e67206c61726765206772> 20.0195 <6170687320696e20616e20696e746572> 20.0195 <616374697665206d616e6e6572206c696b> 20.0195 <6520696e>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4369 Tw
-
-BT
-48.24 213.806 Td
-/F1.0 10.5 Tf
-<74686520> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.4369 Tw
-
-BT
-67.3669 213.806 Td
-/F1.0 10.5 Tf
-[<50616e746f6772> 20.0195 <617068>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4369 Tw
-
-BT
-125.5157 213.806 Td
-/F1.0 10.5 Tf
-<2070726f6a6563742e20416c6c20696e70757420616e64206f757470757420706f736974696f6e732061726520312d62617365642e204966206e6f2049502061646472657373206973207370656369666965642c20746865> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 198.026 Td
-/F1.0 10.5 Tf
-<7365727665722077696c6c2072756e206f6e206c6f63616c686f73742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 158.186 Td
-/F2.0 18 Tf
-<32382e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 123.446 Td
-/F2.0 13 Tf
-[<32382e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 96.886 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.7695 96.886 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.639 96.886 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-2.5838 Tw
-
-BT
-63.24 78.106 Td
-/F1.0 10.5 Tf
-[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820696e64657820746f20686f737420696e20612048545450207365727665722e205468652066696c65206e616d65>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 62.326 Td
-/F1.0 10.5 Tf
-<757375616c6c7920656e6473207769746820> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-154.086 62.326 Td
-/F3.0 10.5 Tf
-<2e7870> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-168.492 62.326 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3531> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-585 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 584 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
-/F1.1 80 0 R
-/F4.0 111 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
-/Annots [589 0 R 596 0 R 597 0 R 598 0 R 599 0 R]
->>
-endobj
-586 0 obj
-[585 0 R /XYZ 0 841.89 null]
-endobj
-587 0 obj
-[585 0 R /XYZ 0 677.49 null]
-endobj
-588 0 obj
-<< /Limits [(_bugs_26) (_commands)]
-/Names [(_bugs_26) 569 0 R (_bugs_27) 587 0 R (_bugs_28) 607 0 R (_bugs_29) 624 0 R (_bugs_3) 138 0 R (_bugs_30) 642 0 R (_bugs_4) 156 0 R (_bugs_5) 191 0 R (_bugs_6) 205 0 R (_bugs_7) 224 0 R (_bugs_8) 244 0 R (_bugs_9) 260 0 R (_chop_options) 476 0 R (_commands) 54 0 R]
->>
-endobj
-589 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 622.38 401.1446 636.66]
-/Type /Annot
->>
-endobj
-590 0 obj
-[585 0 R /XYZ 0 609.63 null]
-endobj
-591 0 obj
-[585 0 R /XYZ 0 541.77 null]
-endobj
-592 0 obj
-<< /Limits [(_odgi_position1) (_options)]
-/Names [(_odgi_position1) 572 0 R (_odgi_prune1) 375 0 R (_odgi_server1) 591 0 R (_odgi_sort1) 159 0 R (_odgi_squeeze1) 247 0 R (_odgi_stats1) 123 0 R (_odgi_test1) 610 0 R (_odgi_unchop1) 396 0 R (_odgi_unitig1) 314 0 R (_odgi_version1) 629 0 R (_odgi_view1) 283 0 R (_odgi_viz1) 331 0 R (_options) 109 0 R]
->>
-endobj
-593 0 obj
-[585 0 R /XYZ 0 496.25 null]
-endobj
-594 0 obj
-[585 0 R /XYZ 0 428.39 null]
-endobj
-595 0 obj
-[585 0 R /XYZ 0 360.53 null]
-endobj
-596 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (http://localost:3000/path_name/nucleotide_position)
->>
-/Subtype /Link
-/Rect [444.4445 273.86 547.04 288.14]
-/Type /Annot
->>
-endobj
-597 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (http://localost:3000/path_name/nucleotide_position)
->>
-/Subtype /Link
-/Rect [48.24 258.08 214.497 272.36]
-/Type /Annot
->>
-endobj
-598 0 obj
-<< /Border [0 0 0]
-/Dest (_odgi_pathindex1)
-/Subtype /Link
-/Rect [331.9798 242.3 382.9153 256.58]
-/Type /Annot
->>
-endobj
-599 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://graph-genome.github.io/)
->>
-/Subtype /Link
-/Rect [67.3669 210.74 125.5157 225.02]
-/Type /Annot
->>
-endobj
-600 0 obj
-[585 0 R /XYZ 0 182.21 null]
-endobj
-601 0 obj
-[585 0 R /XYZ 0 142.13 null]
-endobj
-602 0 obj
-<< /Length 7238
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 792.006 Td
-/F2.0 13 Tf
-<32382e342e322e2048545450204f7074696f6e73> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 765.446 Td
-/F2.0 10.5 Tf
-<2d702c202d2d706f7274> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.495 765.446 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-99.3645 765.446 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 746.666 Td
-/F1.0 10.5 Tf
-<52756e207468652073657276657220756e646572207468697320706f72742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 718.886 Td
-/F2.0 10.5 Tf
-<2d612c202d2d6970> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-80.559 718.886 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-86.4285 718.886 Td
-/F4.0 10.5 Tf
-<4950> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 700.106 Td
-/F1.0 10.5 Tf
-<52756e207468652073657276657220756e646572207468697320495020616464726573732e204966206e6f74207370656369666965642c20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-330.612 700.106 Td
-/F3.0 10.5 Tf
-<4950> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-340.9755 700.106 Td
-/F1.0 10.5 Tf
-<2077696c6c20626520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-380.088 700.106 Td
-/F3.0 10.5 Tf
-<6c6f63616c686f7374> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-424.7235 700.106 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 665.606 Td
-/F2.0 13 Tf
-[<32382e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 639.046 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 620.266 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 620.266 Td
-/F2.0 10.5 Tf
-<6f64676920736572766572> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-246.78 620.266 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 580.426 Td
-/F2.0 18 Tf
-[<32382e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 552.406 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 533.626 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 505.846 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 487.066 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 447.226 Td
-/F2.0 18 Tf
-<32382e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 419.206 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 419.206 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 419.206 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 419.206 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 419.206 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 379.366 Td
-/F2.0 18 Tf
-[<32382e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 351.346 Td
-/F2.0 10.5 Tf
-<6f64676920736572766572> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-108.1635 351.346 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <792053696d6f6e204865756d6f732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 307.234 Td
-/F2.0 22 Tf
-<32392e206f6467692074657374283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 265.986 Td
-/F2.0 18 Tf
-<32392e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 237.966 Td
-/F1.0 10.5 Tf
-<6f6467695f74657374202d2072756e206f64676920756e6974207465737473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 198.126 Td
-/F2.0 18 Tf
-[<32392e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 170.106 Td
-/F2.0 10.5 Tf
-<6f6467692074657374> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.348 170.106 Td
-/F1.0 10.5 Tf
-[<205b3c544553> 20.0195 <54204e414d457c50> 49.8047 <41> 60.0586 <545445524e7c54> 60.0586 <41> 20.0195 <47533e20c95d205b>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-277.7389 170.106 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-318.1219 170.106 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 130.266 Td
-/F2.0 18 Tf
-<32392e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.8333 Tw
-
-BT
-48.24 102.246 Td
-/F1.0 10.5 Tf
-[<546865206f646769207465737428312920636f6d6d616e642073746172747320616c6c20756e697420746573747320746861742061726520696d706c656d656e74656420696e206f6467692e2046> 40.0391 <6f722074617267657465642074657374696e672c2061>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.6657 Tw
-
-BT
-48.24 86.466 Td
-/F1.0 10.5 Tf
-<737562736574206f662074657374732063616e2062652073656c65637465642e206f646769207465737428312920646570656e6473206f6e20> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-0.6657 Tw
-
-BT
-326.3008 86.466 Td
-/F1.0 10.5 Tf
-<436174636832> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.6657 Tw
-
-BT
-360.0268 86.466 Td
-/F1.0 10.5 Tf
-<2e20496e207468652064656661756c742073657474696e672c20616c6c20726573756c747320617265> Tj
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 70.686 Td
-/F1.0 10.5 Tf
-<7072696e74656420746f207374646f75742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3532> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-603 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 602 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [608 0 R 615 0 R]
->>
-endobj
-604 0 obj
-[603 0 R /XYZ 0 841.89 null]
-endobj
-605 0 obj
-[603 0 R /XYZ 0 684.29 null]
-endobj
-606 0 obj
-[603 0 R /XYZ 0 604.45 null]
-endobj
-607 0 obj
-[603 0 R /XYZ 0 471.25 null]
-endobj
-608 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 416.14 401.1446 430.42]
-/Type /Annot
->>
-endobj
-609 0 obj
-[603 0 R /XYZ 0 403.39 null]
-endobj
-610 0 obj
-[603 0 R /XYZ 0 335.53 null]
-endobj
-611 0 obj
-[603 0 R /XYZ 0 290.01 null]
-endobj
-612 0 obj
-<< /Limits [(_name_21) (_name_4)]
-/Names [(_name_21) 469 0 R (_name_22) 487 0 R (_name_23) 505 0 R (_name_24) 521 0 R (_name_25) 539 0 R (_name_26) 557 0 R (_name_27) 573 0 R (_name_28) 593 0 R (_name_29) 611 0 R (_name_3) 124 0 R (_name_30) 630 0 R (_name_4) 143 0 R]
->>
-endobj
-613 0 obj
-[603 0 R /XYZ 0 222.15 null]
-endobj
-614 0 obj
-[603 0 R /XYZ 0 154.29 null]
-endobj
-615 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/catchorg/Catch2)
->>
-/Subtype /Link
-/Rect [326.3008 83.4 360.0268 97.68]
-/Type /Annot
->>
-endobj
-616 0 obj
-<< /Length 7633
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-<32392e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 751.926 Td
-/F2.0 13 Tf
-[<32392e342e312e2054> 29.7852 <657374696e67204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 725.366 Td
-/F2.0 10.5 Tf
-<2d6c2c202d2d6c6973742d7465737473> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 706.586 Td
-/F1.0 10.5 Tf
-<4c69737420616c6c20746573742063617365732e2049662061207061747465726e20776173207370656369666965642c20616c6c206d61746368696e67207465737420636173657320617265206c69737465642e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 678.806 Td
-/F2.0 10.5 Tf
-<2d742c202d2d6c6973742d74616773> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 660.026 Td
-/F1.0 10.5 Tf
-<4c69737420616c6c20746167732e2049662061207061747465726e20776173207370656369666965642c20616c6c206d61746368696e67207461677320617265206c69737465642e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 632.246 Td
-/F2.0 10.5 Tf
-<2d732c202d2d73756363657373> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 613.466 Td
-/F1.0 10.5 Tf
-<496e636c756465207375636365737366756c20746573747320696e206f75747075742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 585.686 Td
-/F2.0 10.5 Tf
-<2d622c202d2d627265616b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 566.906 Td
-/F1.0 10.5 Tf
-<427265616b20696e746f206465627567676572206d6f64652075706f6e206661696c656420746573742e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 539.126 Td
-/F2.0 10.5 Tf
-<2d652c202d2d6e6f7468726f77> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 520.346 Td
-/F1.0 10.5 Tf
-<536b697020657863657074696f6e2074657374732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 492.566 Td
-/F2.0 10.5 Tf
-<2d692c202d2d696e76697369626c6573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 473.786 Td
-/F1.0 10.5 Tf
-[<53686f7720696e76697369626c6573206c696b> 20.0195 <652074616273206f72206e65776c696e65732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 446.006 Td
-/F2.0 10.5 Tf
-<2d6f2c202d2d6f7574> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-87.888 446.006 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.7575 446.006 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 427.226 Td
-/F1.0 10.5 Tf
-<577269746520616c6c206f757470757420746f20> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-158.076 427.226 Td
-/F3.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-181.197 427.226 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 399.446 Td
-/F2.0 10.5 Tf
-<2d722c202d2d7265706f72746572> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-115.1355 399.446 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-121.005 399.446 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 380.666 Td
-/F1.0 10.5 Tf
-<5265706f7274657220746f207573652e2044656661756c7420697320636f6e736f6c652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 352.886 Td
-/F2.0 10.5 Tf
-<2d6e2c202d2d6e616d65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-100.404 352.886 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-106.2735 352.886 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 334.106 Td
-/F1.0 10.5 Tf
-<5375697465206e616d652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 306.326 Td
-/F2.0 10.5 Tf
-<2d612c202d2d61626f7274> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 287.546 Td
-/F1.0 10.5 Tf
-<41626f7274206174206669727374206661696c7572652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 259.766 Td
-/F2.0 10.5 Tf
-<2d782c202d2d61626f727478> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-106.5885 259.766 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-112.458 259.766 Td
-/F4.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 240.986 Td
-/F1.0 10.5 Tf
-<41626f727420616674657220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-121.2525 240.986 Td
-/F3.0 10.5 Tf
-<4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-129.264 240.986 Td
-/F1.0 10.5 Tf
-<206661696c757265732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 213.206 Td
-/F2.0 10.5 Tf
-[<2d77> 69.8242 <2c202d2d7761726e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-99.7863 213.206 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-105.6558 213.206 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 194.426 Td
-/F1.0 10.5 Tf
-<456e61626c65207761726e696e67732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 166.646 Td
-/F2.0 10.5 Tf
-[<2d642c202d2d647572> 20.0195 <6174696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-122.4328 166.646 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-128.3023 166.646 Td
-/F4.0 10.5 Tf
-<7965737c6e6f> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 147.866 Td
-/F1.0 10.5 Tf
-[<53686f77207465737420647572> 20.0195 <6174696f6e732e2044656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-217.7263 147.866 Td
-/F3.0 10.5 Tf
-<6e6f> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-230.0428 147.866 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 120.086 Td
-/F2.0 10.5 Tf
-<2d662c202d2d696e7075742d66696c65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-117.6765 120.086 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-123.546 120.086 Td
-/F4.0 10.5 Tf
-<46494c45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 101.306 Td
-/F1.0 10.5 Tf
-<4c6f61642074657374206e616d65732066726f6d20612066696c652e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 73.526 Td
-/F2.0 10.5 Tf
-<2d232c202d2d66696c656e616d65732d61732d74616773> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 54.746 Td
-/F1.0 10.5 Tf
-[<41> 20.0195 <64647320612074616720666f72207468652066696c65206e616d652e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3533> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-617 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 616 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F4.0 111 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
->>
-endobj
-618 0 obj
-[617 0 R /XYZ 0 841.89 null]
-endobj
-619 0 obj
-[617 0 R /XYZ 0 770.61 null]
-endobj
-620 0 obj
-<< /Length 8548
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 793.926 Td
-/F2.0 10.5 Tf
-<2d632c202d2d73656374696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-107.3025 793.926 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.172 793.926 Td
-/F4.0 10.5 Tf
-[<53> 20.0195 <5452494e47>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 775.146 Td
-/F1.0 10.5 Tf
-<53706563696679207468652073656374696f6e20746f2072756e20746865207465737473206f6e2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 747.366 Td
-/F2.0 10.5 Tf
-[<2d76> 49.8047 <2c202d2d7665726f73697479>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.0061 747.366 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-118.8756 747.366 Td
-/F4.0 10.5 Tf
-<71756965747c6e6f726d616c7c68696768> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 728.586 Td
-/F1.0 10.5 Tf
-[<536574206f757470757420766572626f73697479> 89.8438 <2e2044656661756c7420697320>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-218.2951 728.586 Td
-/F3.0 10.5 Tf
-<6e6f726d616c> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-254.1841 728.586 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 700.806 Td
-/F2.0 10.5 Tf
-<2d2d6c6973742d746573742d6e616d65732d6f6e6c79> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 682.026 Td
-/F1.0 10.5 Tf
-[<4c69737420616c6c2074657374206361736573206e616d6573206f6e6c79> 89.8438 <2e2049662061207061747465726e20776173207370656369666965642c20616c6c206d61746368696e67207465737420636173657320617265206c69737465642e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 654.246 Td
-/F2.0 10.5 Tf
-<2d2d6c6973742d7265706f7274657273> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 635.466 Td
-/F1.0 10.5 Tf
-<4c69737420616c6c207265706f72746572732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 607.686 Td
-/F2.0 10.5 Tf
-<2d2d6f72646572> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-84.927 607.686 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-90.7965 607.686 Td
-/F4.0 10.5 Tf
-[<6465636c7c6c65787c72> 20.0195 <616e64>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 588.906 Td
-/F1.0 10.5 Tf
-[<54> 29.7852 <6573742063617365206f726465722e2044656661756c742069737420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-197.4638 588.906 Td
-/F3.0 10.5 Tf
-<6465636c> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-217.0148 588.906 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 561.126 Td
-/F2.0 10.5 Tf
-<2d2d726e672d73656564> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-100.2465 561.126 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-106.116 561.126 Td
-/F4.0 10.5 Tf
-<74696d657c6e756d626572> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 542.346 Td
-/F1.0 10.5 Tf
-[<5365742061207370656369666963207365656420666f722072> 20.0195 <616e646f6d206e756d626572732e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 514.566 Td
-/F2.0 10.5 Tf
-<2d2d7573652d636f6c6f72> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-103.6485 514.566 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.518 514.566 Td
-/F4.0 10.5 Tf
-<7965737c6e6f> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 495.786 Td
-/F1.0 10.5 Tf
-<53686f756c6420746865206f757470757420626520636f6c6f72697a65643f2044656661756c7420697320> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-274.4895 495.786 Td
-/F3.0 10.5 Tf
-<796573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-290.061 495.786 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 468.006 Td
-/F2.0 10.5 Tf
-<2d2d6c69626964656e74696679> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 449.226 Td
-/F1.0 10.5 Tf
-[<5265706f7274206e616d6520616e642076657273696f6e206163636f7264696e6720746f206c69626964656e74696679> 89.8438 <2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 421.446 Td
-/F2.0 10.5 Tf
-[<2d2d776169742d666f722d6b> 20.0195 <65797072657373>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-147.6433 421.446 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-153.5128 421.446 Td
-/F4.0 10.5 Tf
-<73746172747c657869747c626f7468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 402.666 Td
-/F1.0 10.5 Tf
-[<57> 49.8047 <6169747320666f722061206b> 20.0195 <65797072657373206265666f726520>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-202.2408 402.666 Td
-/F3.0 10.5 Tf
-<73746172747c657869747c626f7468> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-277.5888 402.666 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 374.886 Td
-/F2.0 10.5 Tf
-<2d2d62656e63686d61726b2d7265736f6c7574696f6e2d6d756c7469706c65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 356.106 Td
-/F1.0 10.5 Tf
-<4d756c7469706c65206f6620636c6f636b207265736f6c7574696f6e20746f2072756e2062656e63686d61726b732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 321.606 Td
-/F2.0 13 Tf
-[<32392e342e322e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 295.046 Td
-/F2.0 10.5 Tf
-<2d3f2c202d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 276.266 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 276.266 Td
-/F2.0 10.5 Tf
-<6f6467692074657374> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-231.9645 276.266 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 236.426 Td
-/F2.0 18 Tf
-[<32392e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 208.406 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 189.626 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 161.846 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 143.066 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 103.226 Td
-/F2.0 18 Tf
-<32392e362e2042554753> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 75.206 Td
-/F1.0 10.5 Tf
-<526566657220746f2074686520> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.056 75.206 Td
-/F2.0 10.5 Tf
-<6f646769> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-131.862 75.206 Td
-/F1.0 10.5 Tf
-[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2588 0.5451 0.7922 scn
-0.2588 0.5451 0.7922 SCN
-
-BT
-213.4151 75.206 Td
-/F1.0 10.5 Tf
-<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-401.1446 75.206 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp2 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-49.24 14.388 Td
-/F1.0 9 Tf
-<3534> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-621 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 620 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F4.0 111 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp2 707 0 R
->>
->>
-/Annots [625 0 R]
->>
-endobj
-622 0 obj
-[621 0 R /XYZ 0 340.29 null]
-endobj
-623 0 obj
-[621 0 R /XYZ 0 260.45 null]
-endobj
-624 0 obj
-[621 0 R /XYZ 0 127.25 null]
-endobj
-625 0 obj
-<< /Border [0 0 0]
-/A << /Type /Action
-/S /URI
-/URI (https://github.com/vgteam/odgi/issues)
->>
-/Subtype /Link
-/Rect [213.4151 72.14 401.1446 86.42]
-/Type /Annot
->>
-endobj
-626 0 obj
-<< /Length 6439
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-[<32392e372e2041> 20.0195 <5554484f5253>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 758.646 Td
-/F2.0 10.5 Tf
-<6f6467692074657374> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-93.348 758.646 Td
-/F1.0 10.5 Tf
-[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2c2053696d6f6e204865756d6f732c20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 714.534 Td
-/F2.0 22 Tf
-<33302e206f6467692076657273696f6e283129> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 673.286 Td
-/F2.0 18 Tf
-<33302e312e204e414d45> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 645.266 Td
-/F1.0 10.5 Tf
-[<6f6467695f76657273696f6e202d20646973706c61> 20.0195 <79207468652076657273696f6e206f66206f646769>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 605.426 Td
-/F2.0 18 Tf
-[<33302e322e2053> 20.0195 <594e4f50534953>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 577.406 Td
-/F2.0 10.5 Tf
-<6f6467692076657273696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-113.8125 577.406 Td
-/F1.0 10.5 Tf
-<205b> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-120.3015 577.406 Td
-/F3.0 10.5 Tf
-<4f5054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-160.6845 577.406 Td
-/F1.0 10.5 Tf
-<5dc9> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 537.566 Td
-/F2.0 18 Tf
-<33302e332e204445534352495054494f4e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-0.4583 Tw
-
-BT
-48.24 509.546 Td
-/F1.0 10.5 Tf
-[<546865206f6467692076657273696f6e28312920636f6d6d616e64207072696e7473207468652063757272656e74206769742076657273696f6e2077697468207461677320616e6420636f64656e616d6520746f207374646f757420286c696b> 20.0195 <65>] TJ
-ET
-
-
-0.0 Tw
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 493.766 Td
-/F3.0 10.5 Tf
-<762d34342d673839643032326220226261636b20746f206f6c642041424922> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-205.0995 493.766 Td
-/F1.0 10.5 Tf
-[<292e204f7074696f6e616c6c79> 89.8438 <2c206f6e6c79207468652072656c656173652c2076657273696f6e206f7220636f64656e616d652063616e206265207072696e7465642e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 453.926 Td
-/F2.0 18 Tf
-<33302e342e204f5054494f4e53> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 419.186 Td
-/F2.0 13 Tf
-[<33302e342e312e2056> 60.0586 <657273696f6e204f7074696f6e73>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 392.626 Td
-/F2.0 10.5 Tf
-[<2d76> 49.8047 <2c202d2d76657273696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-109.6776 392.626 Td
-/F2.0 10.5 Tf
-<3d> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 373.846 Td
-/F1.0 10.5 Tf
-[<5072696e74206f6e6c79207468652076657273696f6e20286c696b> 20.0195 <6520>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-199.2568 373.846 Td
-/F3.0 10.5 Tf
-<762d34342d6738396430323262> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-270.3208 373.846 Td
-/F1.0 10.5 Tf
-<292e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 346.066 Td
-/F2.0 10.5 Tf
-<2d632c202d2d636f64656e616d65> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 327.286 Td
-/F1.0 10.5 Tf
-[<5072696e74206f6e6c792074686520636f64656e616d6520286c696b> 20.0195 <6520>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-213.1798 327.286 Td
-/F3.0 10.5 Tf
-<6261636b20746f206f6c6420414249> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-287.6878 327.286 Td
-/F1.0 10.5 Tf
-<292e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 299.506 Td
-/F2.0 10.5 Tf
-<2d722c202d2d72656c65617365> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 280.726 Td
-/F1.0 10.5 Tf
-[<5072696e74206f6e6c79207468652072656c6561736520286c696b> 20.0195 <6520>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-197.3878 280.726 Td
-/F3.0 10.5 Tf
-<76> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-203.0368 280.726 Td
-/F1.0 10.5 Tf
-<292e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 246.226 Td
-/F2.0 13 Tf
-[<33302e342e322e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 219.666 Td
-/F2.0 10.5 Tf
-<2d682c202d2d68656c70> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 200.886 Td
-/F1.0 10.5 Tf
-<5072696e7420612068656c70206d65737361676520666f7220> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-186.8565 200.886 Td
-/F2.0 10.5 Tf
-<6f6467692076657273696f6e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-252.429 200.886 Td
-/F1.0 10.5 Tf
-<2e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 161.046 Td
-/F2.0 18 Tf
-[<33302e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 133.026 Td
-/F2.0 10.5 Tf
-<30> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 114.246 Td
-/F1.0 10.5 Tf
-<537563636573732e> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-48.24 86.466 Td
-/F2.0 10.5 Tf
-<31> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-63.24 67.686 Td
-/F1.0 10.5 Tf
-[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-q
-0.0 0.0 0.0 scn
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-/Stamp1 Do
-0.2 0.2 0.2 scn
-0.2 0.2 0.2 SCN
-
-BT
-535.978 14.388 Td
-/F1.0 9 Tf
-<3535> Tj
-ET
-
-0.0 0.0 0.0 SCN
-0.0 0.0 0.0 scn
-Q
-Q
-
-endstream
-endobj
-627 0 obj
-<< /Type /Page
-/Parent 3 0 R
-/MediaBox [0 0 595.28 841.89]
-/CropBox [0 0 595.28 841.89]
-/BleedBox [0 0 595.28 841.89]
-/TrimBox [0 0 595.28 841.89]
-/ArtBox [0 0 595.28 841.89]
-/Contents 626 0 R
-/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
-/Font << /F2.0 17 0 R
-/F1.0 8 0 R
-/F3.0 55 0 R
->>
-/XObject << /Stamp1 706 0 R
->>
->>
->>
-endobj
-628 0 obj
-[627 0 R /XYZ 0 841.89 null]
-endobj
-629 0 obj
-[627 0 R /XYZ 0 742.83 null]
-endobj
-630 0 obj
-[627 0 R /XYZ 0 697.31 null]
-endobj
-631 0 obj
-[627 0 R /XYZ 0 629.45 null]
-endobj
-632 0 obj
-<< /Limits [(_synopsis_23) (_synopsis_5)]
-/Names [(_synopsis_23) 506 0 R (_synopsis_24) 522 0 R (_synopsis_25) 540 0 R (_synopsis_26) 558 0 R (_synopsis_27) 574 0 R (_synopsis_28) 594 0 R (_synopsis_29) 613 0 R (_synopsis_3) 125 0 R (_synopsis_30) 631 0 R (_synopsis_4) 144 0 R (_synopsis_5) 161 0 R]
->>
-endobj
-633 0 obj
-[627 0 R /XYZ 0 561.59 null]
-endobj
-634 0 obj
-<< /Limits [(_description_25) (_description_7)]
-/Names [(_description_25) 541 0 R (_description_26) 559 0 R (_description_27) 575 0 R (_description_28) 595 0 R (_description_29) 614 0 R (_description_3) 126 0 R (_description_30) 633 0 R (_description_4) 145 0 R (_description_5) 162 0 R (_description_6) 199 0 R (_description_7) 213 0 R]
->>
-endobj
-635 0 obj
-[627 0 R /XYZ 0 477.95 null]
-endobj
-636 0 obj
-[627 0 R /XYZ 0 437.87 null]
-endobj
-637 0 obj
-<< /Limits [(_threading_3) (_visualization_options)]
-/Names [(_threading_3) 187 0 R (_threading_4) 220 0 R (_threading_5) 237 0 R (_threading_6) 273 0 R (_threading_7) 306 0 R (_threading_8) 365 0 R (_threading_9) 388 0 R (_topological_sorts) 174 0 R (_unitig_options) 323 0 R (_version_options) 636 0 R (_visualization_options) 340 0 R]
->>
-endobj
-638 0 obj
-[627 0 R /XYZ 0 264.91 null]
-endobj
-639 0 obj
-[627 0 R /XYZ 0 185.07 null]
-endobj
-640 0 obj
-<< /Length 1539
->>
-stream
-q
-/DeviceRGB cs
-0.2 0.2 0.2 scn
-/DeviceRGB CS
-0.2 0.2 0.2 SCN
-
-BT
-48.24 786.666 Td
-/F2.0 18 Tf
-<33302e362e2042554753> Tj
+<31322e362e2042554753> Tj
 ET
 
 0.0 0.0 0.0 SCN
@@ -44640,7 +23886,7 @@ ET
 BT
 48.24 718.806 Td
 /F2.0 18 Tf
-[<33302e372e2041> 20.0195 <5554484f5253>] TJ
+[<31322e372e2041> 20.0195 <5554484f5253>] TJ
 ET
 
 0.0 0.0 0.0 SCN
@@ -44651,6 +23897,20266 @@ ET
 BT
 48.24 690.786 Td
 /F2.0 10.5 Tf
+<6f646769206b6d657273> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+107.3655 690.786 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 646.674 Td
+/F2.0 22 Tf
+<31332e206f64676920756e69746967283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 605.426 Td
+/F2.0 18 Tf
+<31332e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 577.406 Td
+/F1.0 10.5 Tf
+[<6f6467695f756e69746967202d206f757470757420756e6974696773206f6620746865206772> 20.0195 <617068>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 537.566 Td
+/F2.0 18 Tf
+[<31332e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 509.546 Td
+/F2.0 10.5 Tf
+<6f64676920756e69746967> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.2655 509.546 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+111.7545 509.546 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+148.284 509.546 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+154.1535 509.546 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+177.2745 509.546 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+187.533 509.546 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+227.916 509.546 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 469.706 Td
+/F2.0 18 Tf
+<31332e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.3722 Tw
+
+BT
+48.24 441.686 Td
+/F1.0 10.5 Tf
+<546865206f64676920756e6974696728312920636f6d6d616e642063616e207072696e7420616c6c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.3722 Tw
+
+BT
+258.2942 441.686 Td
+/F1.0 10.5 Tf
+<756e6974696773> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.3722 Tw
+
+BT
+292.5032 441.686 Td
+/F1.0 10.5 Tf
+[<206f66206120676976656e206f646769206772> 20.0195 <61706820746f207374616e64617264206f757470757420696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <41>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8795 Tw
+
+BT
+48.24 425.906 Td
+/F1.0 10.5 Tf
+[<666f726d61742e20556e69746967732063616e20616c736f20626520656d697474656420696e20612066697865642073657175656e6365207175616c6974792046> 69.8242 <4153> 20.0195 <54> 20.0195 <5120666f726d61742e2056> 60.0586 <6172696f757320706172> 20.0195 <616d6574657273>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 410.126 Td
+/F1.0 10.5 Tf
+<63616e20726566696e652074686520756e697469677320746f207072696e742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 370.286 Td
+/F2.0 18 Tf
+<31332e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 335.546 Td
+/F2.0 13 Tf
+[<31332e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 308.986 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 308.986 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 308.986 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 290.206 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20636f6e766572742066726f6d2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+529.2298 290.206 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+543.7198 290.206 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 255.706 Td
+/F2.0 13 Tf
+[<31332e342e322e2046> 69.8242 <4153> 20.0195 <54> 20.0195 <51204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 229.146 Td
+/F2.0 10.5 Tf
+[<2d662c202d2d66616b> 20.0195 <652d6661737471>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 210.366 Td
+/F1.0 10.5 Tf
+[<57726974652074686520756e697469677320696e2046> 69.8242 <4153> 20.0195 <54> 20.0195 <5120666f726d617420746f207374646f757420776974682061206669786564207175616c6974792076616c7565206f6620>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+424.6304 210.366 Td
+/F3.0 10.5 Tf
+<49> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+428.4839 210.366 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 175.866 Td
+/F2.0 13 Tf
+<31332e342e332e20556e69746967204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 149.306 Td
+/F2.0 10.5 Tf
+<2d742c202d2d73616d706c652d746f> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+120.165 149.306 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+126.0345 149.306 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 130.526 Td
+/F1.0 10.5 Tf
+[<436f6e74696e756520756e6974696773207769746820612072> 20.0195 <616e646f6d2077616c6b20696e20746865206772> 20.0195 <61706820736f207468617420746865792068617665206174206c656173742074686520676976656e20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+490.4321 130.526 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+498.4436 130.526 Td
+/F1.0 10.5 Tf
+<206c656e6774682e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 102.746 Td
+/F2.0 10.5 Tf
+<2d702c202d2d73616d706c652d706c7573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+134.6025 102.746 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+140.472 102.746 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 83.966 Td
+/F1.0 10.5 Tf
+[<436f6e74696e756520756e6974696773207769746820612072> 20.0195 <616e646f6d2077616c6b20696e20746865206772> 20.0195 <6170682062> 20.0195 <7920>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+330.4119 83.966 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+338.4234 83.966 Td
+/F1.0 10.5 Tf
+[<2070617374207468656972206e61747572> 20.0195 <616c20656e642e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3237> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+311 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 310 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [313 0 R 319 0 R]
+>>
+endobj
+312 0 obj
+[311 0 R /XYZ 0 841.89 null]
+endobj
+313 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 755.58 401.1446 769.86]
+/Type /Annot
+>>
+endobj
+314 0 obj
+[311 0 R /XYZ 0 742.83 null]
+endobj
+315 0 obj
+[311 0 R /XYZ 0 674.97 null]
+endobj
+316 0 obj
+[311 0 R /XYZ 0 629.45 null]
+endobj
+317 0 obj
+[311 0 R /XYZ 0 561.59 null]
+endobj
+318 0 obj
+[311 0 R /XYZ 0 493.73 null]
+endobj
+319 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/mcveanlab/mccortex/wiki/unitig)
+>>
+/Subtype /Link
+/Rect [258.2942 438.62 292.5032 452.9]
+/Type /Annot
+>>
+endobj
+320 0 obj
+[311 0 R /XYZ 0 394.31 null]
+endobj
+321 0 obj
+[311 0 R /XYZ 0 354.23 null]
+endobj
+322 0 obj
+<< /Limits [(_graph_files_io_9) (_name_11)]
+/Names [(_graph_files_io_9) 273 0 R (_graph_sorting) 112 0 R (_haploblocker_options) 443 0 R (_http_options) 605 0 R (_intervals_selection) 344 0 R (_investigation_options) 365 0 R (_kmer_options) 306 0 R (_kmer_options_2) 384 0 R (_matrix_options) 462 0 R (_name) 18 0 R (_name_10) 266 0 R (_name_11) 285 0 R]
+>>
+endobj
+323 0 obj
+[311 0 R /XYZ 0 274.39 null]
+endobj
+324 0 obj
+[311 0 R /XYZ 0 194.55 null]
+endobj
+325 0 obj
+<< /Length 7876
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 793.926 Td
+/F2.0 10.5 Tf
+<2d6c2c202d2d6d696e2d626567696e2d6e6f64652d6c656e677468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+187.6485 793.926 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+193.518 793.926 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 775.146 Td
+/F1.0 10.5 Tf
+<4f6e6c7920626567696e20756e697469677320636f6c6c656374696f6e2066726f6d206e6f6465732077686963682068617665206174206c65617374206c656e67746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.3085 775.146 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+409.32 775.146 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 740.646 Td
+/F2.0 13 Tf
+[<31332e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 714.086 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 695.306 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 695.306 Td
+/F2.0 10.5 Tf
+<6f64676920756e69746967> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+243.882 695.306 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 655.466 Td
+/F2.0 18 Tf
+[<31332e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 627.446 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 608.666 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 580.886 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 562.106 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 522.266 Td
+/F2.0 18 Tf
+<31332e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 494.246 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 494.246 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 494.246 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 494.246 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 494.246 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 454.406 Td
+/F2.0 18 Tf
+[<31332e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 426.386 Td
+/F2.0 10.5 Tf
+<6f64676920756e69746967> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.2655 426.386 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 382.274 Td
+/F2.0 22 Tf
+<31342e206f6467692076697a283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 341.026 Td
+/F2.0 18 Tf
+<31342e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 313.006 Td
+/F1.0 10.5 Tf
+[<6f6467695f76697a202d20766172696174696f6e206772> 20.0195 <6170682076697375616c697a6174696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 273.166 Td
+/F2.0 18 Tf
+[<31342e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 245.146 Td
+/F2.0 10.5 Tf
+<6f6467692076697a> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+89.358 245.146 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+95.847 245.146 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+132.3765 245.146 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+138.246 245.146 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+161.367 245.146 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+171.6255 245.146 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+211.2735 245.146 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+217.143 245.146 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+240.264 245.146 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+250.5225 245.146 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+290.9055 245.146 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 205.306 Td
+/F2.0 18 Tf
+<31342e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.0576 Tw
+
+BT
+48.24 177.286 Td
+/F1.0 10.5 Tf
+[<546865206f6467692076697a28312920636f6d6d616e642063616e2070726f647563652061206c696e6561722c207374617469632076697375616c697a6174696f6e206f6620616e206f64676920766172696174696f6e206772> 20.0195 <6170682e2049742063616e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1219 Tw
+
+BT
+48.24 161.506 Td
+/F1.0 10.5 Tf
+[<616767726567617465207468652070616e67656e6f6d6520696e746f2062696e7320616e64206469726563746c792072656e6465727320612072> 20.0195 <617374657220696d6167652e205468652062696e6e696e67206c6576656c2063616e206265>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.201 Tw
+
+BT
+48.24 145.726 Td
+/F1.0 10.5 Tf
+<73706563696669656420696e20696e707574206f722069742069732063616c63756c617465642066726f6d2074686520746172676574207769647468206f662074686520504e4720746f20656d69742e2043616e206265207573656420746f> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.969 Tw
+
+BT
+48.24 129.946 Td
+/F1.0 10.5 Tf
+[<70726f647563652076697375616c697a6174696f6e7320666f72206769676162617365207363616c652070616e67656e6f6d65732e2046> 40.0391 <6f72206d6f726520696e666f726d6174696f6e2061626f7574207468652062696e6e696e67>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 114.166 Td
+/F1.0 10.5 Tf
+<70726f636573732c20706c6561736520726566657220746f20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+165.756 114.166 Td
+/F1.0 10.5 Tf
+<6f6467692062696e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+206.5275 114.166 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3238> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+326 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 325 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [330 0 R 336 0 R]
+>>
+endobj
+327 0 obj
+[326 0 R /XYZ 0 759.33 null]
+endobj
+328 0 obj
+[326 0 R /XYZ 0 679.49 null]
+endobj
+329 0 obj
+[326 0 R /XYZ 0 546.29 null]
+endobj
+330 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 491.18 401.1446 505.46]
+/Type /Annot
+>>
+endobj
+331 0 obj
+[326 0 R /XYZ 0 478.43 null]
+endobj
+332 0 obj
+[326 0 R /XYZ 0 410.57 null]
+endobj
+333 0 obj
+[326 0 R /XYZ 0 365.05 null]
+endobj
+334 0 obj
+[326 0 R /XYZ 0 297.19 null]
+endobj
+335 0 obj
+[326 0 R /XYZ 0 229.33 null]
+endobj
+336 0 obj
+<< /Border [0 0 0]
+/Dest (_odgi_bin1)
+/Subtype /Link
+/Rect [165.756 111.1 206.5275 125.38]
+/Type /Annot
+>>
+endobj
+337 0 obj
+<< /Length 9895
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<31342e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 751.926 Td
+/F2.0 13 Tf
+[<31342e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 725.366 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 725.366 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 725.366 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 706.586 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20636f6e766572742066726f6d2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+529.2298 706.586 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+543.7198 706.586 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 678.806 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 678.806 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 678.806 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 660.026 Td
+/F1.0 10.5 Tf
+<5772697465207468652076697375616c697a6174696f6e20696e20504e4720666f726d617420746f20746869732066696c652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 625.526 Td
+/F2.0 13 Tf
+<31342e342e322e2056697375616c697a6174696f6e204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 598.966 Td
+/F2.0 10.5 Tf
+<2d782c202d2d7769647468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+101.286 598.966 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+107.1555 598.966 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 580.186 Td
+/F1.0 10.5 Tf
+<5365742074686520776964746820696e20706978656c73206f6620746865206f757470757420696d6167652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 552.406 Td
+/F2.0 10.5 Tf
+[<2d79> 89.8438 <2c202d2d686569676874>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+102.7261 552.406 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.5956 552.406 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 533.626 Td
+/F1.0 10.5 Tf
+<536574207468652068656967687420696e20706978656c73206f6620746865206f757470757420696d6167652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 505.846 Td
+/F2.0 10.5 Tf
+[<2d50> 120.1172 <2c202d2d706174682d686569676874>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+130.5798 505.846 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+136.4493 505.846 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 487.066 Td
+/F1.0 10.5 Tf
+<5468652068656967687420696e20706978656c7320666f72206120706174682e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 459.286 Td
+/F2.0 10.5 Tf
+<2d582c202d2d706174682d782d70616464696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+152.295 459.286 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+158.1645 459.286 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 440.506 Td
+/F1.0 10.5 Tf
+<5468652070616464696e6720696e20706978656c73206f6e2074686520782d6178697320666f72206120706174682e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 412.726 Td
+/F2.0 10.5 Tf
+<2d522c202d2d7061636b2d7061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 393.946 Td
+/F1.0 10.5 Tf
+[<5061636b20616c6c2070617468732072> 20.0195 <6174686572207468616e20646973706c61> 20.0195 <79696e6720612073696e676c6520706174682070657220726f77> 69.8242 <2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 366.166 Td
+/F2.0 10.5 Tf
+<2d4c2c202d2d6c696e6b2d706174682d706965636573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+155.6025 366.166 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+161.472 366.166 Td
+/F4.0 10.5 Tf
+[<464c4f> 20.0195 <41> 60.0586 <54>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 347.386 Td
+/F1.0 10.5 Tf
+<53686f77207468696e206c696e6b73206f6620746869732072656c617469766520776964746820746f20636f6e6e6563742070617468207069656365732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 319.606 Td
+/F2.0 10.5 Tf
+<2d412c202d2d616c69676e6d656e742d707265666978> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+162.0495 319.606 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+167.919 319.606 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.4043 Tw
+
+BT
+63.24 300.826 Td
+/F1.0 10.5 Tf
+<4170706c7920616c69676e6d656e742072656c617465642076697375616c206d6f7469667320746f20706174687320776869636820686176652074686973206e616d65207072656669782e204974206166666563747320746865205b> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.4043 Tw
+
+BT
+534.566 300.826 Td
+/F2.0 10.5 Tf
+<2d532c> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 285.046 Td
+/F2.0 10.5 Tf
+[<2d2d73686f772d737472> 20.0195 <616e64>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+135.2278 285.046 Td
+/F1.0 10.5 Tf
+<5d20616e64205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+167.3158 285.046 Td
+/F2.0 10.5 Tf
+<2d642c202d2d6368616e67652d6461726b6e657373> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+279.0568 285.046 Td
+/F1.0 10.5 Tf
+<5d206f7074696f6e732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 257.266 Td
+/F2.0 10.5 Tf
+[<2d532c202d2d73686f772d737472> 20.0195 <616e64>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4132 Tw
+
+BT
+63.24 238.486 Td
+/F1.0 10.5 Tf
+[<5573652072656420616e6420626c756520636f6c6f72696e6720746f20646973706c61> 20.0195 <7920666f727761726420616e64207265766572736520616c69676e6d656e74732e205468697320706172> 20.0195 <616d657465722063616e20626520736574>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 222.706 Td
+/F1.0 10.5 Tf
+<696e20636f6d62696e6174696f6e2077697468205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+171.5055 222.706 Td
+/F2.0 10.5 Tf
+<2d412c202d2d616c69676e6d656e742d707265666978> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+285.315 222.706 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+291.1845 222.706 Td
+/F3.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+329.4253 222.706 Td
+/F1.0 10.5 Tf
+<5d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 194.926 Td
+/F2.0 10.5 Tf
+[<2d7a2c202d2d636f6c6f722d62> 20.0195 <792d6d65616e2d696e76657273696f6e2d72> 20.0195 <617465>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8499 Tw
+
+BT
+63.24 176.146 Td
+/F1.0 10.5 Tf
+[<4368616e67652074686520636f6c6f72207265737065637420746f20746865206e6f646520737472> 20.0195 <616e646e6573732028626c61636b20666f7220666f72776172642c2072656420666f722072657665727365293b20696e2062696e6e6564>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1264 Tw
+
+BT
+63.24 160.366 Td
+/F1.0 10.5 Tf
+<6d6f64652028> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1264 Tw
+
+BT
+98.7434 160.366 Td
+/F2.0 10.5 Tf
+<2d622c202d2d62696e6e65642d6d6f6465> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1264 Tw
+
+BT
+192.3224 160.366 Td
+/F1.0 10.5 Tf
+[<292c206368616e67652074686520636f6c6f72207265737065637420746f20746865206d65616e20696e76657273696f6e2072> 20.0195 <617465206f6620746865207061746820666f72>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 144.586 Td
+/F1.0 10.5 Tf
+[<656163682062696e2c2066726f6d20626c61636b20286e6f20696e76657273696f6e732920746f20726564202862696e206d65616e20696e76657273696f6e2072> 20.0195 <61746520657175616c7320746f2031292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 116.806 Td
+/F2.0 10.5 Tf
+[<2d732c202d2d636f6c6f722d62> 20.0195 <792d707265666978>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 98.026 Td
+/F1.0 10.5 Tf
+[<436f6c6f72732070617468732062> 20.0195 <79207468656972206e616d6573206c6f6f6b696e672061742074686520707265666978206265666f72652074686520676976656e2063686172> 20.0195 <616374657220432e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3239> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+338 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 337 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+>>
+endobj
+339 0 obj
+[338 0 R /XYZ 0 841.89 null]
+endobj
+340 0 obj
+[338 0 R /XYZ 0 770.61 null]
+endobj
+341 0 obj
+[338 0 R /XYZ 0 644.21 null]
+endobj
+342 0 obj
+<< /Length 10475
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 792.006 Td
+/F2.0 13 Tf
+<31342e342e332e20496e74657276616c732073656c656374696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 765.446 Td
+/F2.0 10.5 Tf
+[<2d722c202d2d706174682d72> 20.0195 <616e6765>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+7.0924 Tw
+
+BT
+63.24 746.666 Td
+/F1.0 10.5 Tf
+[<4e75636c656f746964652072> 20.0195 <616e676520746f2076697375616c697a653a20>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+7.0924 Tw
+
+BT
+242.0954 746.666 Td
+/F5.0 10.5 Tf
+<535452494e473d5b504154483a5d73746172742d656e64> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+7.0924 Tw
+
+BT
+362.8454 746.666 Td
+/F1.0 10.5 Tf
+<2e20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+7.0924 Tw
+
+BT
+375.2824 746.666 Td
+/F5.0 10.5 Tf
+<2a2d656e64> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+7.0924 Tw
+
+BT
+401.5324 746.666 Td
+/F1.0 10.5 Tf
+<20666f7220> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+7.0924 Tw
+
+BT
+436.0347 746.666 Td
+/F5.0 10.5 Tf
+<5b302c656e645d> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+7.0924 Tw
+
+BT
+472.7847 746.666 Td
+/F1.0 10.5 Tf
+<3b20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+7.0924 Tw
+
+BT
+485.5996 746.666 Td
+/F5.0 10.5 Tf
+<73746172742d2a> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+7.0924 Tw
+
+BT
+522.3496 746.666 Td
+/F1.0 10.5 Tf
+<20666f72> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+5.2329 Tw
+
+BT
+63.24 730.886 Td
+/F5.0 10.5 Tf
+<5b73746172742c70616e67656e6f6d655f6c656e6774685d> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+5.2329 Tw
+
+BT
+189.24 730.886 Td
+/F1.0 10.5 Tf
+[<2e204966206e6f2050> 49.8047 <41> 60.0586 <5448206973207370656369666965642c20746865206e75636c656f7469646520706f736974696f6e7320726566657220746f20746865>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.3636 Tw
+
+BT
+63.24 715.106 Td
+/F1.0 10.5 Tf
+[<70616e67656e6f6d65d5732073657175656e63652028692e652e2c207468652073657175656e6365206f627461696e656420617272> 20.0195 <616e67696e6720616c6c20746865206772> 20.0195 <617068d573206e6f64652066726f6d206c65667420746f>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 699.326 Td
+/F1.0 10.5 Tf
+<7269676874292e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 664.826 Td
+/F2.0 13 Tf
+<31342e342e342e2050617468732073656c656374696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 638.266 Td
+/F2.0 10.5 Tf
+[<2d702c202d2d70617468732d746f2d646973706c61> 20.0195 <79>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.2134 Tw
+
+BT
+63.24 619.486 Td
+/F1.0 10.5 Tf
+[<4c697374206f6620706174687320746f20646973706c61> 20.0195 <7920696e2074686520737065636966696564206f726465723b207468652066696c65206d75737420636f6e7461696e206f6e652070617468206e616d6520706572206c696e6520616e642061>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 603.706 Td
+/F1.0 10.5 Tf
+<737562736574206f6620616c6c2070617468732063616e206265207370656369666965642e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 569.206 Td
+/F2.0 13 Tf
+<31342e342e352e2050617468206e616d65732076697375616c697a6174696f6e204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 542.646 Td
+/F2.0 10.5 Tf
+<2d482c202d2d686964652d706174682d6e616d6573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 523.866 Td
+/F1.0 10.5 Tf
+[<48696465207468652070617468206e616d6573206f6e20746865206c656674206f66207468652067656e6572> 20.0195 <6174656420696d6167652e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 496.086 Td
+/F2.0 10.5 Tf
+[<2d432c202d2d636f6c6f722d706174682d6e616d65732d6261636b> 20.0195 <67726f756e64>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 477.306 Td
+/F1.0 10.5 Tf
+[<436f6c6f722070617468206e616d6573206261636b> 20.0195 <67726f756e642077697468207468652073616d6520636f6c6f72206173207061746873>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 449.526 Td
+/F2.0 10.5 Tf
+[<2d632c202d2d6d61782d6e756d2d6f662d63686172> 20.0195 <616374657273>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.0399 Tw
+
+BT
+63.24 430.746 Td
+/F1.0 10.5 Tf
+[<4d6178696d756d206e756d626572206f662063686172> 20.0195 <61637465727320746f20646973706c61> 20.0195 <7920666f7220656163682070617468206e616d6520286d6178203132382063686172> 20.0195 <616374657273292e205468652064656661756c74>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 414.966 Td
+/F1.0 10.5 Tf
+<76616c756520697320> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+104.274 414.966 Td
+/F3.0 10.5 Tf
+<746865206c656e677468206f6620746865206c6f6e676573742070617468206e616d65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+275.739 414.966 Td
+/F1.0 10.5 Tf
+[<2028757020746f2033322063686172> 20.0195 <616374657273292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 380.466 Td
+/F2.0 13 Tf
+<31342e342e362e2042696e6e6564204d6f6465204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 353.906 Td
+/F2.0 10.5 Tf
+<2d622c202d2d62696e6e65642d6d6f6465> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.7917 Tw
+
+BT
+63.24 335.126 Td
+/F1.0 10.5 Tf
+[<54686520766172696174696f6e206772> 20.0195 <6170682069732062696e6e6564206265666f7265206974732076697375616c697a6174696f6e2e204561636820706978656c20696e20746865206f757470757420696d6167652077696c6c>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 319.346 Td
+/F1.0 10.5 Tf
+[<636f72726573706f6e6420746f20612062696e2e2046> 40.0391 <6f72206d6f726520696e666f726d6174696f6e2061626f7574207468652062696e6e696e672070726f636573732c20706c6561736520726566657220746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+487.7756 319.346 Td
+/F1.0 10.5 Tf
+<6f6467692062696e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+528.5471 319.346 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 291.566 Td
+/F2.0 10.5 Tf
+[<2d77> 69.8242 <2c202d2d62696e2d7769647468>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+123.5058 291.566 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.3753 291.566 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5099 Tw
+
+BT
+63.24 272.786 Td
+/F1.0 10.5 Tf
+<5468652062696e20776964746820737065636966696573207468652073697a65206f6620656163682062696e20696e207468652062696e6e6564206d6f64652e204966206974206973206e6f74207370656369666965642c207468652062696e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 257.006 Td
+/F1.0 10.5 Tf
+<77696474682069732063616c63756c617465642066726f6d2074686520776964746820696e20706978656c73206f6620746865206f757470757420696d6167652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 229.226 Td
+/F2.0 10.5 Tf
+<2d672c202d2d6e6f2d6761702d6c696e6b73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 210.446 Td
+/F1.0 10.5 Tf
+[<57> 60.0586 <6520646976696465206c696e6b7320696e746f203220636c61737365733a>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+-0.5 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+67.6765 182.666 Td
+/F1.0 10.5 Tf
+<312e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+0.0 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.2408 Tw
+
+BT
+81.24 182.666 Td
+/F1.0 10.5 Tf
+[<746865206c696e6b732077686963682068656c7020746f20666f6c6c6f7720636f6d706c657820766172696174696f6e732e2054686579206e65656420746f206265206472> 20.0195 <61776e2c20656c7365206f6e6520636f756c64206e6f74>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+81.24 166.886 Td
+/F1.0 10.5 Tf
+<666f6c6c6f77207468652073657175656e6365206f66206120706174682e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+-0.5 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+67.6765 145.106 Td
+/F1.0 10.5 Tf
+<322e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+0.0 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9739 Tw
+
+BT
+81.24 145.106 Td
+/F1.0 10.5 Tf
+<746865206c696e6b732068656c70696e6720746f20666f6c6c6f772073696d706c6520766172696174696f6e732e205468657365206c696e6b73206172652063616c6c656420> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9739 Tw
+
+BT
+438.2287 145.106 Td
+/F2.0 10.5 Tf
+<6761702d6c696e6b73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9739 Tw
+
+BT
+486.6022 145.106 Td
+/F1.0 10.5 Tf
+<2e2053756368206c696e6b73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.7733 Tw
+
+BT
+81.24 129.326 Td
+/F1.0 10.5 Tf
+[<736f6c656c7920636f6e6e656374696e67206120706174682066726f6d206c65667420746f207269676874206d61> 20.0195 <79206e6f742062652072656c6576616e7420746f20756e6465727374616e6420612070617468d573>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4291 Tw
+
+BT
+81.24 113.546 Td
+/F1.0 10.5 Tf
+[<7472> 20.0195 <6176657273616c207468726f756768207468652062696e732e205468657265666f72652c207768656e2074686973206f7074696f6e206973207365742c20746865206761702d6c696e6b7320617265206e6f74206472> 20.0195 <61776e20696e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+81.24 97.766 Td
+/F1.0 10.5 Tf
+<62696e6e6564206d6f64652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 69.986 Td
+/F2.0 10.5 Tf
+[<2d6d2c202d2d636f6c6f722d62> 20.0195 <792d6d65616e2d636f766572> 20.0195 <616765>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3330> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+343 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 342 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F5.0 236 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [348 0 R]
+>>
+endobj
+344 0 obj
+[343 0 R /XYZ 0 841.89 null]
+endobj
+345 0 obj
+[343 0 R /XYZ 0 683.51 null]
+endobj
+346 0 obj
+[343 0 R /XYZ 0 587.89 null]
+endobj
+347 0 obj
+[343 0 R /XYZ 0 399.15 null]
+endobj
+348 0 obj
+<< /Border [0 0 0]
+/Dest (_odgi_bin1)
+/Subtype /Link
+/Rect [487.7756 316.28 528.5471 330.56]
+/Type /Annot
+>>
+endobj
+349 0 obj
+<< /Length 7280
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+0.0891 Tw
+
+BT
+63.24 794.676 Td
+/F1.0 10.5 Tf
+[<4368616e67652074686520636f6c6f72207265737065637420746f20746865206d65616e20636f766572> 20.0195 <616765206f6620746865207061746820666f7220656163682062696e2c2066726f6d20626c61636b20286e6f20636f766572> 20.0195 <61676529>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 778.896 Td
+/F1.0 10.5 Tf
+[<746f20626c756520286d61782062696e206d65616e20636f766572> 20.0195 <61676520696e2074686520656e74697265206772> 20.0195 <617068292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 744.396 Td
+/F2.0 13 Tf
+[<31342e342e372e204772> 20.0195 <616469656e74204d6f64652028616c736f206b6e6f776e20617320506f736974696f6e204d6f646529204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 717.836 Td
+/F2.0 10.5 Tf
+<2d642c202d2d6368616e67652d6461726b6e657373> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9976 Tw
+
+BT
+63.24 699.056 Td
+/F1.0 10.5 Tf
+<4368616e67652074686520636f6c6f72206461726b6e657373206261736564206f6e206e75636c656f7469646520706f736974696f6e20696e2074686520706174682e205768656e206974206973207573656420696e2062696e6e6564> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.3192 Tw
+
+BT
+63.24 683.276 Td
+/F1.0 10.5 Tf
+[<6d6f64652c20746865206d65616e20696e76657273696f6e2072> 20.0195 <617465206f66207468652062696e206e6f646520697320636f6e7369646572656420746f207365742074686520636f6c6f72206772> 20.0195 <616469656e74207374617274696e67>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.1419 Tw
+
+BT
+63.24 667.496 Td
+/F1.0 10.5 Tf
+[<706f736974696f6e3a207768656e20746869732072> 20.0195 <6174652069732067726561746572207468616e20302e352c207468652062696e20697320636f6e7369646572656420696e7665727465642c20616e642074686520636f6c6f72206772> 20.0195 <616469656e74>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.3909 Tw
+
+BT
+63.24 651.716 Td
+/F1.0 10.5 Tf
+[<7374617274732066726f6d207468652072696768742d656e64206f66207468652062696e2e205468697320706172> 20.0195 <616d657465722063616e2062652073657420696e20636f6d62696e6174696f6e2077697468205b>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.3909 Tw
+
+BT
+532.8125 651.716 Td
+/F2.0 10.5 Tf
+<2d412c> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 635.936 Td
+/F2.0 10.5 Tf
+<2d2d616c69676e6d656e742d707265666978> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+160.1025 635.936 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+165.972 635.936 Td
+/F3.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+204.2128 635.936 Td
+/F1.0 10.5 Tf
+<5d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 608.156 Td
+/F2.0 10.5 Tf
+<2d6c2c202d2d6c6f6e676573742d70617468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 589.376 Td
+/F1.0 10.5 Tf
+<55736520746865206c6f6e676573742070617468206c656e67746820746f206368616e67652074686520636f6c6f72206461726b6e6573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 561.596 Td
+/F2.0 10.5 Tf
+<2d752c202d2d77686974652d746f2d626c61636b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.7053 Tw
+
+BT
+63.24 542.816 Td
+/F1.0 10.5 Tf
+<4368616e67652074686520636f6c6f72206461726b6e6573732066726f6d2077686974652028666f7220746865206669727374206e75636c656f7469646520706f736974696f6e2920746f20626c61636b2028666f7220746865206c617374> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 527.036 Td
+/F1.0 10.5 Tf
+<6e75636c656f7469646520706f736974696f6e292e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 492.536 Td
+/F2.0 13 Tf
+[<31342e342e382e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 465.976 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 447.196 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 447.196 Td
+/F2.0 10.5 Tf
+<6f6467692076697a> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+227.9745 447.196 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 407.356 Td
+/F2.0 18 Tf
+[<31342e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 379.336 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 360.556 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 332.776 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 313.996 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 274.156 Td
+/F2.0 18 Tf
+<31342e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.9608 0.9608 0.9608 scn
+52.24 258.1 m
+543.04 258.1 l
+545.2491 258.1 547.04 256.3091 547.04 254.1 c
+547.04 225.36 l
+547.04 223.1509 545.2491 221.36 543.04 221.36 c
+52.24 221.36 l
+50.0309 221.36 48.24 223.1509 48.24 225.36 c
+48.24 254.1 l
+48.24 256.3091 50.0309 258.1 52.24 258.1 c
+h
+f
+0.8 0.8 0.8 SCN
+0.75 w
+52.24 258.1 m
+543.04 258.1 l
+545.2491 258.1 547.04 256.3091 547.04 254.1 c
+547.04 225.36 l
+547.04 223.1509 545.2491 221.36 543.04 221.36 c
+52.24 221.36 l
+50.0309 221.36 48.24 223.1509 48.24 225.36 c
+48.24 254.1 l
+48.24 256.3091 50.0309 258.1 52.24 258.1 c
+h
+S
+Q
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+59.24 235.275 Td
+/F5.0 11 Tf
+<526566657220746f20746865202a6f6467692a20697373756520747261636b65722061742068747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f6973737565732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 185.336 Td
+/F2.0 18 Tf
+[<31342e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 157.316 Td
+/F2.0 10.5 Tf
+<6f6467692076697a> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+89.358 157.316 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 113.204 Td
+/F2.0 22 Tf
+<31352e206f646769207061746873283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3331> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+350 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 349 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 8 0 R
+/F2.0 17 0 R
+/F3.0 55 0 R
+/F5.0 236 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+>>
+endobj
+351 0 obj
+[350 0 R /XYZ 0 763.08 null]
+endobj
+352 0 obj
+[350 0 R /XYZ 0 511.22 null]
+endobj
+353 0 obj
+[350 0 R /XYZ 0 431.38 null]
+endobj
+354 0 obj
+[350 0 R /XYZ 0 298.18 null]
+endobj
+355 0 obj
+[350 0 R /XYZ 0 209.36 null]
+endobj
+356 0 obj
+[350 0 R /XYZ 0 141.5 null]
+endobj
+357 0 obj
+<< /Limits [(_odgi_extract1) (_odgi_paths1)]
+/Names [(_odgi_extract1) 265 0 R (_odgi_flatten1) 507 0 R (_odgi_groom1) 194 0 R (_odgi_kmers1) 298 0 R (_odgi_layout1) 487 0 R (_odgi_matrix1) 452 0 R (_odgi_normalize1) 412 0 R (_odgi_panpos1) 557 0 R (_odgi_pathindex1) 539 0 R (_odgi_paths1) 356 0 R]
+>>
+endobj
+358 0 obj
+<< /Length 10501
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<31352e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 758.646 Td
+/F1.0 10.5 Tf
+<6f6467695f7061746873202d20656d626564646564207061746820696e746572726f676174696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 718.806 Td
+/F2.0 18 Tf
+[<31352e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 690.786 Td
+/F2.0 10.5 Tf
+<6f646769207061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+103.176 690.786 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.665 690.786 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+146.1945 690.786 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+152.064 690.786 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+175.185 690.786 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+185.4435 690.786 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+225.8265 690.786 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 650.946 Td
+/F2.0 18 Tf
+<31352e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9829 Tw
+
+BT
+48.24 622.926 Td
+/F1.0 10.5 Tf
+[<546865206f64676920706174687328312920636f6d6d616e6420616c6c6f77732074686520696e7665737469676174696f6e206f66207061746873206f66206120676976656e20766172696174696f6e206772> 20.0195 <6170682e2049742063616e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 607.146 Td
+/F1.0 10.5 Tf
+<63616c63756c617465206f7665726c61702073746174697374696373206f662067726f7570696e6773206f662070617468732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 567.306 Td
+/F2.0 18 Tf
+<31352e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 532.566 Td
+/F2.0 13 Tf
+[<31352e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 506.006 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 506.006 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 506.006 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.5222 Tw
+
+BT
+63.24 487.226 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20696e766573746967617465207468652070617468732066726f6d2e205468652066696c65206e616d6520757375616c6c79>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 471.446 Td
+/F1.0 10.5 Tf
+<656e6473207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.984 471.446 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.474 471.446 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 443.666 Td
+/F2.0 10.5 Tf
+<2d4f2c202d2d6f7665726c617073> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+118.1805 443.666 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+124.05 443.666 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.2386 Tw
+
+BT
+63.24 424.886 Td
+/F1.0 10.5 Tf
+[<5265616420696e2074686520706174682067726f7570696e672066696c6520746f2067656e6572> 20.0195 <61746520746865206f7665726c617020737461746973746963732066726f6d2e205468652066696c65206d757374206265207461622d>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.0934 Tw
+
+BT
+63.24 409.106 Td
+/F1.0 10.5 Tf
+<64656c696d697465642e2054686520666972737420636f6c756d6e206c6973747320612067726f7570696e6720616e6420746865207365636f6e6420746865207061746820697473656c662e2045616368206c696e6520686173206f6e652070617468> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.1998 Tw
+
+BT
+63.24 393.326 Td
+/F1.0 10.5 Tf
+[<656e747279> 89.8438 <2e2046> 40.0391 <6f7220656163682067726f757020746865207061697277697365206f7665726c6170207374617469737469637320666f7220656163682070616972696e672077696c6c2062652063616c63756c6174656420616e64>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 377.546 Td
+/F1.0 10.5 Tf
+<7072696e74656420746f207374646f75742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 343.046 Td
+/F2.0 13 Tf
+<31352e342e322e20496e7665737469676174696f6e204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 316.486 Td
+/F2.0 10.5 Tf
+<2d4c2c202d2d6c6973742d7061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 297.706 Td
+/F1.0 10.5 Tf
+[<5072696e742074686520706174687320696e20746865206772> 20.0195 <61706820746f207374646f75742e20456163682070617468206973207072696e74656420696e20697473206f776e206c696e652e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 269.926 Td
+/F2.0 10.5 Tf
+<2d482c202d2d6861706c6f7479706573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.0046 Tw
+
+BT
+63.24 251.146 Td
+/F1.0 10.5 Tf
+[<5072696e7420746f207374646f75742074686520706174687320696e20616e20617070726f78696d6174652062696e617279206861706c6f74797065206d6174726978206261736564206f6e20746865206772> 20.0195 <617068d57320736f7274>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+63.24 235.366 Td
+/F1.0 10.5 Tf
+<6f726465722e20546865206f7574707574206973207461622d64656c696d697465643a20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+258.3626 235.366 Td
+/F2.0 10.5 Tf
+<706174682e6e616d65> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+315.3461 235.366 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+324.8803 235.366 Td
+/F2.0 10.5 Tf
+<706174682e6c656e677468> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+386.0428 235.366 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+395.5771 235.366 Td
+/F2.0 10.5 Tf
+<6e6f64652e636f756e74> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+455.0386 235.366 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+464.5728 235.366 Td
+/F2.0 10.5 Tf
+<6e6f64652e31> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+499.7268 235.366 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+509.261 235.366 Td
+/F2.0 10.5 Tf
+<6e6f64652e32> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+4.1897 Tw
+
+BT
+544.415 235.366 Td
+/F1.0 10.5 Tf
+<2c> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 219.586 Td
+/F2.0 10.5 Tf
+<6e6f64652e6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+99.5175 219.586 Td
+/F1.0 10.5 Tf
+<2e2045616368207061746820656e747279206973207072696e74656420696e20697473206f776e206c696e652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 191.806 Td
+/F2.0 10.5 Tf
+<2d442c202d2d64656c696d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+102.378 191.806 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.2475 191.806 Td
+/F4.0 10.5 Tf
+<43484152> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.3931 Tw
+
+BT
+63.24 173.026 Td
+/F1.0 10.5 Tf
+[<5468652070617274206f6620656163682070617468206e616d65206265666f726520746869732064656c696d6974657220697320612067726f7570206964656e7469666965722e205468697320706172> 20.0195 <616d657465722073686f756c64>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+5.1697 Tw
+
+BT
+63.24 157.246 Td
+/F1.0 10.5 Tf
+<6f6e6c792062652073657420696e20636f6d62696e6174696f6e2077697468205b> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+5.1697 Tw
+
+BT
+258.793 157.246 Td
+/F2.0 10.5 Tf
+<2d482c202d2d6861706c6f7479706573> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+5.1697 Tw
+
+BT
+346.4822 157.246 Td
+/F1.0 10.5 Tf
+<5d2e205072696e747320616e206164646974696f6e616c2c20666972737420636f6c756d6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 141.466 Td
+/F2.0 10.5 Tf
+<67726f75702e6e616d65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+127.479 141.466 Td
+/F1.0 10.5 Tf
+<20746f207374646f75742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 113.686 Td
+/F2.0 10.5 Tf
+<2d642c202d2d64697374616e6365> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.2098 Tw
+
+BT
+63.24 94.906 Td
+/F1.0 10.5 Tf
+<50726f76696465732061207370617273652064697374616e6365206d617472697820666f722070617468732e204966205b> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.2098 Tw
+
+BT
+324.4863 94.906 Td
+/F2.0 10.5 Tf
+<2d442c202d2d64656c696d> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.2098 Tw
+
+BT
+381.8341 94.906 Td
+/F1.0 10.5 Tf
+<5d206973207365742c2069742077696c6c20626520706174682067726f757073> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 79.126 Td
+/F1.0 10.5 Tf
+<64697374616e6365732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3332> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+359 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 358 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+>>
+endobj
+360 0 obj
+[359 0 R /XYZ 0 841.89 null]
+endobj
+361 0 obj
+[359 0 R /XYZ 0 742.83 null]
+endobj
+362 0 obj
+[359 0 R /XYZ 0 674.97 null]
+endobj
+363 0 obj
+[359 0 R /XYZ 0 591.33 null]
+endobj
+364 0 obj
+[359 0 R /XYZ 0 551.25 null]
+endobj
+365 0 obj
+[359 0 R /XYZ 0 361.73 null]
+endobj
+366 0 obj
+<< /Length 7292
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 793.926 Td
+/F2.0 10.5 Tf
+<2d662c202d2d6661737461> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 775.146 Td
+/F1.0 10.5 Tf
+[<5072696e7420706174687320696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120666f726d617420746f207374646f75742e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 740.646 Td
+/F2.0 13 Tf
+<31352e342e332e20546872656164696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 714.086 Td
+/F2.0 10.5 Tf
+<2d742c202d2d74687265616473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.951 714.086 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.8205 714.086 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 695.306 Td
+/F1.0 10.5 Tf
+<4e756d626572206f66207468726561647320746f207573652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 660.806 Td
+/F2.0 13 Tf
+[<31352e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 634.246 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 615.466 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 615.466 Td
+/F2.0 10.5 Tf
+<6f646769207061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+241.7925 615.466 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 575.626 Td
+/F2.0 18 Tf
+[<31352e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 547.606 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 528.826 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 501.046 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 482.266 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 442.426 Td
+/F2.0 18 Tf
+<31352e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 414.406 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 414.406 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 414.406 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 414.406 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 414.406 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 374.566 Td
+/F2.0 18 Tf
+[<31352e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 346.546 Td
+/F2.0 10.5 Tf
+<6f646769207061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+103.176 346.546 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 302.434 Td
+/F2.0 22 Tf
+<31362e206f646769207072756e65283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 261.186 Td
+/F2.0 18 Tf
+<31362e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 233.166 Td
+/F1.0 10.5 Tf
+[<6f6467695f7072756e65202d2072656d6f766520636f6d706c6578207061727473206f6620746865206772> 20.0195 <617068>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 193.326 Td
+/F2.0 18 Tf
+[<31362e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 165.306 Td
+/F2.0 10.5 Tf
+<6f646769207072756e65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.99 165.306 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+112.479 165.306 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+149.0085 165.306 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+154.878 165.306 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+177.999 165.306 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+188.2575 165.306 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+227.9055 165.306 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+233.775 165.306 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+256.896 165.306 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+267.1545 165.306 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+307.5375 165.306 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 125.466 Td
+/F2.0 18 Tf
+<31362e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4057 Tw
+
+BT
+48.24 97.446 Td
+/F1.0 10.5 Tf
+[<546865206f646769207072756e6528312920636f6d6d616e642063616e2072656d6f766520636f6d706c6578207061727473206f662061206772> 20.0195 <6170682e204f6e652063616e2064726f702070617468732c206e6f6465732062> 20.0195 <792061>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9375 Tw
+
+BT
+48.24 81.666 Td
+/F1.0 10.5 Tf
+[<6365727461696e206b696e64206f66206564676520636f766572> 20.0195 <6167652c20656467657320616e64206772> 20.0195 <61706820746970732e2053706563696679696e672061206b6d6572206c656e67746820616e642061206d6178696d756d>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 65.886 Td
+/F1.0 10.5 Tf
+[<6e756d626572206f6620667572636174696f6e732c20746865206772> 20.0195 <6170682063616e2062652062726f6b> 20.0195 <656e206174206564676573206e6f742066697474696e6720696e746f20746865736520636f6e646974696f6e732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3333> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+367 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 366 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F4.0 111 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [374 0 R]
+>>
+endobj
+368 0 obj
+[367 0 R /XYZ 0 759.33 null]
+endobj
+369 0 obj
+[367 0 R /XYZ 0 679.49 null]
+endobj
+370 0 obj
+<< /Limits [(_program_information_13) (_program_information_21)]
+/Names [(_program_information_13) 352 0 R (_program_information_14) 369 0 R (_program_information_15) 392 0 R (_program_information_16) 407 0 R (_program_information_17) 422 0 R (_program_information_18) 447 0 R (_program_information_19) 463 0 R (_program_information_2) 134 0 R (_program_information_20) 480 0 R (_program_information_21) 500 0 R]
+>>
+endobj
+371 0 obj
+[367 0 R /XYZ 0 599.65 null]
+endobj
+372 0 obj
+<< /Limits [(_exit_status_4) (_graph_files_io)]
+/Names [(_exit_status_4) 190 0 R (_exit_status_5) 204 0 R (_exit_status_6) 223 0 R (_exit_status_7) 241 0 R (_exit_status_8) 260 0 R (_exit_status_9) 280 0 R (_explode_options) 235 0 R (_extract_options) 274 0 R (_fasta_options) 441 0 R (_fastq_options) 323 0 R (_gradient_mode_also_known_as_position_mode_options) 351 0 R (_graph_files_io) 110 0 R]
+>>
+endobj
+373 0 obj
+[367 0 R /XYZ 0 466.45 null]
+endobj
+374 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 411.34 401.1446 425.62]
+/Type /Annot
+>>
+endobj
+375 0 obj
+[367 0 R /XYZ 0 398.59 null]
+endobj
+376 0 obj
+[367 0 R /XYZ 0 330.73 null]
+endobj
+377 0 obj
+[367 0 R /XYZ 0 285.21 null]
+endobj
+378 0 obj
+[367 0 R /XYZ 0 217.35 null]
+endobj
+379 0 obj
+[367 0 R /XYZ 0 149.49 null]
+endobj
+380 0 obj
+<< /Length 10355
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<31362e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 751.926 Td
+/F2.0 13 Tf
+[<31362e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 725.366 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 725.366 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 725.366 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 706.586 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206c6f616420696e2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+497.8768 706.586 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+512.3668 706.586 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 678.806 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 678.806 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 678.806 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 660.026 Td
+/F1.0 10.5 Tf
+[<577269746520746865207072756e6564206772> 20.0195 <61706820746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+197.3983 660.026 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+220.5193 660.026 Td
+/F1.0 10.5 Tf
+<2e205468652066696c65206e616d652073686f756c6420656e64207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+380.5498 660.026 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+395.0398 660.026 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 625.526 Td
+/F2.0 13 Tf
+<31362e342e322e204b6d6572204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 598.966 Td
+/F2.0 10.5 Tf
+<2d6b2c202d2d6b6d65722d6c656e677468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+136.0095 598.966 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+141.879 598.966 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 580.186 Td
+/F1.0 10.5 Tf
+<546865206c656e677468206f6620746865206b6d65727320746f20636f6e73696465722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 552.406 Td
+/F2.0 10.5 Tf
+<2d652c202d2d6d61782d667572636174696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+151.476 552.406 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+157.3455 552.406 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 533.626 Td
+/F1.0 10.5 Tf
+<427265616b206174206564676573207468617420776f756c6420696e6475636520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+232.059 533.626 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+240.0705 533.626 Td
+/F1.0 10.5 Tf
+[<206d616e> 20.0195 <7920667572636174696f6e7320696e2061206b6d65722e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 499.126 Td
+/F2.0 13 Tf
+<31362e342e332e204e6f6465204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 472.566 Td
+/F2.0 10.5 Tf
+<2d642c202d2d6d61782d646567726565> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+133.3845 472.566 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+139.254 472.566 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 453.786 Td
+/F1.0 10.5 Tf
+<52656d6f7665206e6f64657320746861742068617665206120686967686572206e6f646520646567726565207468616e20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+322.275 453.786 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+330.2865 453.786 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 426.006 Td
+/F2.0 10.5 Tf
+[<2d632c202d2d6d696e2d636f766572> 20.0195 <616765>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+141.3223 426.006 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+147.1918 426.006 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 407.226 Td
+/F1.0 10.5 Tf
+[<52656d6f7665206e6f6465736520636f76657265642062> 20.0195 <79206665776572207468616e20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+259.1488 407.226 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+267.1603 407.226 Td
+/F1.0 10.5 Tf
+<206e756d626572206f6620706174682073746570732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 379.446 Td
+/F2.0 10.5 Tf
+[<2d432c202d2d6d61782d636f766572> 20.0195 <616765>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+145.1758 379.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+151.0453 379.446 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 360.666 Td
+/F1.0 10.5 Tf
+[<52656d6f7665206e6f64657320636f76657265642062> 20.0195 <79206d6f7265207468616e20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+250.9693 360.666 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+258.9808 360.666 Td
+/F1.0 10.5 Tf
+<206e756d626572206f6620706174682073746570732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 332.886 Td
+/F2.0 10.5 Tf
+[<2d54> 89.8438 <2c202d2d6375742d74697073>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.5406 332.886 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+115.4101 332.886 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 314.106 Td
+/F1.0 10.5 Tf
+[<52656d6f7665206e6f64657320776869636820617265206772> 20.0195 <61706820746970732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 279.606 Td
+/F2.0 13 Tf
+<31362e342e342e2045646765204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 253.046 Td
+/F2.0 10.5 Tf
+[<2d452c202d2d656467652d636f766572> 20.0195 <616765>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4637 Tw
+
+BT
+63.24 234.266 Td
+/F1.0 10.5 Tf
+[<52656d6f7665206564676573206f757473696465206f6620746865206d696e696d756d20616e64206d6178696d756d20636f766572> 20.0195 <6167652072> 20.0195 <6174686572207468616e206e6f6465732e204f6e6c79207365742074686973>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 218.486 Td
+/F1.0 10.5 Tf
+<617267756d656e7420696e20636f6d62696e6174696f6e2077697468205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+223.3755 218.486 Td
+/F2.0 10.5 Tf
+[<2d632c202d2d6d696e2d636f766572> 20.0195 <616765>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+316.4578 218.486 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+322.3273 218.486 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+330.3388 218.486 Td
+/F1.0 10.5 Tf
+<5d20616e64205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+362.4268 218.486 Td
+/F2.0 10.5 Tf
+[<2d432c202d2d6d61782d636f766572> 20.0195 <616765>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+459.3626 218.486 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+465.2321 218.486 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+473.2436 218.486 Td
+/F1.0 10.5 Tf
+<5d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 190.706 Td
+/F2.0 10.5 Tf
+<2d622c202d2d626573742d6564676573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+125.772 190.706 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.6415 190.706 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 171.926 Td
+/F1.0 10.5 Tf
+[<4f6e6c79206b> 20.0195 <6565702074686520>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+134.7028 171.926 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+142.7143 171.926 Td
+/F1.0 10.5 Tf
+<206d6f737420636f766572656420696e626f756e6420616e64206f7574707574206564676573206f662065616368206e6f64652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 137.426 Td
+/F2.0 13 Tf
+<31362e342e352e2050617468204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 110.866 Td
+/F2.0 10.5 Tf
+<2d442c202d2d64726f702d7061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 92.086 Td
+/F1.0 10.5 Tf
+[<52656d6f7665207468652070617468732066726f6d20746865206772> 20.0195 <6170682e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3334> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+381 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 380 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+>>
+endobj
+382 0 obj
+[381 0 R /XYZ 0 841.89 null]
+endobj
+383 0 obj
+[381 0 R /XYZ 0 770.61 null]
+endobj
+384 0 obj
+[381 0 R /XYZ 0 644.21 null]
+endobj
+385 0 obj
+[381 0 R /XYZ 0 517.81 null]
+endobj
+386 0 obj
+[381 0 R /XYZ 0 298.29 null]
+endobj
+387 0 obj
+[381 0 R /XYZ 0 156.11 null]
+endobj
+388 0 obj
+<< /Limits [(_options_6) (_processing_information)]
+/Names [(_options_6) 214 0 R (_options_7) 233 0 R (_options_8) 252 0 R (_options_9) 272 0 R (_output_options) 513 0 R (_path_guided_1d_linear_sgd_sort) 178 0 R (_path_names_visualization_options) 346 0 R (_path_options) 387 0 R (_path_sorting_options) 181 0 R (_paths_selection) 345 0 R (_pipeline_sorting) 183 0 R (_position_options) 567 0 R (_position_options_2) 582 0 R (_processing_information) 113 0 R]
+>>
+endobj
+389 0 obj
+<< /Length 6374
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 792.006 Td
+/F2.0 13 Tf
+<31362e342e362e20546872656164696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 765.446 Td
+/F2.0 10.5 Tf
+<2d742c202d2d74687265616473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.951 765.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.8205 765.446 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 746.666 Td
+/F1.0 10.5 Tf
+<4e756d626572206f66207468726561647320746f207573652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 712.166 Td
+/F2.0 13 Tf
+[<31362e342e372e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 685.606 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 666.826 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 666.826 Td
+/F2.0 10.5 Tf
+<6f646769207072756e65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+244.6065 666.826 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 626.986 Td
+/F2.0 18 Tf
+[<31362e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 598.966 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 580.186 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 552.406 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 533.626 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 493.786 Td
+/F2.0 18 Tf
+<31362e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 465.766 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 465.766 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 465.766 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 465.766 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 465.766 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 425.926 Td
+/F2.0 18 Tf
+[<31362e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 397.906 Td
+/F2.0 10.5 Tf
+<6f646769207072756e65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.99 397.906 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 353.794 Td
+/F2.0 22 Tf
+<31372e206f64676920756e63686f70283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 312.546 Td
+/F2.0 18 Tf
+<31372e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 284.526 Td
+/F1.0 10.5 Tf
+<6f6467695f756e63686f70202d206d6572676520756e697469677320696e746f2073696e676c65206e6f646573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 244.686 Td
+/F2.0 18 Tf
+[<31372e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 216.666 Td
+/F2.0 10.5 Tf
+<6f64676920756e63686f70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.466 216.666 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+119.955 216.666 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+156.4845 216.666 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+162.354 216.666 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+185.475 216.666 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+195.7335 216.666 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+235.3815 216.666 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+241.251 216.666 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+264.372 216.666 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+274.6305 216.666 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+315.0135 216.666 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 176.826 Td
+/F2.0 18 Tf
+<31372e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 148.806 Td
+/F1.0 10.5 Tf
+<546865206f64676920756e63686f7028312920636f6d6d616e64206d6572676573206561636820756e6974696720696e746f20612073696e676c65206e6f64652070726573657276696e6720746865206e6f6465206f726465722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 108.966 Td
+/F2.0 18 Tf
+<31372e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3335> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+390 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 389 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [395 0 R]
+>>
+endobj
+391 0 obj
+[390 0 R /XYZ 0 841.89 null]
+endobj
+392 0 obj
+[390 0 R /XYZ 0 730.85 null]
+endobj
+393 0 obj
+[390 0 R /XYZ 0 651.01 null]
+endobj
+394 0 obj
+[390 0 R /XYZ 0 517.81 null]
+endobj
+395 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 462.7 401.1446 476.98]
+/Type /Annot
+>>
+endobj
+396 0 obj
+[390 0 R /XYZ 0 449.95 null]
+endobj
+397 0 obj
+[390 0 R /XYZ 0 382.09 null]
+endobj
+398 0 obj
+[390 0 R /XYZ 0 336.57 null]
+endobj
+399 0 obj
+[390 0 R /XYZ 0 268.71 null]
+endobj
+400 0 obj
+[390 0 R /XYZ 0 200.85 null]
+endobj
+401 0 obj
+[390 0 R /XYZ 0 132.99 null]
+endobj
+402 0 obj
+<< /Length 7029
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 792.006 Td
+/F2.0 13 Tf
+[<31372e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 765.446 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 765.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 765.446 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 746.666 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20756e63686f702e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+501.1318 746.666 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+515.6218 746.666 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 718.886 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 718.886 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 718.886 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.1519 Tw
+
+BT
+63.24 700.106 Td
+/F1.0 10.5 Tf
+[<57726974652074686520756e63686f707065642064796e616d69632073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20746869732066696c652e20412066696c6520656e64696e67207769746820>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.1519 Tw
+
+BT
+519.5936 700.106 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.1519 Tw
+
+BT
+534.0836 700.106 Td
+/F1.0 10.5 Tf
+<206973> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 684.326 Td
+/F1.0 10.5 Tf
+<7265636f6d6d656e6465642e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 649.826 Td
+/F2.0 13 Tf
+<31372e342e322e2050726f63657373696e6720496e666f726d6174696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 623.266 Td
+/F2.0 10.5 Tf
+<2d642c202d2d6465627567> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 604.486 Td
+/F1.0 10.5 Tf
+<5072696e7420696e666f726d6174696f6e2061626f7574207468652070726f6365737320746f207374646572722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 569.986 Td
+/F2.0 13 Tf
+<31372e342e332e20546872656164696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 543.426 Td
+/F2.0 10.5 Tf
+<2d742c202d2d74687265616473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.951 543.426 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.8205 543.426 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 524.646 Td
+/F1.0 10.5 Tf
+[<4e756d626572206f66207468726561647320746f2075736520666f722074686520706172> 20.0195 <616c6c656c206f706572> 20.0195 <6174696f6e732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 490.146 Td
+/F2.0 13 Tf
+[<31372e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 463.586 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 444.806 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 444.806 Td
+/F2.0 10.5 Tf
+<6f64676920756e63686f70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+252.0825 444.806 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 404.966 Td
+/F2.0 18 Tf
+[<31372e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 376.946 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 358.166 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 330.386 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 311.606 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 271.766 Td
+/F2.0 18 Tf
+<31372e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 243.746 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 243.746 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 243.746 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 243.746 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 243.746 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 203.906 Td
+/F2.0 18 Tf
+[<31372e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 175.886 Td
+/F2.0 10.5 Tf
+<6f64676920756e63686f70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.466 175.886 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 131.774 Td
+/F2.0 22 Tf
+<31382e206f646769206e6f726d616c697a65283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 90.526 Td
+/F2.0 18 Tf
+<31382e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 62.506 Td
+/F1.0 10.5 Tf
+<6f6467695f6e6f726d616c697a65202d20636f6d7061637420756e697469677320616e642073696d706c69667920726564756e64616e7420667572636174696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3336> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+403 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 402 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [410 0 R]
+>>
+endobj
+404 0 obj
+[403 0 R /XYZ 0 841.89 null]
+endobj
+405 0 obj
+[403 0 R /XYZ 0 668.51 null]
+endobj
+406 0 obj
+[403 0 R /XYZ 0 588.67 null]
+endobj
+407 0 obj
+[403 0 R /XYZ 0 508.83 null]
+endobj
+408 0 obj
+[403 0 R /XYZ 0 428.99 null]
+endobj
+409 0 obj
+[403 0 R /XYZ 0 295.79 null]
+endobj
+410 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 240.68 401.1446 254.96]
+/Type /Annot
+>>
+endobj
+411 0 obj
+[403 0 R /XYZ 0 227.93 null]
+endobj
+412 0 obj
+[403 0 R /XYZ 0 160.07 null]
+endobj
+413 0 obj
+[403 0 R /XYZ 0 114.55 null]
+endobj
+414 0 obj
+<< /Length 8996
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+[<31382e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 758.646 Td
+/F2.0 10.5 Tf
+<6f646769206e6f726d616c697a65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+128.2185 758.646 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+134.7075 758.646 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+171.237 758.646 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+177.1065 758.646 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+200.2275 758.646 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+210.486 758.646 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+250.134 758.646 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+256.0035 758.646 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+279.1245 758.646 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+289.383 758.646 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+329.766 758.646 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 718.806 Td
+/F2.0 18 Tf
+<31382e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.8161 Tw
+
+BT
+48.24 690.786 Td
+/F1.0 10.5 Tf
+<546865206f646769206e6f726d616c697a6528312920636f6d6d616e6420> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+3.8161 Tw
+
+BT
+229.0473 690.786 Td
+/F1.0 10.5 Tf
+<756e63686f7073> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.8161 Tw
+
+BT
+271.5303 690.786 Td
+/F1.0 10.5 Tf
+[<206120676976656e20766172696174696f6e206772> 20.0195 <61706820616e642073696d706c696669657320726564756e64616e74>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 675.006 Td
+/F1.0 10.5 Tf
+<667572636174696f6e732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 635.166 Td
+/F2.0 18 Tf
+<31382e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 600.426 Td
+/F2.0 13 Tf
+[<31382e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 573.866 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 573.866 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 573.866 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 555.086 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206e6f726d616c697a652e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+514.5613 555.086 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+529.0513 555.086 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 527.306 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 527.306 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 527.306 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0602 Tw
+
+BT
+63.24 508.526 Td
+/F1.0 10.5 Tf
+[<577269746520746865206e6f726d616c697a65642064796e616d69632073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20746869732066696c652e20412066696c6520656e64696e67207769746820>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0602 Tw
+
+BT
+519.6853 508.526 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0602 Tw
+
+BT
+534.1753 508.526 Td
+/F1.0 10.5 Tf
+<206973> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 492.746 Td
+/F1.0 10.5 Tf
+<7265636f6d6d656e6465642e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 464.966 Td
+/F2.0 10.5 Tf
+[<2d492c202d2d6d61782d69746572> 20.0195 <6174696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+146.6143 464.966 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+152.4838 464.966 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 446.186 Td
+/F1.0 10.5 Tf
+[<49746572> 20.0195 <61746520746865206e6f726d616c697a6174696f6e20757020746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+220.1098 446.186 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+228.1213 446.186 Td
+/F1.0 10.5 Tf
+[<206d616e> 20.0195 <792074696d65732e205468652064656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+364.8941 446.186 Td
+/F3.0 10.5 Tf
+<3130> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+376.6331 446.186 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 411.686 Td
+/F2.0 13 Tf
+[<31382e342e322e2050726f6772> 20.0195 <616d20446562756767696e67>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 385.126 Td
+/F2.0 10.5 Tf
+<2d642c202d2d6465627567> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 366.346 Td
+/F1.0 10.5 Tf
+<5072696e7420696e666f726d6174696f6e2061626f757420746865206e6f726d616c697a6174696f6e2070726f6365737320746f207374646f75742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 331.846 Td
+/F2.0 13 Tf
+[<31382e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 305.286 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 286.506 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 286.506 Td
+/F2.0 10.5 Tf
+<6f646769206e6f726d616c697a65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+266.835 286.506 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 246.666 Td
+/F2.0 18 Tf
+[<31382e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 218.646 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 199.866 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 172.086 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 153.306 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 113.466 Td
+/F2.0 18 Tf
+<31382e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 85.446 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 85.446 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 85.446 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 85.446 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 85.446 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3337> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+415 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 414 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [418 0 R 426 0 R]
+>>
+endobj
+416 0 obj
+[415 0 R /XYZ 0 841.89 null]
+endobj
+417 0 obj
+[415 0 R /XYZ 0 742.83 null]
+endobj
+418 0 obj
+<< /Border [0 0 0]
+/Dest (_odgi_unchop1)
+/Subtype /Link
+/Rect [229.0473 687.72 271.5303 702]
+/Type /Annot
+>>
+endobj
+419 0 obj
+[415 0 R /XYZ 0 659.19 null]
+endobj
+420 0 obj
+[415 0 R /XYZ 0 619.11 null]
+endobj
+421 0 obj
+[415 0 R /XYZ 0 430.37 null]
+endobj
+422 0 obj
+[415 0 R /XYZ 0 350.53 null]
+endobj
+423 0 obj
+[415 0 R /XYZ 0 270.69 null]
+endobj
+424 0 obj
+[415 0 R /XYZ 0 137.49 null]
+endobj
+425 0 obj
+<< /Limits [(_bugs_17) (_bugs_25)]
+/Names [(_bugs_17) 409 0 R (_bugs_18) 424 0 R (_bugs_19) 449 0 R (_bugs_2) 118 0 R (_bugs_20) 465 0 R (_bugs_21) 484 0 R (_bugs_22) 502 0 R (_bugs_23) 518 0 R (_bugs_24) 536 0 R (_bugs_25) 554 0 R]
+>>
+endobj
+426 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 82.38 401.1446 96.66]
+/Type /Annot
+>>
+endobj
+427 0 obj
+<< /Length 13936
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+[<31382e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 758.646 Td
+/F2.0 10.5 Tf
+<6f646769206e6f726d616c697a65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+128.2185 758.646 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 714.534 Td
+/F2.0 22 Tf
+<31392e206f6467692062696e283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 673.286 Td
+/F2.0 18 Tf
+<31392e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 645.266 Td
+/F1.0 10.5 Tf
+[<6f6467695f62696e202d2062696e6e696e67206f662070616e67656e6f6d652073657175656e636520616e64207061746820696e666f726d6174696f6e20696e20746865206772> 20.0195 <617068>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 605.426 Td
+/F2.0 18 Tf
+[<31392e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 577.406 Td
+/F2.0 10.5 Tf
+<6f6467692062696e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+91.2585 577.406 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+97.7475 577.406 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+134.277 577.406 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+140.1465 577.406 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+163.2675 577.406 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+173.526 577.406 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+213.909 577.406 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 537.566 Td
+/F2.0 18 Tf
+<31392e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.8268 Tw
+
+BT
+48.24 509.546 Td
+/F1.0 10.5 Tf
+[<546865206f6467692062696e28312920636f6d6d616e642062696e73206120676976656e20766172696174696f6e206772> 20.0195 <6170682e205468652070616e67656e6f6d652073657175656e63652c20746865206f6e652d74696d65>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.6768 Tw
+
+BT
+48.24 493.766 Td
+/F1.0 10.5 Tf
+[<7472> 20.0195 <6176657273616c206f6620616c6c206e6f6465732066726f6d20736d616c6c65737420746f206c617267657374206e6f6465206964656e7469666965722c2063616e2062652073756d6d656420757020696e746f2062696e73206f662061>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.894 Tw
+
+BT
+48.24 477.986 Td
+/F1.0 10.5 Tf
+[<7370656369666965642073697a652e2046> 40.0391 <6f7220656163682062696e2c207468652070617468206d657461696e666f726d6174696f6e2069732073756d6d6172697a65642e205468697320656e61626c657320612073756d6d6172697a6564>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.2295 Tw
+
+BT
+48.24 462.206 Td
+/F1.0 10.5 Tf
+[<76696577206f66206769676162617365207363616c65206772> 20.0195 <617068732e20456163682073746570206f662061207061746820697320612062696e20616e6420636f6e6e656374656420746f20697473206e6578742062696e207669612061206c696e6b2e2041>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 446.426 Td
+/F1.0 10.5 Tf
+<6c696e6b2068617320612073746172742062696e206964656e74696669657220616e6420616e20656e642062696e206964656e7469666965722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.0911 Tw
+
+BT
+48.24 430.646 Td
+/F1.0 10.5 Tf
+<54686520636f6e63657074206f66206f6467692062696e20697320616c736f206170706c69656420696e206f64676920> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.0911 Tw
+
+BT
+279.0271 430.646 Td
+/F1.0 10.5 Tf
+<76697a> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.0911 Tw
+
+BT
+293.8216 430.646 Td
+/F1.0 10.5 Tf
+[<2e20412064656d6f6e737472> 20.0195 <6174696f6e206f6620686f7720746865206f6467692062696e204a534f4e206f7574707574>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7804 Tw
+
+BT
+48.24 414.866 Td
+/F1.0 10.5 Tf
+[<63616e206265207573656420666f7220616e20696e746572> 20.0195 <6163746976652076697375616c697a6174696f6e206973207265616c697a656420696e2074686520>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.7804 Tw
+
+BT
+360.7463 414.866 Td
+/F1.0 10.5 Tf
+[<50616e746f6772> 20.0195 <617068>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7804 Tw
+
+BT
+418.8951 414.866 Td
+/F1.0 10.5 Tf
+<2070726f6a6563742e205065722064656661756c742c206f646769> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+48.24 399.086 Td
+/F1.0 10.5 Tf
+<62696e20777269746573207468652062696e7320746f207374646f757420696e2061207461622d64656c696d6974656420666f726d61743a20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+334.0731 399.086 Td
+/F2.0 10.5 Tf
+<706174682e6e616d65> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+391.0566 399.086 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+397.6036 399.086 Td
+/F2.0 10.5 Tf
+<706174682e707265666978> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+457.9576 399.086 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+464.5045 399.086 Td
+/F2.0 10.5 Tf
+<706174682e737566666978> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+523.0 399.086 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+529.547 399.086 Td
+/F2.0 10.5 Tf
+<62696e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2025 Tw
+
+BT
+547.04 399.086 Td
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7469 Tw
+
+BT
+48.24 383.306 Td
+/F1.0 10.5 Tf
+<2862696e206964656e746966696572292c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7469 Tw
+
+BT
+128.6307 383.306 Td
+/F2.0 10.5 Tf
+<6d65616e2e636f76> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7469 Tw
+
+BT
+179.6187 383.306 Td
+/F1.0 10.5 Tf
+[<20286d65616e20636f766572> 20.0195 <616765206f6620746865207061746820696e20746869732062696e292c20>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7469 Tw
+
+BT
+387.4467 383.306 Td
+/F2.0 10.5 Tf
+<6d65616e2e696e76> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7469 Tw
+
+BT
+437.1747 383.306 Td
+/F1.0 10.5 Tf
+[<20286d65616e20696e76657273696f6e2072> 20.0195 <617465>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.588 Tw
+
+BT
+48.24 367.526 Td
+/F1.0 10.5 Tf
+<6f662074686973207061746820696e20746869732062696e292c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.588 Tw
+
+BT
+176.5228 367.526 Td
+/F2.0 10.5 Tf
+<6d65616e2e706f73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.588 Tw
+
+BT
+227.5213 367.526 Td
+/F1.0 10.5 Tf
+<20286d65616e206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e20746869732062696e292c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.588 Tw
+
+BT
+497.9525 367.526 Td
+/F2.0 10.5 Tf
+<66697273742e6e75636c> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.588 Tw
+
+BT
+547.04 367.526 Td
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9015 Tw
+
+BT
+48.24 351.746 Td
+/F1.0 10.5 Tf
+<286669727374206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e20746869732062696e292c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9015 Tw
+
+BT
+300.5838 351.746 Td
+/F2.0 10.5 Tf
+<6c6173742e6e75636c> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9015 Tw
+
+BT
+346.2063 351.746 Td
+/F1.0 10.5 Tf
+<20286c617374206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.6541 Tw
+
+BT
+48.24 335.966 Td
+/F1.0 10.5 Tf
+[<746869732062696e292e205468657365206e75636c656f746964652072> 20.0195 <616e676573206d69676874207370616e20706f736974696f6e73207468617420617265206e6f742070726573656e7420696e207468652062696e2e204578616d706c653a2041>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0047 Tw
+
+BT
+48.24 320.186 Td
+/F1.0 10.5 Tf
+[<72> 20.0195 <616e6765206f6620312d313030206d65616e73207468617420746865206669727374206e75636c656f746964652068617320706f736974696f6e203120616e6420746865206c6173742068617320706f736974696f6e203130302c20627574>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.8143 Tw
+
+BT
+48.24 304.406 Td
+/F1.0 10.5 Tf
+[<6e75636c656f7469646520343520636f756c64206265206c6f636174656420696e20616e6f746865722062696e2e2046> 40.0391 <6f7220616e20657861637420706f736974696f6e616c206f75747075742c20706c656173652073706563696679205b>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.8143 Tw
+
+BT
+537.086 304.406 Td
+/F2.0 10.5 Tf
+<2d6a2c> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 288.626 Td
+/F2.0 10.5 Tf
+<2d2d6a736f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+76.905 288.626 Td
+/F1.0 10.5 Tf
+<5d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.6706 Tw
+
+BT
+48.24 272.846 Td
+/F1.0 10.5 Tf
+<52756e6e696e67206f6467692062696e20696e20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+2.6706 Tw
+
+BT
+160.825 272.846 Td
+/F1.0 10.5 Tf
+[<4861706c6f426c6f636b> 20.0195 <6572>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.6706 Tw
+
+BT
+228.6128 272.846 Td
+/F1.0 10.5 Tf
+<206d6f64652c206f6e6c7920617267756d656e7473205b> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.6706 Tw
+
+BT
+360.4863 272.846 Td
+/F2.0 10.5 Tf
+[<2d622c202d2d6861706c6f2d626c6f636b> 20.0195 <6572>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.6706 Tw
+
+BT
+459.3367 272.846 Td
+/F1.0 10.5 Tf
+<5d2c205b> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.6706 Tw
+
+BT
+474.8909 272.846 Td
+/F2.0 10.5 Tf
+<2d705b4e5d2c202d2d6861706c6f> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.4372 Tw
+
+BT
+48.24 257.066 Td
+/F2.0 10.5 Tf
+[<2d626c6f636b> 20.0195 <65722d6d696e2d70617468735b4e5d>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.4372 Tw
+
+BT
+165.7978 257.066 Td
+/F1.0 10.5 Tf
+<5d2c20616e64205b> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.4372 Tw
+
+BT
+207.3852 257.066 Td
+/F2.0 10.5 Tf
+[<2d635b4e5d2c202d2d6861706c6f2d626c6f636b> 20.0195 <65722d6d696e2d636f766572> 20.0195 <6167655b4e5d>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.4372 Tw
+
+BT
+414.9106 257.066 Td
+/F1.0 10.5 Tf
+[<5d206172652072657175697265642e2041205453> 20.0195 <56206973>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.492 Tw
+
+BT
+48.24 241.286 Td
+/F1.0 10.5 Tf
+<7072696e74656420746f207374646f75743a204561636820726f7720636f72726573706f6e647320746f2061206e6f64652e204561636820636f6c756d6e20636f72726573706f6e647320746f206120706174682e20456163682076616c7565> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 225.506 Td
+/F1.0 10.5 Tf
+[<69732074686520636f766572> 20.0195 <616765206f662061207370656369666963206e6f6465206f66206120737065636966696320706174682e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 185.666 Td
+/F2.0 18 Tf
+<31392e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 150.926 Td
+/F2.0 13 Tf
+[<31392e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 124.366 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 124.366 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 124.366 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2984 Tw
+
+BT
+63.24 105.586 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20696e766573746967617465207468652062696e2066726f6d2e205468652066696c65206e616d6520757375616c6c79>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 89.806 Td
+/F1.0 10.5 Tf
+<656e6473207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.984 89.806 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.474 89.806 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3338> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+428 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 427 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [434 0 R 435 0 R 436 0 R]
+>>
+endobj
+429 0 obj
+[428 0 R /XYZ 0 841.89 null]
+endobj
+430 0 obj
+[428 0 R /XYZ 0 742.83 null]
+endobj
+431 0 obj
+[428 0 R /XYZ 0 697.31 null]
+endobj
+432 0 obj
+[428 0 R /XYZ 0 629.45 null]
+endobj
+433 0 obj
+[428 0 R /XYZ 0 561.59 null]
+endobj
+434 0 obj
+<< /Border [0 0 0]
+/Dest (_odgi_viz1)
+/Subtype /Link
+/Rect [279.0271 427.58 293.8216 441.86]
+/Type /Annot
+>>
+endobj
+435 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://graph-genome.github.io/)
+>>
+/Subtype /Link
+/Rect [360.7463 411.8 418.8951 426.08]
+/Type /Annot
+>>
+endobj
+436 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/tpook92/HaploBlocker)
+>>
+/Subtype /Link
+/Rect [160.825 269.78 228.6128 284.06]
+/Type /Annot
+>>
+endobj
+437 0 obj
+[428 0 R /XYZ 0 209.69 null]
+endobj
+438 0 obj
+[428 0 R /XYZ 0 169.61 null]
+endobj
+439 0 obj
+<< /Length 11939
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 792.006 Td
+/F2.0 13 Tf
+[<31392e342e322e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <41204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 765.446 Td
+/F2.0 10.5 Tf
+<2d662c202d2d6661737461> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+94.2825 765.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+100.152 765.446 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 746.666 Td
+/F1.0 10.5 Tf
+<5772697465207468652070616e67656e6f6d652073657175656e636520746f20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+236.511 746.666 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+259.632 746.666 Td
+/F1.0 10.5 Tf
+[<20696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120666f726d61742e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 712.166 Td
+/F2.0 13 Tf
+<31392e342e332e2042696e204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 685.606 Td
+/F2.0 10.5 Tf
+<2d6e2c202d2d6e756d6265722d62696e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+139.254 685.606 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+145.1235 685.606 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 666.826 Td
+/F1.0 10.5 Tf
+<546865206e756d626572206f662062696e73207468652070616e67656e6f6d652073657175656e63652073686f756c642062652063686f7070656420757020746f2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 639.046 Td
+/F2.0 10.5 Tf
+[<2d77> 69.8242 <2c202d2d62696e2d7769647468>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+123.5058 639.046 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.3753 639.046 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 620.266 Td
+/F1.0 10.5 Tf
+<5468652062696e20776964746820737065636966696573207468652073697a65206f6620656163682062696e2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 592.486 Td
+/F2.0 10.5 Tf
+<2d442c202d2d706174682d64656c696d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.93 592.486 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+135.7995 592.486 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 573.706 Td
+/F1.0 10.5 Tf
+[<416e6e6f7461746520726f77732062> 20.0195 <792070726566697820616e6420737566666978206f6620746869732064656c696d697465722e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 545.926 Td
+/F2.0 10.5 Tf
+<2d612c202d2d6167677265676174652d64656c696d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 527.146 Td
+/F1.0 10.5 Tf
+[<41> 20.0195 <6767726567617465206f6e2070617468207072656669782064656c696d697465722e20417267756d656e7420646570656e6473206f6e205b>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+358.8358 527.146 Td
+/F2.0 10.5 Tf
+<2d442c202d2d706174682d64656c696d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+440.5258 527.146 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+446.3953 527.146 Td
+/F3.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+484.6361 527.146 Td
+/F1.0 10.5 Tf
+<5d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 499.366 Td
+/F2.0 10.5 Tf
+<2d6a2c202d2d6a736f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.263 Tw
+
+BT
+63.24 480.586 Td
+/F1.0 10.5 Tf
+<5072696e742062696e7320616e64206c696e6b7320746f207374646f757420696e2070736575646f204a534f4e20666f726d61742e2045616368206c696e6520697320612076616c6964204a534f4e206f626a6563742c2062757420746865> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5134 Tw
+
+BT
+63.24 464.806 Td
+/F1.0 10.5 Tf
+<77686f6c652066696c65206973206e6f7420612076616c6964204a534f4e212046697273742c20656163682062696e20696e636c7564696e67206974732070616e67656e6f6d652073657175656e6365206973207072696e74656420746f> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.0984 Tw
+
+BT
+63.24 449.026 Td
+/F1.0 10.5 Tf
+[<7374646f757420706572206c696e652e205365636f6e642c20666f722065616368207061746820696e20746865206772> 20.0195 <6170682c20697473207472> 20.0195 <617665727365642062696e7320696e636c7564696e67206d657461696e666f726d6174696f6e3a>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7164 Tw
+
+BT
+63.24 433.246 Td
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7164 Tw
+
+BT
+63.24 433.246 Td
+/F2.0 10.5 Tf
+<62696e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7164 Tw
+
+BT
+80.733 433.246 Td
+/F1.0 10.5 Tf
+<202862696e206964656e746966696572292c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7164 Tw
+
+BT
+173.4986 433.246 Td
+/F2.0 10.5 Tf
+<6d65616e2e636f76> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7164 Tw
+
+BT
+224.4866 433.246 Td
+/F1.0 10.5 Tf
+[<20286d65616e20636f766572> 20.0195 <616765206f6620746865207061746820696e20746869732062696e292c20>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7164 Tw
+
+BT
+459.0401 433.246 Td
+/F2.0 10.5 Tf
+<6d65616e2e696e76> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7164 Tw
+
+BT
+508.7681 433.246 Td
+/F1.0 10.5 Tf
+<20286d65616e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9176 Tw
+
+BT
+63.24 417.466 Td
+/F1.0 10.5 Tf
+[<696e76657273696f6e2072> 20.0195 <617465206f662074686973207061746820696e20746869732062696e292c20>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9176 Tw
+
+BT
+262.4049 417.466 Td
+/F2.0 10.5 Tf
+<6d65616e2e706f73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9176 Tw
+
+BT
+313.4034 417.466 Td
+/F1.0 10.5 Tf
+<20286d65616e206e75636c656f7469646520706f736974696f6e206f662074686973207061746820696e2074686973> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.3574 Tw
+
+BT
+63.24 401.686 Td
+/F1.0 10.5 Tf
+[<62696e292c20616e6420616e20617272> 20.0195 <61> 20.0195 <79206f662072> 20.0195 <616e6765732064657465726d696e696e6720746865206e75636c656f7469646520706f736974696f6e206f6620746865207061746820696e20746869732062696e2e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.4902 Tw
+
+BT
+63.24 385.906 Td
+/F1.0 10.5 Tf
+[<53> 9.7656 <7769746368696e6720666972737420616e64206c617374206e75636c656f7469646520696e20612072> 20.0195 <616e676520726570726573656e7473206120636f6d706c656d656e742072657665727365206f7269656e746174696f6e206f66>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 370.126 Td
+/F1.0 10.5 Tf
+<7468617420706172746963756c61722073657175656e63652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 342.346 Td
+/F2.0 10.5 Tf
+<2d732c202d2d6e6f2d73657173> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 323.566 Td
+/F1.0 10.5 Tf
+<4966205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+77.457 323.566 Td
+/F2.0 10.5 Tf
+<2d6a2c202d2d6a736f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+118.7955 323.566 Td
+/F1.0 10.5 Tf
+<5d206973207365742c206e6f206e75636c656f746964652073657175656e6365732077696c6c206265207072696e74656420746f207374646f757420696e206f7264657220746f2073617665206469736b2073706163652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 295.786 Td
+/F2.0 10.5 Tf
+<2d672c202d2d6e6f2d6761702d6c696e6b73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 277.006 Td
+/F1.0 10.5 Tf
+[<57> 60.0586 <6520646976696465206c696e6b7320696e746f203220636c61737365733a>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+-0.5 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+67.6765 249.226 Td
+/F1.0 10.5 Tf
+<312e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+0.0 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.2408 Tw
+
+BT
+81.24 249.226 Td
+/F1.0 10.5 Tf
+[<746865206c696e6b732077686963682068656c7020746f20666f6c6c6f7720636f6d706c657820766172696174696f6e732e2054686579206e65656420746f206265206472> 20.0195 <61776e2c20656c7365206f6e6520636f756c64206e6f74>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+81.24 233.446 Td
+/F1.0 10.5 Tf
+<666f6c6c6f77207468652073657175656e6365206f66206120706174682e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+-0.5 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+67.6765 211.666 Td
+/F1.0 10.5 Tf
+<322e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+
+0.0 Tc
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9739 Tw
+
+BT
+81.24 211.666 Td
+/F1.0 10.5 Tf
+<746865206c696e6b732068656c70696e6720746f20666f6c6c6f772073696d706c6520766172696174696f6e732e205468657365206c696e6b73206172652063616c6c656420> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9739 Tw
+
+BT
+438.2287 211.666 Td
+/F2.0 10.5 Tf
+<6761702d6c696e6b73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9739 Tw
+
+BT
+486.6022 211.666 Td
+/F1.0 10.5 Tf
+<2e2053756368206c696e6b73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.7733 Tw
+
+BT
+81.24 195.886 Td
+/F1.0 10.5 Tf
+[<736f6c656c7920636f6e6e656374696e67206120706174682066726f6d206c65667420746f207269676874206d61> 20.0195 <79206e6f742062652072656c6576616e7420746f20756e6465727374616e6420612070617468d573>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.0419 Tw
+
+BT
+81.24 180.106 Td
+/F1.0 10.5 Tf
+[<7472> 20.0195 <6176657273616c207468726f756768207468652062696e732e205468657265666f72652c207768656e2074686973206f7074696f6e206973207365742c20746865206761702d6c696e6b7320617265206c656674206f757420736176696e67>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+81.24 164.326 Td
+/F1.0 10.5 Tf
+<6469736b207370616365> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 129.826 Td
+/F2.0 13 Tf
+[<31392e342e342e204861706c6f426c6f636b> 20.0195 <6572204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 103.266 Td
+/F2.0 10.5 Tf
+[<2d622c202d2d6861706c6f2d626c6f636b> 20.0195 <6572>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.4118 Tw
+
+BT
+63.24 84.486 Td
+/F1.0 10.5 Tf
+[<57726974652061205453> 20.0195 <5620746f207374646f757420666f726d617474656420696e2061207761> 20.0195 <7920726561647920666f72204861706c6f426c6f636b> 20.0195 <65723a204561636820726f7720636f72726573706f6e647320746f2061>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.7759 Tw
+
+BT
+63.24 68.706 Td
+/F1.0 10.5 Tf
+[<6e6f64652e204561636820636f6c756d6e20636f72726573706f6e647320746f206120706174682e20456163682076616c75652069732074686520636f766572> 20.0195 <616765206f662061207370656369666963206e6f6465206f662061>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 52.926 Td
+/F1.0 10.5 Tf
+<737065636966696320706174682e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3339> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+440 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 439 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+>>
+endobj
+441 0 obj
+[440 0 R /XYZ 0 841.89 null]
+endobj
+442 0 obj
+[440 0 R /XYZ 0 730.85 null]
+endobj
+443 0 obj
+[440 0 R /XYZ 0 148.51 null]
+endobj
+444 0 obj
+<< /Limits [(_name_12) (_name_20)]
+/Names [(_name_12) 299 0 R (_name_13) 316 0 R (_name_14) 333 0 R (_name_15) 360 0 R (_name_16) 377 0 R (_name_17) 398 0 R (_name_18) 413 0 R (_name_19) 431 0 R (_name_2) 101 0 R (_name_20) 453 0 R]
+>>
+endobj
+445 0 obj
+<< /Length 6423
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 793.926 Td
+/F2.0 10.5 Tf
+[<2d705b4e5d2c202d2d6861706c6f2d626c6f636b> 20.0195 <65722d6d696e2d70617468735b4e5d>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.5961 Tw
+
+BT
+63.24 775.146 Td
+/F1.0 10.5 Tf
+<5370656369667920746865206d696e696d756d206e756d626572206f662070617468732074686174206e65656420746f2062652070726573656e7420696e207468652062696e20746f2061637475616c6c79207265706f72742074686174> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 759.366 Td
+/F1.0 10.5 Tf
+<62696e2e205468652064656661756c742076616c756520697320312e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 731.586 Td
+/F2.0 10.5 Tf
+[<2d635b4e5d2c202d2d6861706c6f2d626c6f636b> 20.0195 <65722d6d696e2d636f766572> 20.0195 <6167655b4e5d>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.614 Tw
+
+BT
+63.24 712.806 Td
+/F1.0 10.5 Tf
+[<5370656369667920746865206d696e696d756d20636f766572> 20.0195 <61676520612070617468206e6565647320746f206861766520696e20612062696e20746f2061637475616c6c79207265706f727420746861742062696e2e20546865>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 697.026 Td
+/F1.0 10.5 Tf
+<64656661756c742076616c756520697320312e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 662.526 Td
+/F2.0 13 Tf
+[<31392e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 635.966 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 617.186 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 617.186 Td
+/F2.0 10.5 Tf
+<6f6467692062696e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+229.875 617.186 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 589.406 Td
+/F2.0 10.5 Tf
+[<2d50> 120.1172 <2c202d2d70726f6772657373>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 570.626 Td
+/F1.0 10.5 Tf
+<5772697465207468652063757272656e742070726f677265737320746f207374646572722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 530.786 Td
+/F2.0 18 Tf
+[<31392e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 502.766 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 483.986 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 456.206 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 437.426 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 397.586 Td
+/F2.0 18 Tf
+<31392e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 369.566 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 369.566 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 369.566 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 369.566 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 369.566 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 329.726 Td
+/F2.0 18 Tf
+[<31392e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 301.706 Td
+/F2.0 10.5 Tf
+<6f6467692062696e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+91.2585 301.706 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e642053696d6f6e204865756d6f73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 257.594 Td
+/F2.0 22 Tf
+<32302e206f646769206d6174726978283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 216.346 Td
+/F2.0 18 Tf
+<32302e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 188.326 Td
+/F1.0 10.5 Tf
+[<6f6467695f6d6174726978202d20777269746520746865206772> 20.0195 <61706820746f706f6c6f677920696e20737061727365206d617472697820666f726d617473>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 148.486 Td
+/F2.0 18 Tf
+[<32302e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 120.466 Td
+/F2.0 10.5 Tf
+<6f646769206d6174726978> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+110.589 120.466 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+117.078 120.466 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+153.6075 120.466 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+159.477 120.466 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+182.598 120.466 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+192.8565 120.466 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+233.2395 120.466 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3430> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+446 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 445 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [450 0 R]
+>>
+endobj
+447 0 obj
+[446 0 R /XYZ 0 681.21 null]
+endobj
+448 0 obj
+[446 0 R /XYZ 0 554.81 null]
+endobj
+449 0 obj
+[446 0 R /XYZ 0 421.61 null]
+endobj
+450 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 366.5 401.1446 380.78]
+/Type /Annot
+>>
+endobj
+451 0 obj
+[446 0 R /XYZ 0 353.75 null]
+endobj
+452 0 obj
+[446 0 R /XYZ 0 285.89 null]
+endobj
+453 0 obj
+[446 0 R /XYZ 0 240.37 null]
+endobj
+454 0 obj
+[446 0 R /XYZ 0 172.51 null]
+endobj
+455 0 obj
+<< /Limits [(_synopsis_14) (_synopsis_22)]
+/Names [(_synopsis_14) 334 0 R (_synopsis_15) 361 0 R (_synopsis_16) 378 0 R (_synopsis_17) 399 0 R (_synopsis_18) 416 0 R (_synopsis_19) 432 0 R (_synopsis_2) 102 0 R (_synopsis_20) 454 0 R (_synopsis_21) 473 0 R (_synopsis_22) 489 0 R]
+>>
+endobj
+456 0 obj
+<< /Length 6079
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<32302e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.3077 Tw
+
+BT
+48.24 758.646 Td
+/F1.0 10.5 Tf
+[<546865206f646769206d617472697828312920636f6d6d616e642067656e6572> 20.0195 <61746573206120737061727365206d617472697820666f726d6174206f7574206f6620746865206772> 20.0195 <61706820746f706f6c6f6779206f66206120676976656e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 742.866 Td
+/F1.0 10.5 Tf
+[<766172696174696f6e206772> 20.0195 <6170682e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 703.026 Td
+/F2.0 18 Tf
+<32302e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 668.286 Td
+/F2.0 13 Tf
+[<32302e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 641.726 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 641.726 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 641.726 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0282 Tw
+
+BT
+63.24 622.946 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206372656174652074686520737061727365206d61747269782066726f6d2e205468652066696c65206e616d65>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 607.166 Td
+/F1.0 10.5 Tf
+<757375616c6c7920656e6473207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+154.086 607.166 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+168.576 607.166 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 572.666 Td
+/F2.0 13 Tf
+<32302e342e322e204d6174726978204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 546.106 Td
+/F2.0 10.5 Tf
+<2d652c202d2d656467652d64657074682d776569676874> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 527.326 Td
+/F1.0 10.5 Tf
+[<57> 60.0586 <656967682065646765732062> 20.0195 <7920746865697220706174682064657074682e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 499.546 Td
+/F2.0 10.5 Tf
+<2d642c202d2d64656c74612d776569676874> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 480.766 Td
+/F1.0 10.5 Tf
+[<57> 60.0586 <656967682065646765732062> 20.0195 <7920746865697220696e76657273652069642064656c74612e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 446.266 Td
+/F2.0 13 Tf
+[<32302e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 419.706 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 400.926 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 400.926 Td
+/F2.0 10.5 Tf
+<6f646769206d6174726978> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+249.2055 400.926 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 361.086 Td
+/F2.0 18 Tf
+[<32302e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 333.066 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 314.286 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 286.506 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 267.726 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 227.886 Td
+/F2.0 18 Tf
+<32302e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 199.866 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 199.866 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 199.866 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 199.866 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 199.866 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 160.026 Td
+/F2.0 18 Tf
+[<32302e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 132.006 Td
+/F2.0 10.5 Tf
+<6f646769206d6174726978> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+110.589 132.006 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 87.894 Td
+/F2.0 22 Tf
+<32312e206f6467692063686f70283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3431> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+457 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 456 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F4.0 111 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [466 0 R]
+>>
+endobj
+458 0 obj
+[457 0 R /XYZ 0 841.89 null]
+endobj
+459 0 obj
+<< /Limits [(_description_16) (_description_24)]
+/Names [(_description_16) 379 0 R (_description_17) 400 0 R (_description_18) 417 0 R (_description_19) 433 0 R (_description_2) 103 0 R (_description_20) 458 0 R (_description_21) 474 0 R (_description_22) 490 0 R (_description_23) 510 0 R (_description_24) 524 0 R]
+>>
+endobj
+460 0 obj
+[457 0 R /XYZ 0 727.05 null]
+endobj
+461 0 obj
+[457 0 R /XYZ 0 686.97 null]
+endobj
+462 0 obj
+[457 0 R /XYZ 0 591.35 null]
+endobj
+463 0 obj
+[457 0 R /XYZ 0 464.95 null]
+endobj
+464 0 obj
+[457 0 R /XYZ 0 385.11 null]
+endobj
+465 0 obj
+[457 0 R /XYZ 0 251.91 null]
+endobj
+466 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 196.8 401.1446 211.08]
+/Type /Annot
+>>
+endobj
+467 0 obj
+[457 0 R /XYZ 0 184.05 null]
+endobj
+468 0 obj
+<< /Limits [(_authors_17) (_authors_25)]
+/Names [(_authors_17) 411 0 R (_authors_18) 429 0 R (_authors_19) 451 0 R (_authors_2) 122 0 R (_authors_20) 467 0 R (_authors_21) 486 0 R (_authors_22) 504 0 R (_authors_23) 520 0 R (_authors_24) 538 0 R (_authors_25) 556 0 R]
+>>
+endobj
+469 0 obj
+[457 0 R /XYZ 0 116.19 null]
+endobj
+470 0 obj
+<< /Length 8710
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<32312e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 758.646 Td
+/F1.0 10.5 Tf
+<6f6467695f63686f70202d20646976696465206e6f64657320696e746f20736d616c6c657220706965636573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 718.806 Td
+/F2.0 18 Tf
+[<32312e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 690.786 Td
+/F2.0 10.5 Tf
+<6f6467692063686f70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+99.48 690.786 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.969 690.786 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+142.4985 690.786 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+148.368 690.786 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+171.489 690.786 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+181.7475 690.786 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+221.3955 690.786 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+227.265 690.786 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+250.386 690.786 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+260.6445 690.786 Td
+/F2.0 10.5 Tf
+<2d632c202d2d63686f702d746f> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+321.366 690.786 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+327.2355 690.786 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+335.247 690.786 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+345.5055 690.786 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+385.8885 690.786 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 650.946 Td
+/F2.0 18 Tf
+<32312e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9148 Tw
+
+BT
+48.24 622.926 Td
+/F1.0 10.5 Tf
+[<546865206f6467692063686f7028312920636f6d6d616e642063686f7073206c6f6e67206e6f64657320696e746f2073686f7274206f6e6573207768696c652070726573657276696e6720746865206772> 20.0195 <61706820746f706f6c6f6779>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 607.146 Td
+/F1.0 10.5 Tf
+<616e64206e6f6465206f726465722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 567.306 Td
+/F2.0 18 Tf
+<32312e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 532.566 Td
+/F2.0 13 Tf
+[<32312e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 506.006 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 506.006 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 506.006 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 487.226 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f2063686f702e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+487.7023 487.226 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+502.1923 487.226 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 459.446 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 459.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 459.446 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 440.666 Td
+/F1.0 10.5 Tf
+[<5772697465207468652063686f7065642073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+289.1053 440.666 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+312.2263 440.666 Td
+/F1.0 10.5 Tf
+<2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+479.5753 440.666 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+494.0653 440.666 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 406.166 Td
+/F2.0 13 Tf
+<32312e342e322e2043686f70204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 379.606 Td
+/F2.0 10.5 Tf
+<2d632c202d2d63686f702d746f> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.9615 379.606 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.831 379.606 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 360.826 Td
+/F1.0 10.5 Tf
+<446976696465206e6f6465732074686174206c6f6e676572207468616e20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+214.1985 360.826 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+222.21 360.826 Td
+/F1.0 10.5 Tf
+<20696e746f206e6f646573206e6f206c6f6e676572207468616e20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+356.1795 360.826 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+364.191 360.826 Td
+/F1.0 10.5 Tf
+[<207768696c65206d61696e7461696e696e67206772> 20.0195 <61706820746f706f6c6f6779> 89.8438 <2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 326.326 Td
+/F2.0 13 Tf
+<32312e342e332e20546872656164696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 299.766 Td
+/F2.0 10.5 Tf
+<2d742c202d2d74687265616473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.951 299.766 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.8205 299.766 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 280.986 Td
+/F1.0 10.5 Tf
+[<4e756d626572206f66207468726561647320746f2075736520666f722074686520706172> 20.0195 <616c6c656c206f706572> 20.0195 <6174696f6e732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 246.486 Td
+/F2.0 13 Tf
+<32312e342e342e2050726f63657373696e6720496e666f726d6174696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 219.926 Td
+/F2.0 10.5 Tf
+<2d642c202d2d6465627567> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 201.146 Td
+/F1.0 10.5 Tf
+<5072696e7420696e666f726d6174696f6e2061626f7574207468652070726f6365737320746f207374646572722e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 166.646 Td
+/F2.0 13 Tf
+[<32312e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 140.086 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 121.306 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 121.306 Td
+/F2.0 10.5 Tf
+<6f6467692063686f70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+238.0965 121.306 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3432> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+471 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 470 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+>>
+endobj
+472 0 obj
+[471 0 R /XYZ 0 841.89 null]
+endobj
+473 0 obj
+[471 0 R /XYZ 0 742.83 null]
+endobj
+474 0 obj
+[471 0 R /XYZ 0 674.97 null]
+endobj
+475 0 obj
+[471 0 R /XYZ 0 591.33 null]
+endobj
+476 0 obj
+[471 0 R /XYZ 0 551.25 null]
+endobj
+477 0 obj
+[471 0 R /XYZ 0 424.85 null]
+endobj
+478 0 obj
+[471 0 R /XYZ 0 345.01 null]
+endobj
+479 0 obj
+[471 0 R /XYZ 0 265.17 null]
+endobj
+480 0 obj
+[471 0 R /XYZ 0 185.33 null]
+endobj
+481 0 obj
+<< /Length 8697
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+[<32312e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 758.646 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 739.866 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 712.086 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 693.306 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 653.466 Td
+/F2.0 18 Tf
+<32312e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 625.446 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 625.446 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 625.446 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 625.446 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 625.446 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 585.606 Td
+/F2.0 18 Tf
+[<32312e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 557.586 Td
+/F2.0 10.5 Tf
+<6f6467692063686f70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+99.48 557.586 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 513.474 Td
+/F2.0 22 Tf
+[<32322e206f646769206c61> 20.0195 <796f7574283129>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 472.226 Td
+/F2.0 18 Tf
+<32322e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 444.206 Td
+/F1.0 10.5 Tf
+[<6f6467695f6c61> 20.0195 <796f7574202d207573652053474420746f206d616b> 20.0195 <65203244206c61> 20.0195 <796f757473206f6620746865206772> 20.0195 <617068>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 404.366 Td
+/F2.0 18 Tf
+[<32322e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 376.346 Td
+/F2.0 10.5 Tf
+[<6f646769206c61> 20.0195 <796f7574>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+107.2813 376.346 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.7703 376.346 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+150.2998 376.346 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+156.1693 376.346 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+179.2903 376.346 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+189.5488 376.346 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+229.1968 376.346 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+235.0663 376.346 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+258.1873 376.346 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+268.4458 376.346 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+308.8288 376.346 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 336.506 Td
+/F2.0 18 Tf
+<32322e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.2196 Tw
+
+BT
+48.24 308.486 Td
+/F1.0 10.5 Tf
+[<546865206f646769206c61> 20.0195 <796f757428312920636f6d6d616e64206472> 20.0195 <617773203244206c61> 20.0195 <796f757473206f6620746865206772> 20.0195 <617068207573696e672073746f63686173746963206772> 20.0195 <616469656e742064657363656e742028534744292e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.6579 Tw
+
+BT
+48.24 292.706 Td
+/F1.0 10.5 Tf
+[<54686520696e707574206772> 20.0195 <617068206d75737420626520736f7274656420616e642069642d636f6d7061637465642e2054686520616c676f726974686d20697473656c662069732064657363726962656420696e20>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+2.6579 Tw
+
+BT
+515.8237 292.706 Td
+/F1.0 10.5 Tf
+[<4772> 20.0195 <617068>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+1.8458 Tw
+
+BT
+48.24 276.926 Td
+/F1.0 10.5 Tf
+[<4472> 20.0195 <6177696e672062> 20.0195 <792053746f63686173746963204772> 20.0195 <616469656e742044657363656e74>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.8458 Tw
+
+BT
+255.0909 276.926 Td
+/F1.0 10.5 Tf
+[<2e2054686520666f7263652d6469726563746564206772> 20.0195 <617068206472> 20.0195 <6177696e6720616c676f726974686d206d696e696d697a6573>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.7338 Tw
+
+BT
+48.24 261.146 Td
+/F1.0 10.5 Tf
+[<746865206772> 20.0195 <617068d57320656e657267792066756e6374696f6e206f7220737472657373206c6576656c2e204974206170706c6965732053474420746f206d6f766520612073696e676c652070616972206f66206e6f64657320617420612074696d652e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 245.366 Td
+/F1.0 10.5 Tf
+[<5468652072656e6465726564206772> 20.0195 <617068206973207772697474656e20696e2053> 20.0195 <56> 20.0195 <4720666f726d61742e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 205.526 Td
+/F2.0 18 Tf
+<32322e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 170.786 Td
+/F2.0 13 Tf
+[<32322e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 144.226 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 144.226 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 144.226 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 125.446 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f206c61> 20.0195 <796f75742e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+494.6636 125.446 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+509.1536 125.446 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 97.666 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 97.666 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 97.666 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 78.886 Td
+/F1.0 10.5 Tf
+[<5772697465207468652072656e6465726564206c61> 20.0195 <796f757420696e2053> 20.0195 <56> 20.0195 <4720666f726d617420746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+281.3349 78.886 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+304.4559 78.886 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3433> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+482 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 481 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [485 0 R 491 0 R 492 0 R]
+>>
+endobj
+483 0 obj
+[482 0 R /XYZ 0 841.89 null]
+endobj
+484 0 obj
+[482 0 R /XYZ 0 677.49 null]
+endobj
+485 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 622.38 401.1446 636.66]
+/Type /Annot
+>>
+endobj
+486 0 obj
+[482 0 R /XYZ 0 609.63 null]
+endobj
+487 0 obj
+[482 0 R /XYZ 0 541.77 null]
+endobj
+488 0 obj
+[482 0 R /XYZ 0 496.25 null]
+endobj
+489 0 obj
+[482 0 R /XYZ 0 428.39 null]
+endobj
+490 0 obj
+[482 0 R /XYZ 0 360.53 null]
+endobj
+491 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://arxiv.org/abs/1710.04626)
+>>
+/Subtype /Link
+/Rect [515.8237 289.64 547.04 303.92]
+/Type /Annot
+>>
+endobj
+492 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://arxiv.org/abs/1710.04626)
+>>
+/Subtype /Link
+/Rect [48.24 273.86 255.0909 288.14]
+/Type /Annot
+>>
+endobj
+493 0 obj
+[482 0 R /XYZ 0 229.55 null]
+endobj
+494 0 obj
+[482 0 R /XYZ 0 189.47 null]
+endobj
+495 0 obj
+<< /Length 8202
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 792.006 Td
+/F2.0 13 Tf
+<32322e342e322e20534744204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 765.446 Td
+/F2.0 10.5 Tf
+<2d6d2c202d2d697465722d6d6178> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+120.207 765.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+126.0765 765.446 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 746.666 Td
+/F1.0 10.5 Tf
+[<546865206d6178696d756d206e756d626572206f662069746572> 20.0195 <6174696f6e7320746f2072756e20746865206c61> 20.0195 <796f75742e2044656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+384.4766 746.666 Td
+/F3.0 10.5 Tf
+<3330> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+396.2156 746.666 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 718.886 Td
+/F2.0 10.5 Tf
+<2d702c202d2d6e2d7069766f7473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.424 718.886 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+119.2935 718.886 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 700.106 Td
+/F1.0 10.5 Tf
+[<546865206e756d626572206f66207069766f747320666f7220737061727365206c61> 20.0195 <796f75742e2044656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+312.9193 700.106 Td
+/F3.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+318.7888 700.106 Td
+/F1.0 10.5 Tf
+[<206c656164696e6720746f2061206e6f6e2d737061727365206c61> 20.0195 <796f75742e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 672.326 Td
+/F2.0 10.5 Tf
+<2d652c202d2d657073> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.657 672.326 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.5265 672.326 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 653.546 Td
+/F1.0 10.5 Tf
+[<546865206c6561726e696e672072> 20.0195 <61746520666f7220534744206c61> 20.0195 <796f75742e2044656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+280.2326 653.546 Td
+/F3.0 10.5 Tf
+<302e3031> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+300.4661 653.546 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 619.046 Td
+/F2.0 13 Tf
+[<32322e342e332e2053> 20.0195 <56> 20.0195 <47204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 592.486 Td
+/F2.0 10.5 Tf
+<2d782c202d2d782d70616464696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+123.84 592.486 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.7095 592.486 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 573.706 Td
+/F1.0 10.5 Tf
+[<5468652070616464696e67206265747765656e2074686520636f6e6e656374656420636f6d706f6e656e74206c61> 20.0195 <796f7574732e2044656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+397.3183 573.706 Td
+/F3.0 10.5 Tf
+<31302e30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+417.5518 573.706 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 545.926 Td
+/F2.0 10.5 Tf
+<2d522c202d2d72656e6465722d7363616c65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+137.8155 545.926 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+143.685 545.926 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 527.146 Td
+/F1.0 10.5 Tf
+[<53> 20.0195 <56> 20.0195 <47207363616c696e672044656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+173.5106 527.146 Td
+/F3.0 10.5 Tf
+<352e30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+187.8746 527.146 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 492.646 Td
+/F2.0 13 Tf
+<32322e342e342e2050726f63657373696e6720496e666f726d6174696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 466.086 Td
+/F2.0 10.5 Tf
+<2d642c202d2d6465627567> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 447.306 Td
+/F1.0 10.5 Tf
+<5072696e7420696e666f726d6174696f6e2061626f75742074686520636f6d706f6e656e747320746f207374646f75742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 412.806 Td
+/F2.0 13 Tf
+[<32322e342e352e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 386.246 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 367.466 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 367.466 Td
+/F2.0 10.5 Tf
+[<6f646769206c61> 20.0195 <796f7574>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+245.8978 367.466 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 327.626 Td
+/F2.0 18 Tf
+[<32322e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 299.606 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 280.826 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 253.046 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 234.266 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 194.426 Td
+/F2.0 18 Tf
+<32322e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 166.406 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 166.406 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 166.406 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 166.406 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 166.406 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 126.566 Td
+/F2.0 18 Tf
+[<32322e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 98.546 Td
+/F2.0 10.5 Tf
+[<6f646769206c61> 20.0195 <796f7574>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+107.2813 98.546 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2c20416e64726561204775617272> 20.0195 <6163696e6f2c20616e642053696d6f6e204865756d6f732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3434> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+496 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 495 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [503 0 R]
+>>
+endobj
+497 0 obj
+[496 0 R /XYZ 0 841.89 null]
+endobj
+498 0 obj
+[496 0 R /XYZ 0 637.73 null]
+endobj
+499 0 obj
+[496 0 R /XYZ 0 511.33 null]
+endobj
+500 0 obj
+[496 0 R /XYZ 0 431.49 null]
+endobj
+501 0 obj
+[496 0 R /XYZ 0 351.65 null]
+endobj
+502 0 obj
+[496 0 R /XYZ 0 218.45 null]
+endobj
+503 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 163.34 401.1446 177.62]
+/Type /Annot
+>>
+endobj
+504 0 obj
+[496 0 R /XYZ 0 150.59 null]
+endobj
+505 0 obj
+<< /Length 7892
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 782.394 Td
+/F2.0 22 Tf
+<32332e206f64676920666c617474656e283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 741.146 Td
+/F2.0 18 Tf
+<32332e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 713.126 Td
+/F1.0 10.5 Tf
+[<6f6467695f666c617474656e202d2067656e6572> 20.0195 <617465206c696e656172697a6174696f6e206f6620746865206772> 20.0195 <617068>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 673.286 Td
+/F2.0 18 Tf
+[<32332e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 645.266 Td
+/F2.0 10.5 Tf
+<6f64676920666c617474656e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.4865 645.266 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+115.9755 645.266 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+152.505 645.266 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+158.3745 645.266 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+181.4955 645.266 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+191.754 645.266 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+232.137 645.266 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 605.426 Td
+/F2.0 18 Tf
+<32332e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 577.406 Td
+/F1.0 10.5 Tf
+[<546865206f64676920666c617474656e28312920636f6d6d616e642070726f6a6563747320746865206772> 20.0195 <6170682073657175656e636520616e6420706174687320696e746f2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120616e64204245442e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 537.566 Td
+/F2.0 18 Tf
+<32332e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 502.826 Td
+/F2.0 13 Tf
+[<32332e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 476.266 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 476.266 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 476.266 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 457.486 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20666c617474656e2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+496.1968 457.486 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+510.6868 457.486 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 422.986 Td
+/F2.0 13 Tf
+<32332e342e322e204f7574707574204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 396.426 Td
+/F2.0 10.5 Tf
+<2d662c202d2d6661737461> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+94.2825 396.426 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+100.152 396.426 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 377.646 Td
+/F1.0 10.5 Tf
+[<57726974652074686520636f6e636174656e61746564206e6f64652073657175656e63657320696e2046> 69.8242 <4153> 20.0195 <54> 60.0586 <4120666f726d617420746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+361.126 377.646 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+384.247 377.646 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 349.866 Td
+/F2.0 10.5 Tf
+<2d6e2c202d2d6e616d652d736571> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+121.551 349.866 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+127.4205 349.866 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0339 Tw
+
+BT
+63.24 331.086 Td
+/F1.0 10.5 Tf
+[<546865206e616d6520746f2075736520666f722074686520636f6e636174656e61746564206772> 20.0195 <6170682073657175656e63652e2044656661756c7420697320746865206e616d65206f662074686520696e7075742066696c65>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 315.306 Td
+/F1.0 10.5 Tf
+<7768696368207761732073706563696669656420766961205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+188.3475 315.306 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+224.877 315.306 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+230.7465 315.306 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+253.8675 315.306 Td
+/F1.0 10.5 Tf
+<5d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 287.526 Td
+/F2.0 10.5 Tf
+<2d622c202d2d626564> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.198 287.526 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+96.0675 287.526 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2826 Tw
+
+BT
+63.24 268.746 Td
+/F1.0 10.5 Tf
+[<577269746520746865206d617070696e67206265747765656e206772> 20.0195 <61706820706174687320616e6420746865206c696e656172697a65642046> 69.8242 <4153> 20.0195 <54> 60.0586 <412073657175656e636520696e2042454420666f726d617420746f>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 252.966 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+86.361 252.966 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 218.466 Td
+/F2.0 13 Tf
+[<32332e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 191.906 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 173.126 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 173.126 Td
+/F2.0 10.5 Tf
+<6f64676920666c617474656e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+248.103 173.126 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 133.286 Td
+/F2.0 18 Tf
+[<32332e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 105.266 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 86.486 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3435> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+506 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 505 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+>>
+endobj
+507 0 obj
+[506 0 R /XYZ 0 841.89 null]
+endobj
+508 0 obj
+[506 0 R /XYZ 0 765.17 null]
+endobj
+509 0 obj
+[506 0 R /XYZ 0 697.31 null]
+endobj
+510 0 obj
+[506 0 R /XYZ 0 629.45 null]
+endobj
+511 0 obj
+[506 0 R /XYZ 0 561.59 null]
+endobj
+512 0 obj
+[506 0 R /XYZ 0 521.51 null]
+endobj
+513 0 obj
+[506 0 R /XYZ 0 441.67 null]
+endobj
+514 0 obj
+[506 0 R /XYZ 0 237.15 null]
+endobj
+515 0 obj
+[506 0 R /XYZ 0 157.31 null]
+endobj
+516 0 obj
+<< /Length 8297
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 793.926 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 775.146 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 735.306 Td
+/F2.0 18 Tf
+<32332e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 707.286 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 707.286 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 707.286 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 707.286 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 707.286 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 667.446 Td
+/F2.0 18 Tf
+[<32332e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 639.426 Td
+/F2.0 10.5 Tf
+<6f64676920666c617474656e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.4865 639.426 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 595.314 Td
+/F2.0 22 Tf
+<32342e206f64676920627265616b283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 554.066 Td
+/F2.0 18 Tf
+<32342e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 526.046 Td
+/F1.0 10.5 Tf
+[<6f6467695f627265616b202d20627265616b206379636c657320696e20746865206772> 20.0195 <61706820616e642064726f7020697473207061746873>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 486.206 Td
+/F2.0 18 Tf
+[<32342e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 458.186 Td
+/F2.0 10.5 Tf
+<6f64676920627265616b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.003 458.186 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+111.492 458.186 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+148.0215 458.186 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+153.891 458.186 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+177.012 458.186 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+187.2705 458.186 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+226.9185 458.186 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+232.788 458.186 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+255.909 458.186 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+266.1675 458.186 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+306.5505 458.186 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 418.346 Td
+/F2.0 18 Tf
+<32342e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.3841 Tw
+
+BT
+48.24 390.326 Td
+/F1.0 10.5 Tf
+[<546865206f64676920627265616b28312920636f6d6d616e642066696e6473206379636c657320696e2061206772> 20.0195 <6170682076696120>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.3841 Tw
+
+BT
+327.5593 390.326 Td
+/F1.0 10.5 Tf
+<627265616474682d666972737420736561726368202842465329> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.3841 Tw
+
+BT
+456.3436 390.326 Td
+/F1.0 10.5 Tf
+<20616e6420627265616b73207468656d2c> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 374.546 Td
+/F1.0 10.5 Tf
+[<616c736f2064726f7070696e6720746865206772> 20.0195 <617068d5732070617468732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 334.706 Td
+/F2.0 18 Tf
+<32342e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 299.966 Td
+/F2.0 13 Tf
+[<32342e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 273.406 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 273.406 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 273.406 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 254.626 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f20627265616b2e205468652066696c65206e616d6520757375616c6c7920656e6473207769746820>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+492.4168 254.626 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+506.9068 254.626 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 226.846 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 226.846 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 226.846 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 208.066 Td
+/F1.0 10.5 Tf
+[<5772697465207468652062726f6b> 20.0195 <656e206772> 20.0195 <61706820746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+196.2851 208.066 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+219.4061 208.066 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 173.566 Td
+/F2.0 13 Tf
+<32342e342e322e204379636c65204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 147.006 Td
+/F2.0 10.5 Tf
+<2d632c202d2d6379636c652d6d61782d6270> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+139.6215 147.006 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+145.491 147.006 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 128.226 Td
+/F1.0 10.5 Tf
+<546865206d6178696d756d206379636c65206c656e67746820617420776869636820746f20627265616b2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 100.446 Td
+/F2.0 10.5 Tf
+<2d732c202d2d6d61782d7365617263682d6270> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+147.7905 100.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+153.66 100.446 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 81.666 Td
+/F1.0 10.5 Tf
+<546865206d6178696d756d20736561726368207370616365206f6620656163682042465320676976656e20696e206e756d626572206f6620626173652070616972732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3436> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+517 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 516 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [519 0 R 525 0 R]
+>>
+endobj
+518 0 obj
+[517 0 R /XYZ 0 759.33 null]
+endobj
+519 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 704.22 401.1446 718.5]
+/Type /Annot
+>>
+endobj
+520 0 obj
+[517 0 R /XYZ 0 691.47 null]
+endobj
+521 0 obj
+[517 0 R /XYZ 0 623.61 null]
+endobj
+522 0 obj
+[517 0 R /XYZ 0 578.09 null]
+endobj
+523 0 obj
+[517 0 R /XYZ 0 510.23 null]
+endobj
+524 0 obj
+[517 0 R /XYZ 0 442.37 null]
+endobj
+525 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://en.wikipedia.org/wiki/Breadth-first_search)
+>>
+/Subtype /Link
+/Rect [327.5593 387.26 456.3436 401.54]
+/Type /Annot
+>>
+endobj
+526 0 obj
+[517 0 R /XYZ 0 358.73 null]
+endobj
+527 0 obj
+[517 0 R /XYZ 0 318.65 null]
+endobj
+528 0 obj
+<< /Limits [(_graph_files_io_2) (_graph_files_io_8)]
+/Names [(_graph_files_io_2) 128 0 R (_graph_files_io_20) 476 0 R (_graph_files_io_21) 494 0 R (_graph_files_io_22) 512 0 R (_graph_files_io_23) 527 0 R (_graph_files_io_24) 549 0 R (_graph_files_io_25) 566 0 R (_graph_files_io_26) 581 0 R (_graph_files_io_27) 604 0 R (_graph_files_io_3) 147 0 R (_graph_files_io_4) 173 0 R (_graph_files_io_5) 201 0 R (_graph_files_io_6) 215 0 R (_graph_files_io_7) 234 0 R (_graph_files_io_8) 253 0 R]
+>>
+endobj
+529 0 obj
+<< /Limits [(__anchor-top) (_graph_files_io_8)]
+/Kids [119 0 R 468 0 R 646 0 R 264 0 R 425 0 R 589 0 R 163 0 R 459 0 R 636 0 R 251 0 R 553 0 R 372 0 R 120 0 R 528 0 R]
+>>
+endobj
+530 0 obj
+<< /Limits [(_graph_files_io_9) (_visualization_options)]
+/Kids [322 0 R 444 0 R 615 0 R 216 0 R 357 0 R 593 0 R 142 0 R 580 0 R 388 0 R 239 0 R 370 0 R 551 0 R 182 0 R 455 0 R 634 0 R 268 0 R 621 0 R]
+>>
+endobj
+531 0 obj
+[517 0 R /XYZ 0 192.25 null]
+endobj
+532 0 obj
+<< /Length 9304
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 793.926 Td
+/F2.0 10.5 Tf
+<2d752c202d2d7265706561742d75702d746f> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+136.4925 793.926 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+142.362 793.926 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 775.146 Td
+/F1.0 10.5 Tf
+[<49746572> 20.0195 <617465206379636c6520627265616b696e6720757020746f20>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+202.7323 775.146 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+210.7438 775.146 Td
+/F1.0 10.5 Tf
+<2074696d6573206f722073746f70206966206e6f206e6577206564676573206172652072656d6f7665642e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 747.366 Td
+/F2.0 10.5 Tf
+<2d642c202d2d73686f77> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 728.586 Td
+/F1.0 10.5 Tf
+<5072696e742074686520656467657320776520776f756c642072656d6f766520746f207374646f75742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 694.086 Td
+/F2.0 13 Tf
+[<32342e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 667.526 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 648.746 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 648.746 Td
+/F2.0 10.5 Tf
+<6f64676920627265616b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+243.6195 648.746 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 608.906 Td
+/F2.0 18 Tf
+[<32342e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 580.886 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 562.106 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 534.326 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 515.546 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 475.706 Td
+/F2.0 18 Tf
+<32342e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 447.686 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 447.686 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 447.686 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 447.686 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 447.686 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 407.846 Td
+/F2.0 18 Tf
+[<32342e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 379.826 Td
+/F2.0 10.5 Tf
+<6f64676920627265616b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.003 379.826 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 335.714 Td
+/F2.0 22 Tf
+<32352e206f6467692070617468696e646578283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 294.466 Td
+/F2.0 18 Tf
+<32352e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 266.446 Td
+/F1.0 10.5 Tf
+<6f6467695f70617468696e646578202d206372656174652061207061746820696e64657820666f72206120676976656e2070617468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 226.606 Td
+/F2.0 18 Tf
+[<32352e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 198.586 Td
+/F2.0 10.5 Tf
+<6f6467692070617468696e646578> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+128.313 198.586 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+134.802 198.586 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+171.3315 198.586 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+177.201 198.586 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+200.322 198.586 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+210.5805 198.586 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+250.2285 198.586 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+256.098 198.586 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+279.219 198.586 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+289.4775 198.586 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+329.8605 198.586 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 158.746 Td
+/F2.0 18 Tf
+<32352e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.5186 Tw
+
+BT
+48.24 130.726 Td
+/F1.0 10.5 Tf
+[<546865206f6467692070617468696e64657828312920636f6d6d616e642067656e6572> 20.0195 <617465732061207061746820696e646578206f662061206772> 20.0195 <6170682e20497420757365732073756363696e637420646174612073747275637475726573>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4572 Tw
+
+BT
+48.24 114.946 Td
+/F1.0 10.5 Tf
+<746f20656e636f64652074686520696e6465782e20546865207061746820696e64657820726570726573656e7473206120737562736574206f6620746865206665617475726573206f6620612066756c6c79207265616c697a656420> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.4572 Tw
+
+BT
+501.2753 114.946 Td
+/F1.0 10.5 Tf
+<786720696e646578> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4572 Tw
+
+BT
+544.415 114.946 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5733 Tw
+
+BT
+48.24 99.166 Td
+/F1.0 10.5 Tf
+<486176696e672061207061746820696e6465782c2077652063616e20757365206f64676920> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+1.5733 Tw
+
+BT
+249.1126 99.166 Td
+/F1.0 10.5 Tf
+<70616e706f73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5733 Tw
+
+BT
+285.4531 99.166 Td
+/F1.0 10.5 Tf
+<20746f20676f2066726f6d20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5733 Tw
+
+BT
+348.8769 99.166 Td
+/F2.0 10.5 Tf
+<706174683a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5733 Tw
+
+BT
+419.7309 99.166 Td
+/F1.0 10.5 Tf
+<20> Tj
+/F1.1 10.5 Tf
+<2120> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5733 Tw
+
+BT
+438.8165 99.166 Td
+/F2.0 10.5 Tf
+<70616e67656e6f6d653a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.5733 Tw
+
+BT
+547.04 99.166 Td
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8024 Tw
+
+BT
+48.24 83.386 Td
+/F1.0 10.5 Tf
+[<776869636820697320696d706f7274616e74207768656e206e617669676174696e67206c61726765206772> 20.0195 <6170687320696e20616e20696e746572> 20.0195 <616374697665206d616e6e6572206c696b> 20.0195 <6520696e2074686520>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.8024 Tw
+
+BT
+488.8912 83.386 Td
+/F1.0 10.5 Tf
+[<50616e746f6772> 20.0195 <617068>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8024 Tw
+
+BT
+547.04 83.386 Td
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 67.606 Td
+/F1.0 10.5 Tf
+<70726f6a6563742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3437> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+533 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 532 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F1.1 80 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [537 0 R 543 0 R 544 0 R 545 0 R]
+>>
+endobj
+534 0 obj
+[533 0 R /XYZ 0 712.77 null]
+endobj
+535 0 obj
+[533 0 R /XYZ 0 632.93 null]
+endobj
+536 0 obj
+[533 0 R /XYZ 0 499.73 null]
+endobj
+537 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 444.62 401.1446 458.9]
+/Type /Annot
+>>
+endobj
+538 0 obj
+[533 0 R /XYZ 0 431.87 null]
+endobj
+539 0 obj
+[533 0 R /XYZ 0 364.01 null]
+endobj
+540 0 obj
+[533 0 R /XYZ 0 318.49 null]
+endobj
+541 0 obj
+[533 0 R /XYZ 0 250.63 null]
+endobj
+542 0 obj
+[533 0 R /XYZ 0 182.77 null]
+endobj
+543 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/xg)
+>>
+/Subtype /Link
+/Rect [501.2753 111.88 544.415 126.16]
+/Type /Annot
+>>
+endobj
+544 0 obj
+<< /Border [0 0 0]
+/Dest (_odgi_panpos1)
+/Subtype /Link
+/Rect [249.1126 96.1 285.4531 110.38]
+/Type /Annot
+>>
+endobj
+545 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://graph-genome.github.io/)
+>>
+/Subtype /Link
+/Rect [488.8912 80.32 547.04 94.6]
+/Type /Annot
+>>
+endobj
+546 0 obj
+<< /Length 7861
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<32352e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 751.926 Td
+/F2.0 13 Tf
+[<32352e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 725.366 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 725.366 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 725.366 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.1339 Tw
+
+BT
+63.24 706.586 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820746f2067656e6572> 20.0195 <6174652061207061746820696e6465782066726f6d2e205468652066696c65206e616d6520757375616c6c79>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 690.806 Td
+/F1.0 10.5 Tf
+<656e6473207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.984 690.806 Td
+/F3.0 10.5 Tf
+<2e6f67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.474 690.806 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 663.026 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 663.026 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 663.026 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 644.246 Td
+/F1.0 10.5 Tf
+<577269746520746865207061746820696e64657820746f20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+182.0895 644.246 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+205.2105 644.246 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 609.746 Td
+/F2.0 13 Tf
+[<32352e342e322e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 583.186 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 564.406 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 564.406 Td
+/F2.0 10.5 Tf
+<6f6467692070617468696e646578> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+266.9295 564.406 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 524.566 Td
+/F2.0 18 Tf
+[<32352e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 496.546 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 477.766 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 449.986 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 431.206 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 391.366 Td
+/F2.0 18 Tf
+<32352e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 363.346 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 363.346 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 363.346 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 363.346 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 363.346 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 323.506 Td
+/F2.0 18 Tf
+[<32352e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 295.486 Td
+/F2.0 10.5 Tf
+<6f6467692070617468696e646578> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+128.313 295.486 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <792053696d6f6e204865756d6f732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 251.374 Td
+/F2.0 22 Tf
+<32362e206f6467692070616e706f73283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 210.126 Td
+/F2.0 18 Tf
+<32362e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 182.106 Td
+/F1.0 10.5 Tf
+<6f6467695f70616e706f73202d20676574207468652070616e67656e6f6d6520706f736974696f6e206f66206120676976656e207061746820616e64206e75636c656f7469646520706f736974696f6e2028312d626173656429> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 142.266 Td
+/F2.0 18 Tf
+[<32362e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 114.246 Td
+/F2.0 10.5 Tf
+<6f6467692070616e706f73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+112.1325 114.246 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+118.6215 114.246 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+155.151 114.246 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+161.0205 114.246 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+184.1415 114.246 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+194.4 114.246 Td
+/F2.0 10.5 Tf
+<2d702c202d2d70617468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+241.0305 114.246 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+246.9 114.246 Td
+/F3.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+285.1408 114.246 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+295.3993 114.246 Td
+/F2.0 10.5 Tf
+<2d6e2c202d2d6e75632d706f73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+359.0293 114.246 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+364.8988 114.246 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+372.9103 114.246 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+383.1688 114.246 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+423.5518 114.246 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3438> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+547 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 546 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [555 0 R]
+>>
+endobj
+548 0 obj
+[547 0 R /XYZ 0 841.89 null]
+endobj
+549 0 obj
+[547 0 R /XYZ 0 770.61 null]
+endobj
+550 0 obj
+[547 0 R /XYZ 0 628.43 null]
+endobj
+551 0 obj
+<< /Limits [(_program_information_22) (_random_sort)]
+/Names [(_program_information_22) 514 0 R (_program_information_23) 534 0 R (_program_information_24) 550 0 R (_program_information_25) 568 0 R (_program_information_26) 586 0 R (_program_information_27) 606 0 R (_program_information_28) 626 0 R (_program_information_29) 641 0 R (_program_information_3) 152 0 R (_program_information_4) 189 0 R (_program_information_5) 203 0 R (_program_information_6) 222 0 R (_program_information_7) 240 0 R (_program_information_8) 259 0 R (_program_information_9) 279 0 R (_random_sort) 175 0 R]
+>>
+endobj
+552 0 obj
+[547 0 R /XYZ 0 548.59 null]
+endobj
+553 0 obj
+<< /Limits [(_exit_status_16) (_exit_status_3)]
+/Names [(_exit_status_16) 408 0 R (_exit_status_17) 423 0 R (_exit_status_18) 448 0 R (_exit_status_19) 464 0 R (_exit_status_2) 137 0 R (_exit_status_20) 483 0 R (_exit_status_21) 501 0 R (_exit_status_22) 515 0 R (_exit_status_23) 535 0 R (_exit_status_24) 552 0 R (_exit_status_25) 569 0 R (_exit_status_26) 587 0 R (_exit_status_27) 607 0 R (_exit_status_28) 627 0 R (_exit_status_29) 642 0 R (_exit_status_3) 153 0 R]
+>>
+endobj
+554 0 obj
+[547 0 R /XYZ 0 415.39 null]
+endobj
+555 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 360.28 401.1446 374.56]
+/Type /Annot
+>>
+endobj
+556 0 obj
+[547 0 R /XYZ 0 347.53 null]
+endobj
+557 0 obj
+[547 0 R /XYZ 0 279.67 null]
+endobj
+558 0 obj
+[547 0 R /XYZ 0 234.15 null]
+endobj
+559 0 obj
+[547 0 R /XYZ 0 166.29 null]
+endobj
+560 0 obj
+<< /Length 8057
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<32362e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.6681 Tw
+
+BT
+48.24 758.646 Td
+/F1.0 10.5 Tf
+<546865206f6467692070616e706f7328312920636f6d6d616e64206769766520612070616e67656e6f6d6520706f736974696f6e20666f72206120676976656e207061746820616e64206e75636c656f7469646520706f736974696f6e2e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1527 Tw
+
+BT
+48.24 742.866 Td
+/F1.0 10.5 Tf
+<49742072657175697265732061207061746820696e6465782c2077686963682063616e20626520637265617465642077697468206f64676920> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+1.1527 Tw
+
+BT
+342.5301 742.866 Td
+/F1.0 10.5 Tf
+<70617468696e646578> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1527 Tw
+
+BT
+393.4656 742.866 Td
+/F1.0 10.5 Tf
+<2e20476f696e672066726f6d20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1527 Tw
+
+BT
+461.8138 742.866 Td
+/F2.0 10.5 Tf
+<706174683a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1527 Tw
+
+BT
+532.6678 742.866 Td
+/F1.0 10.5 Tf
+<20> Tj
+/F1.1 10.5 Tf
+<21> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1198 Tw
+
+BT
+48.24 727.086 Td
+/F2.0 10.5 Tf
+<70616e67656e6f6d653a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1198 Tw
+
+BT
+156.4635 727.086 Td
+/F1.0 10.5 Tf
+[<20697320696d706f7274616e74207768656e206e617669676174696e67206c61726765206772> 20.0195 <6170687320696e20616e20696e746572> 20.0195 <616374697665206d616e6e6572206c696b> 20.0195 <6520696e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 711.306 Td
+/F1.0 10.5 Tf
+<74686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+66.93 711.306 Td
+/F1.0 10.5 Tf
+[<50616e746f6772> 20.0195 <617068>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+125.0788 711.306 Td
+/F1.0 10.5 Tf
+<2070726f6a6563742e20416c6c20696e70757420616e64206f757470757420706f736974696f6e732061726520312d62617365642e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 671.466 Td
+/F2.0 18 Tf
+<32362e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 636.726 Td
+/F2.0 13 Tf
+[<32362e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 610.166 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 610.166 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 610.166 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.4702 Tw
+
+BT
+63.24 591.386 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820696e64657820746f2066696e64207468652070616e67656e6f6d6520706f736974696f6e20696e2e205468652066696c65>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 575.606 Td
+/F1.0 10.5 Tf
+<6e616d6520757375616c6c7920656e6473207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+185.0085 575.606 Td
+/F3.0 10.5 Tf
+<2e7870> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+199.4145 575.606 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 541.106 Td
+/F2.0 13 Tf
+<32362e342e322e20506f736974696f6e204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 514.546 Td
+/F2.0 10.5 Tf
+<2d702c202d2d70617468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+94.8705 514.546 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+100.74 514.546 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 495.766 Td
+/F1.0 10.5 Tf
+[<5468652070617468206e616d65206f6620746865207175657279> 89.8438 <2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 467.986 Td
+/F2.0 10.5 Tf
+<2d6e2c202d2d6e75632d706f73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+111.87 467.986 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+117.7395 467.986 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 449.206 Td
+/F1.0 10.5 Tf
+[<546865206e75636c656f746964652073657175656e6365206f6620746865207175657279> 89.8438 <2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 414.706 Td
+/F2.0 13 Tf
+[<32362e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 388.146 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 369.366 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 369.366 Td
+/F2.0 10.5 Tf
+<6f6467692070616e706f73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+250.749 369.366 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 329.526 Td
+/F2.0 18 Tf
+[<32362e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 301.506 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 282.726 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 254.946 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 236.166 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 196.326 Td
+/F2.0 18 Tf
+<32362e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 168.306 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 168.306 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 168.306 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 168.306 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 168.306 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 128.466 Td
+/F2.0 18 Tf
+[<32362e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 100.446 Td
+/F2.0 10.5 Tf
+<6f6467692070616e706f73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+112.1325 100.446 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <792053696d6f6e204865756d6f732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3439> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+561 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 560 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F1.1 80 0 R
+/F4.0 111 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [563 0 R 564 0 R 571 0 R]
+>>
+endobj
+562 0 obj
+[561 0 R /XYZ 0 841.89 null]
+endobj
+563 0 obj
+<< /Border [0 0 0]
+/Dest (_odgi_pathindex1)
+/Subtype /Link
+/Rect [342.5301 739.8 393.4656 754.08]
+/Type /Annot
+>>
+endobj
+564 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://graph-genome.github.io/)
+>>
+/Subtype /Link
+/Rect [66.93 708.24 125.0788 722.52]
+/Type /Annot
+>>
+endobj
+565 0 obj
+[561 0 R /XYZ 0 695.49 null]
+endobj
+566 0 obj
+[561 0 R /XYZ 0 655.41 null]
+endobj
+567 0 obj
+[561 0 R /XYZ 0 559.79 null]
+endobj
+568 0 obj
+[561 0 R /XYZ 0 433.39 null]
+endobj
+569 0 obj
+[561 0 R /XYZ 0 353.55 null]
+endobj
+570 0 obj
+[561 0 R /XYZ 0 220.35 null]
+endobj
+571 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 165.24 401.1446 179.52]
+/Type /Annot
+>>
+endobj
+572 0 obj
+[561 0 R /XYZ 0 152.49 null]
+endobj
+573 0 obj
+<< /Length 10438
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 782.394 Td
+/F2.0 22 Tf
+<32372e206f64676920706f736974696f6e283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 741.146 Td
+/F2.0 18 Tf
+<32372e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 713.126 Td
+/F1.0 10.5 Tf
+[<6f6467695f706f736974696f6e202d20706f736974696f6e207061727473206f6620746865206772> 20.0195 <61706820617320646566696e65642062> 20.0195 <79207175657279206372697465726961>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 673.286 Td
+/F2.0 18 Tf
+[<32372e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 645.266 Td
+/F2.0 10.5 Tf
+<6f64676920706f736974696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+117.1305 645.266 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+123.6195 645.266 Td
+/F2.0 10.5 Tf
+<2d692c202d2d746172676574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+174.996 645.266 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+180.8655 645.266 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+203.9865 645.266 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+214.245 645.266 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+254.628 645.266 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 605.426 Td
+/F2.0 18 Tf
+<32372e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 577.406 Td
+/F1.0 10.5 Tf
+[<546865206f64676920706f736974696f6e28312920636f6d6d616e6420706f736974696f6e207061727473206f6620746865206772> 20.0195 <61706820617320646566696e65642062> 20.0195 <792071756572792063726974657269612e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 537.566 Td
+/F2.0 18 Tf
+<32372e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 502.826 Td
+/F2.0 13 Tf
+[<32372e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 476.266 Td
+/F2.0 10.5 Tf
+<2d692c202d2d746172676574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+99.6165 476.266 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.486 476.266 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 457.486 Td
+/F1.0 10.5 Tf
+[<446573637269626520706f736974696f6e7320696e2074686973206772> 20.0195 <6170682e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 429.706 Td
+/F2.0 10.5 Tf
+<2d782c202d2d736f75726365> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+106.095 429.706 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+111.9645 429.706 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9383 Tw
+
+BT
+63.24 410.926 Td
+/F1.0 10.5 Tf
+[<5472> 20.0195 <616e736c61746520706f736974696f6e732066726f6d2074686973206772> 20.0195 <61706820696e746f2074686520746172676574206772> 20.0195 <617068207573696e6720636f6d6d6f6e20>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+1.9383 Tw
+
+BT
+445.0892 410.926 Td
+/F5.0 10.5 Tf
+<2d2d6c6966742d7061746873> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.9383 Tw
+
+BT
+508.0892 410.926 Td
+/F1.0 10.5 Tf
+<20736861726564> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 395.146 Td
+/F1.0 10.5 Tf
+[<6265747765656e20626f7468206772> 20.0195 <61706873205b64656661756c743a20757365207468652073616d6520736f757263652f746172676574206772> 20.0195 <6170685d>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 360.646 Td
+/F2.0 13 Tf
+<32372e342e322e20506f736974696f6e204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 334.086 Td
+/F2.0 10.5 Tf
+<2d722c202d2d7265662d7061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+117.687 334.086 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+123.5565 334.086 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 315.306 Td
+/F1.0 10.5 Tf
+[<5472> 20.0195 <616e736c6174652074686520676976656e20706f736974696f6e7320696e746f20706f736974696f6e732072656c617469766520746f2074686973207265666572656e636520706174682e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 287.526 Td
+/F2.0 10.5 Tf
+<2d522c202d2d7265662d7061746873> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+119.6295 287.526 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+125.499 287.526 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 268.746 Td
+/F1.0 10.5 Tf
+<55736520746865207265662d706174687320696e2046494c452e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 240.966 Td
+/F2.0 10.5 Tf
+<2d6c2c202d2d6c6966742d70617468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+110.9565 240.966 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+116.826 240.966 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0439 Tw
+
+BT
+63.24 222.186 Td
+/F1.0 10.5 Tf
+<4c69667420706f736974696f6e732066726f6d20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+2.0439 Tw
+
+BT
+164.9742 222.186 Td
+/F5.0 10.5 Tf
+<2d2d736f75726365> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0439 Tw
+
+BT
+206.9742 222.186 Td
+/F1.0 10.5 Tf
+<20746f20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+2.0439 Tw
+
+BT
+226.2555 222.186 Td
+/F5.0 10.5 Tf
+<2d2d746172676574> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.0439 Tw
+
+BT
+268.2555 222.186 Td
+/F1.0 10.5 Tf
+[<2076696120636f6f7264696e6174657320696e2074686973207061746820636f6d6d6f6e20746f20626f7468206772> 20.0195 <61706873>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 206.406 Td
+/F1.0 10.5 Tf
+<5b64656661756c743a20616c6c20636f6d6d6f6e207061746873206265747765656e20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+BT
+245.562 206.406 Td
+/F5.0 10.5 Tf
+<2d2d736f75726365> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+287.562 206.406 Td
+/F1.0 10.5 Tf
+<20616e6420> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+BT
+312.111 206.406 Td
+/F5.0 10.5 Tf
+<2d2d746172676574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+354.111 206.406 Td
+/F1.0 10.5 Tf
+<5d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 178.626 Td
+/F2.0 10.5 Tf
+[<2d672c202d2d6772> 20.0195 <6170682d706f73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+122.4538 178.626 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+128.3233 178.626 Td
+/F4.0 10.5 Tf
+<5b5b6e6f64655f69645d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+183.0073 178.626 Td
+/F4.0 10.5 Tf
+<5d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+187.3543 178.626 Td
+/F4.0 10.5 Tf
+<5d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 159.846 Td
+/F1.0 10.5 Tf
+[<41206772> 20.0195 <61706820706f736974696f6e2c20652e672e2034322c31302c2b206f72203330322c302c2d2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 132.066 Td
+/F2.0 10.5 Tf
+<2d462c202d2d706174682d706f732d66696c65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+137.091 132.066 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+142.9605 132.066 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 113.286 Td
+/F1.0 10.5 Tf
+<412066696c652077697468206f6e65207061746820706f736974696f6e20706572206c696e652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 85.506 Td
+/F2.0 10.5 Tf
+<2d622c202d2d6265642d696e707574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+122.1495 85.506 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+128.019 85.506 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8664 Tw
+
+BT
+63.24 66.726 Td
+/F1.0 10.5 Tf
+[<41204245442066696c65206f662072> 20.0195 <616e67657320696e20706174687320696e20746865206772> 20.0195 <61706820746f206c69667420696e746f2074686520746172676574206772> 20.0195 <61706820>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+0.8664 Tw
+
+BT
+420.1682 66.726 Td
+/F5.0 10.5 Tf
+<2d76> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8664 Tw
+
+BT
+430.6682 66.726 Td
+/F1.0 10.5 Tf
+<2c20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.6941 0.1294 0.2745 scn
+0.6941 0.1294 0.2745 SCN
+
+0.8664 Tw
+
+BT
+436.8791 66.726 Td
+/F5.0 10.5 Tf
+<2d2d676976652d67726170682d706f73> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8664 Tw
+
+BT
+520.8791 66.726 Td
+/F1.0 10.5 Tf
+<20656d6974> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3530> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+574 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 573 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+/F5.0 236 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+>>
+endobj
+575 0 obj
+[574 0 R /XYZ 0 841.89 null]
+endobj
+576 0 obj
+[574 0 R /XYZ 0 765.17 null]
+endobj
+577 0 obj
+[574 0 R /XYZ 0 697.31 null]
+endobj
+578 0 obj
+[574 0 R /XYZ 0 629.45 null]
+endobj
+579 0 obj
+[574 0 R /XYZ 0 561.59 null]
+endobj
+580 0 obj
+<< /Limits [(_options_2) (_options_5)]
+/Names [(_options_2) 127 0 R (_options_20) 475 0 R (_options_21) 493 0 R (_options_22) 511 0 R (_options_23) 526 0 R (_options_24) 548 0 R (_options_25) 565 0 R (_options_26) 579 0 R (_options_27) 603 0 R (_options_28) 619 0 R (_options_29) 639 0 R (_options_3) 146 0 R (_options_4) 172 0 R (_options_5) 200 0 R]
+>>
+endobj
+581 0 obj
+[574 0 R /XYZ 0 521.51 null]
+endobj
+582 0 obj
+[574 0 R /XYZ 0 379.33 null]
+endobj
+583 0 obj
+<< /Length 7389
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+63.24 794.676 Td
+/F1.0 10.5 Tf
+[<6772> 20.0195 <61706820706f736974696f6e732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 766.896 Td
+/F2.0 10.5 Tf
+[<2d76> 49.8047 <2c202d2d676976652d6772> 20.0195 <6170682d706f73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 748.116 Td
+/F1.0 10.5 Tf
+[<456d6974206772> 20.0195 <61706820706f736974696f6e7320286e6f64652c6f66667365742c737472> 20.0195 <616e64292072> 20.0195 <6174686572207468616e207061746820706f736974696f6e732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 720.336 Td
+/F2.0 10.5 Tf
+[<2d642c202d2d7365617263682d72> 20.0195 <6164697573>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+143.4118 720.336 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+149.2813 720.336 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2707 Tw
+
+BT
+63.24 701.556 Td
+/F1.0 10.5 Tf
+[<4c696d697420636f6f7264696e61746520636f6e76657273696f6e20627265616474682d66697273742073656172636820757020746f20444953> 20.0195 <54> 60.0586 <414e43452062702066726f6d206561636820676976656e20706f736974696f6e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 685.776 Td
+/F1.0 10.5 Tf
+<5b64656661756c743a2031303030305d2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 651.276 Td
+/F2.0 13 Tf
+<32372e342e332e20546872656164696e67> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 624.716 Td
+/F2.0 10.5 Tf
+<2d742c202d2d74687265616473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.951 624.716 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.8205 624.716 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 605.936 Td
+/F1.0 10.5 Tf
+<4e756d626572206f66207468726561647320746f207573652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 571.436 Td
+/F2.0 13 Tf
+[<32372e342e342e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 544.876 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 526.096 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 526.096 Td
+/F2.0 10.5 Tf
+<6f64676920706f736974696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+255.747 526.096 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 486.256 Td
+/F2.0 18 Tf
+[<32372e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 458.236 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 439.456 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 411.676 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 392.896 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 353.056 Td
+/F2.0 18 Tf
+<32372e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 325.036 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 325.036 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 325.036 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 325.036 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 325.036 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 285.196 Td
+/F2.0 18 Tf
+[<32372e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 257.176 Td
+/F2.0 10.5 Tf
+<6f64676920706f736974696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+117.1305 257.176 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 213.064 Td
+/F2.0 22 Tf
+<32382e206f64676920736572766572283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 171.816 Td
+/F2.0 18 Tf
+<32382e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 143.796 Td
+/F1.0 10.5 Tf
+<6f6467695f736572766572202d20737461727420612048545450207365727665722077697468206120676976656e20696e6465782066696c6520746f20717565727920612070616e67656e6f6d6520706f736974696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 103.956 Td
+/F2.0 18 Tf
+[<32382e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 75.936 Td
+/F2.0 10.5 Tf
+<6f64676920736572766572> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.1635 75.936 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+114.6525 75.936 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+151.182 75.936 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+157.0515 75.936 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+180.1725 75.936 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+190.431 75.936 Td
+/F2.0 10.5 Tf
+<2d702c202d2d706f7274> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+235.686 75.936 Td
+/F1.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+241.5555 75.936 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+249.567 75.936 Td
+/F1.0 10.5 Tf
+<5d205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+259.8255 75.936 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+300.2085 75.936 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3531> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+584 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 583 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F1.0 8 0 R
+/F2.0 17 0 R
+/F4.0 111 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [590 0 R]
+>>
+endobj
+585 0 obj
+[584 0 R /XYZ 0 669.96 null]
+endobj
+586 0 obj
+[584 0 R /XYZ 0 590.12 null]
+endobj
+587 0 obj
+[584 0 R /XYZ 0 510.28 null]
+endobj
+588 0 obj
+[584 0 R /XYZ 0 377.08 null]
+endobj
+589 0 obj
+<< /Limits [(_bugs_26) (_commands)]
+/Names [(_bugs_26) 570 0 R (_bugs_27) 588 0 R (_bugs_28) 608 0 R (_bugs_29) 628 0 R (_bugs_3) 138 0 R (_bugs_30) 643 0 R (_bugs_4) 156 0 R (_bugs_5) 191 0 R (_bugs_6) 205 0 R (_bugs_7) 224 0 R (_bugs_8) 244 0 R (_bugs_9) 261 0 R (_chop_options) 477 0 R (_commands) 54 0 R]
+>>
+endobj
+590 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 321.97 401.1446 336.25]
+/Type /Annot
+>>
+endobj
+591 0 obj
+[584 0 R /XYZ 0 309.22 null]
+endobj
+592 0 obj
+[584 0 R /XYZ 0 241.36 null]
+endobj
+593 0 obj
+<< /Limits [(_odgi_position1) (_options)]
+/Names [(_odgi_position1) 575 0 R (_odgi_prune1) 376 0 R (_odgi_server1) 592 0 R (_odgi_sort1) 159 0 R (_odgi_squeeze1) 247 0 R (_odgi_stats1) 123 0 R (_odgi_test1) 613 0 R (_odgi_unchop1) 397 0 R (_odgi_unitig1) 315 0 R (_odgi_version1) 631 0 R (_odgi_view1) 284 0 R (_odgi_viz1) 332 0 R (_options) 109 0 R]
+>>
+endobj
+594 0 obj
+[584 0 R /XYZ 0 195.84 null]
+endobj
+595 0 obj
+[584 0 R /XYZ 0 127.98 null]
+endobj
+596 0 obj
+<< /Length 9921
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<32382e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.2938 Tw
+
+BT
+48.24 758.646 Td
+/F1.0 10.5 Tf
+<546865206f6467692073657276657228312920636f6d6d616e642073746172747320616e2048545450207365727665722077697468206120676976656e207061746820696e64657820617320696e7075742e205468652069646561206973> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1556 Tw
+
+BT
+48.24 742.866 Td
+/F1.0 10.5 Tf
+<746861742077652063616e20676f2066726f6d20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1556 Tw
+
+BT
+156.5609 742.866 Td
+/F2.0 10.5 Tf
+<706174683a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1556 Tw
+
+BT
+227.4149 742.866 Td
+/F1.0 10.5 Tf
+<20> Tj
+/F1.1 10.5 Tf
+<2120> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1556 Tw
+
+BT
+245.665 742.866 Td
+/F2.0 10.5 Tf
+<70616e67656e6f6d653a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1556 Tw
+
+BT
+353.8885 742.866 Td
+/F1.0 10.5 Tf
+<207669612047455420726571756573747320746f207468652048545450207365727665722e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.9352 Tw
+
+BT
+48.24 727.086 Td
+/F1.0 10.5 Tf
+<54686520736572766572206865616465727320646f206e6f7420626c6f636b2063726f7373206f726967696e2072657175657374732e204578616d706c652047455420726571756573743a20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.9352 Tw
+
+BT
+444.4445 727.086 Td
+/F2.0 10.5 Tf
+<687474703a2f2f6c6f63616c6f73743a333030302f> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+48.24 711.306 Td
+/F2.0 10.5 Tf
+<706174685f6e616d652f6e75636c656f746964655f706f736974696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+214.497 711.306 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7903 Tw
+
+BT
+48.24 695.526 Td
+/F1.0 10.5 Tf
+<546865207265717569726564207061746820696e6465782063616e20626520637265617465642077697468206f64676920> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+3.7903 Tw
+
+BT
+331.9798 695.526 Td
+/F1.0 10.5 Tf
+<70617468696e646578> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7903 Tw
+
+BT
+382.9153 695.526 Td
+/F1.0 10.5 Tf
+<2e20476f696e672066726f6d20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7903 Tw
+
+BT
+459.1762 695.526 Td
+/F2.0 10.5 Tf
+<706174683a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+3.7903 Tw
+
+BT
+530.0302 695.526 Td
+/F1.0 10.5 Tf
+<20> Tj
+/F1.1 10.5 Tf
+<21> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1198 Tw
+
+BT
+48.24 679.746 Td
+/F2.0 10.5 Tf
+<70616e67656e6f6d653a706f736974696f6e> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+1.1198 Tw
+
+BT
+156.4635 679.746 Td
+/F1.0 10.5 Tf
+[<20697320696d706f7274616e74207768656e206e617669676174696e67206c61726765206772> 20.0195 <6170687320696e20616e20696e746572> 20.0195 <616374697665206d616e6e6572206c696b> 20.0195 <6520696e>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4369 Tw
+
+BT
+48.24 663.966 Td
+/F1.0 10.5 Tf
+<74686520> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.4369 Tw
+
+BT
+67.3669 663.966 Td
+/F1.0 10.5 Tf
+[<50616e746f6772> 20.0195 <617068>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4369 Tw
+
+BT
+125.5157 663.966 Td
+/F1.0 10.5 Tf
+<2070726f6a6563742e20416c6c20696e70757420616e64206f757470757420706f736974696f6e732061726520312d62617365642e204966206e6f2049502061646472657373206973207370656369666965642c20746865> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 648.186 Td
+/F1.0 10.5 Tf
+<7365727665722077696c6c2072756e206f6e206c6f63616c686f73742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 608.346 Td
+/F2.0 18 Tf
+<32382e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 573.606 Td
+/F2.0 13 Tf
+[<32382e342e312e204772> 20.0195 <6170682046696c657320494f>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 547.046 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.7695 547.046 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.639 547.046 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+2.5838 Tw
+
+BT
+63.24 528.266 Td
+/F1.0 10.5 Tf
+[<46696c6520636f6e7461696e696e67207468652073756363696e637420766172696174696f6e206772> 20.0195 <61706820696e64657820746f20686f737420696e20612048545450207365727665722e205468652066696c65206e616d65>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 512.486 Td
+/F1.0 10.5 Tf
+<757375616c6c7920656e6473207769746820> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+154.086 512.486 Td
+/F3.0 10.5 Tf
+<2e7870> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+168.492 512.486 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 477.986 Td
+/F2.0 13 Tf
+<32382e342e322e2048545450204f7074696f6e73> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 451.426 Td
+/F2.0 10.5 Tf
+<2d702c202d2d706f7274> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.495 451.426 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+99.3645 451.426 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 432.646 Td
+/F1.0 10.5 Tf
+<52756e207468652073657276657220756e646572207468697320706f72742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 404.866 Td
+/F2.0 10.5 Tf
+<2d612c202d2d6970> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+80.559 404.866 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+86.4285 404.866 Td
+/F4.0 10.5 Tf
+<4950> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 386.086 Td
+/F1.0 10.5 Tf
+<52756e207468652073657276657220756e646572207468697320495020616464726573732e204966206e6f74207370656369666965642c20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+330.612 386.086 Td
+/F3.0 10.5 Tf
+<4950> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+340.9755 386.086 Td
+/F1.0 10.5 Tf
+<2077696c6c20626520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+380.088 386.086 Td
+/F3.0 10.5 Tf
+<6c6f63616c686f7374> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+424.7235 386.086 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 351.586 Td
+/F2.0 13 Tf
+[<32382e342e332e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 325.026 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 306.246 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 306.246 Td
+/F2.0 10.5 Tf
+<6f64676920736572766572> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+246.78 306.246 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 266.406 Td
+/F2.0 18 Tf
+[<32382e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 238.386 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 219.606 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 191.826 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 173.046 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 133.206 Td
+/F2.0 18 Tf
+<32382e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 105.186 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 105.186 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 105.186 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 105.186 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 105.186 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3532> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+597 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 596 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F1.1 80 0 R
+/F4.0 111 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+/Annots [599 0 R 600 0 R 601 0 R 602 0 R 609 0 R]
+>>
+endobj
+598 0 obj
+[597 0 R /XYZ 0 841.89 null]
+endobj
+599 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (http://localost:3000/path_name/nucleotide_position)
+>>
+/Subtype /Link
+/Rect [444.4445 724.02 547.04 738.3]
+/Type /Annot
+>>
+endobj
+600 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (http://localost:3000/path_name/nucleotide_position)
+>>
+/Subtype /Link
+/Rect [48.24 708.24 214.497 722.52]
+/Type /Annot
+>>
+endobj
+601 0 obj
+<< /Border [0 0 0]
+/Dest (_odgi_pathindex1)
+/Subtype /Link
+/Rect [331.9798 692.46 382.9153 706.74]
+/Type /Annot
+>>
+endobj
+602 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://graph-genome.github.io/)
+>>
+/Subtype /Link
+/Rect [67.3669 660.9 125.5157 675.18]
+/Type /Annot
+>>
+endobj
+603 0 obj
+[597 0 R /XYZ 0 632.37 null]
+endobj
+604 0 obj
+[597 0 R /XYZ 0 592.29 null]
+endobj
+605 0 obj
+[597 0 R /XYZ 0 496.67 null]
+endobj
+606 0 obj
+[597 0 R /XYZ 0 370.27 null]
+endobj
+607 0 obj
+[597 0 R /XYZ 0 290.43 null]
+endobj
+608 0 obj
+[597 0 R /XYZ 0 157.23 null]
+endobj
+609 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 102.12 401.1446 116.4]
+/Type /Annot
+>>
+endobj
+610 0 obj
+<< /Length 6198
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+[<32382e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 758.646 Td
+/F2.0 10.5 Tf
+<6f64676920736572766572> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+108.1635 758.646 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <792053696d6f6e204865756d6f732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 714.534 Td
+/F2.0 22 Tf
+<32392e206f6467692074657374283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 673.286 Td
+/F2.0 18 Tf
+<32392e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 645.266 Td
+/F1.0 10.5 Tf
+<6f6467695f74657374202d2072756e206f64676920756e6974207465737473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 605.426 Td
+/F2.0 18 Tf
+[<32392e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 577.406 Td
+/F2.0 10.5 Tf
+<6f6467692074657374> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.348 577.406 Td
+/F1.0 10.5 Tf
+[<205b3c544553> 20.0195 <54204e414d457c50> 49.8047 <41> 60.0586 <545445524e7c54> 60.0586 <41> 20.0195 <47533e20c95d205b>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+277.7389 577.406 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+318.1219 577.406 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 537.566 Td
+/F2.0 18 Tf
+<32392e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.8333 Tw
+
+BT
+48.24 509.546 Td
+/F1.0 10.5 Tf
+[<546865206f646769207465737428312920636f6d6d616e642073746172747320616c6c20756e697420746573747320746861742061726520696d706c656d656e74656420696e206f6467692e2046> 40.0391 <6f722074617267657465642074657374696e672c2061>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.6657 Tw
+
+BT
+48.24 493.766 Td
+/F1.0 10.5 Tf
+<737562736574206f662074657374732063616e2062652073656c65637465642e206f646769207465737428312920646570656e6473206f6e20> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+0.6657 Tw
+
+BT
+326.3008 493.766 Td
+/F1.0 10.5 Tf
+<436174636832> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.6657 Tw
+
+BT
+360.0268 493.766 Td
+/F1.0 10.5 Tf
+<2e20496e207468652064656661756c742073657474696e672c20616c6c20726573756c747320617265> Tj
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 477.986 Td
+/F1.0 10.5 Tf
+<7072696e74656420746f207374646f75742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 438.146 Td
+/F2.0 18 Tf
+<32392e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 403.406 Td
+/F2.0 13 Tf
+[<32392e342e312e2054> 29.7852 <657374696e67204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 376.846 Td
+/F2.0 10.5 Tf
+<2d6c2c202d2d6c6973742d7465737473> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 358.066 Td
+/F1.0 10.5 Tf
+<4c69737420616c6c20746573742063617365732e2049662061207061747465726e20776173207370656369666965642c20616c6c206d61746368696e67207465737420636173657320617265206c69737465642e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 330.286 Td
+/F2.0 10.5 Tf
+<2d742c202d2d6c6973742d74616773> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 311.506 Td
+/F1.0 10.5 Tf
+<4c69737420616c6c20746167732e2049662061207061747465726e20776173207370656369666965642c20616c6c206d61746368696e67207461677320617265206c69737465642e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 283.726 Td
+/F2.0 10.5 Tf
+<2d732c202d2d73756363657373> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 264.946 Td
+/F1.0 10.5 Tf
+<496e636c756465207375636365737366756c20746573747320696e206f75747075742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 237.166 Td
+/F2.0 10.5 Tf
+<2d622c202d2d627265616b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 218.386 Td
+/F1.0 10.5 Tf
+<427265616b20696e746f206465627567676572206d6f64652075706f6e206661696c656420746573742e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 190.606 Td
+/F2.0 10.5 Tf
+<2d652c202d2d6e6f7468726f77> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 171.826 Td
+/F1.0 10.5 Tf
+<536b697020657863657074696f6e2074657374732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 144.046 Td
+/F2.0 10.5 Tf
+<2d692c202d2d696e76697369626c6573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 125.266 Td
+/F1.0 10.5 Tf
+[<53686f7720696e76697369626c6573206c696b> 20.0195 <652074616273206f72206e65776c696e65732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 97.486 Td
+/F2.0 10.5 Tf
+<2d6f2c202d2d6f7574> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+87.888 97.486 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.7575 97.486 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 78.706 Td
+/F1.0 10.5 Tf
+<577269746520616c6c206f757470757420746f20> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+158.076 78.706 Td
+/F3.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+181.197 78.706 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3533> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+611 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 610 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+/F4.0 111 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [618 0 R]
+>>
+endobj
+612 0 obj
+[611 0 R /XYZ 0 841.89 null]
+endobj
+613 0 obj
+[611 0 R /XYZ 0 742.83 null]
+endobj
+614 0 obj
+[611 0 R /XYZ 0 697.31 null]
+endobj
+615 0 obj
+<< /Limits [(_name_21) (_name_4)]
+/Names [(_name_21) 472 0 R (_name_22) 488 0 R (_name_23) 508 0 R (_name_24) 522 0 R (_name_25) 540 0 R (_name_26) 558 0 R (_name_27) 576 0 R (_name_28) 594 0 R (_name_29) 614 0 R (_name_3) 124 0 R (_name_30) 632 0 R (_name_4) 143 0 R]
+>>
+endobj
+616 0 obj
+[611 0 R /XYZ 0 629.45 null]
+endobj
+617 0 obj
+[611 0 R /XYZ 0 561.59 null]
+endobj
+618 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/catchorg/Catch2)
+>>
+/Subtype /Link
+/Rect [326.3008 490.7 360.0268 504.98]
+/Type /Annot
+>>
+endobj
+619 0 obj
+[611 0 R /XYZ 0 462.17 null]
+endobj
+620 0 obj
+[611 0 R /XYZ 0 422.09 null]
+endobj
+621 0 obj
+<< /Limits [(_threading_2) (_visualization_options)]
+/Names [(_threading_2) 151 0 R (_threading_3) 187 0 R (_threading_4) 220 0 R (_threading_5) 237 0 R (_threading_6) 255 0 R (_threading_7) 275 0 R (_threading_8) 307 0 R (_threading_9) 368 0 R (_topological_sorts) 174 0 R (_unitig_options) 324 0 R (_version_options) 640 0 R (_visualization_options) 341 0 R]
+>>
+endobj
+622 0 obj
+<< /Length 9207
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 793.926 Td
+/F2.0 10.5 Tf
+<2d722c202d2d7265706f72746572> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+115.1355 793.926 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+121.005 793.926 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 775.146 Td
+/F1.0 10.5 Tf
+<5265706f7274657220746f207573652e2044656661756c7420697320636f6e736f6c652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 747.366 Td
+/F2.0 10.5 Tf
+<2d6e2c202d2d6e616d65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+100.404 747.366 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+106.2735 747.366 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 728.586 Td
+/F1.0 10.5 Tf
+<5375697465206e616d652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 700.806 Td
+/F2.0 10.5 Tf
+<2d612c202d2d61626f7274> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 682.026 Td
+/F1.0 10.5 Tf
+<41626f7274206174206669727374206661696c7572652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 654.246 Td
+/F2.0 10.5 Tf
+<2d782c202d2d61626f727478> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+106.5885 654.246 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+112.458 654.246 Td
+/F4.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 635.466 Td
+/F1.0 10.5 Tf
+<41626f727420616674657220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+121.2525 635.466 Td
+/F3.0 10.5 Tf
+<4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+129.264 635.466 Td
+/F1.0 10.5 Tf
+<206661696c757265732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 607.686 Td
+/F2.0 10.5 Tf
+[<2d77> 69.8242 <2c202d2d7761726e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+99.7863 607.686 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+105.6558 607.686 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 588.906 Td
+/F1.0 10.5 Tf
+<456e61626c65207761726e696e67732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 561.126 Td
+/F2.0 10.5 Tf
+[<2d642c202d2d647572> 20.0195 <6174696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+122.4328 561.126 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+128.3023 561.126 Td
+/F4.0 10.5 Tf
+<7965737c6e6f> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 542.346 Td
+/F1.0 10.5 Tf
+[<53686f77207465737420647572> 20.0195 <6174696f6e732e2044656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+217.7263 542.346 Td
+/F3.0 10.5 Tf
+<6e6f> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+230.0428 542.346 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 514.566 Td
+/F2.0 10.5 Tf
+<2d662c202d2d696e7075742d66696c65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+117.6765 514.566 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+123.546 514.566 Td
+/F4.0 10.5 Tf
+<46494c45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 495.786 Td
+/F1.0 10.5 Tf
+<4c6f61642074657374206e616d65732066726f6d20612066696c652e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 468.006 Td
+/F2.0 10.5 Tf
+<2d232c202d2d66696c656e616d65732d61732d74616773> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 449.226 Td
+/F1.0 10.5 Tf
+[<41> 20.0195 <64647320612074616720666f72207468652066696c65206e616d652e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 421.446 Td
+/F2.0 10.5 Tf
+<2d632c202d2d73656374696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+107.3025 421.446 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.172 421.446 Td
+/F4.0 10.5 Tf
+[<53> 20.0195 <5452494e47>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 402.666 Td
+/F1.0 10.5 Tf
+<53706563696679207468652073656374696f6e20746f2072756e20746865207465737473206f6e2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 374.886 Td
+/F2.0 10.5 Tf
+[<2d76> 49.8047 <2c202d2d7665726f73697479>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.0061 374.886 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+118.8756 374.886 Td
+/F4.0 10.5 Tf
+<71756965747c6e6f726d616c7c68696768> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 356.106 Td
+/F1.0 10.5 Tf
+[<536574206f757470757420766572626f73697479> 89.8438 <2e2044656661756c7420697320>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+218.2951 356.106 Td
+/F3.0 10.5 Tf
+<6e6f726d616c> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+254.1841 356.106 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 328.326 Td
+/F2.0 10.5 Tf
+<2d2d6c6973742d746573742d6e616d65732d6f6e6c79> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 309.546 Td
+/F1.0 10.5 Tf
+[<4c69737420616c6c2074657374206361736573206e616d6573206f6e6c79> 89.8438 <2e2049662061207061747465726e20776173207370656369666965642c20616c6c206d61746368696e67207465737420636173657320617265206c69737465642e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 281.766 Td
+/F2.0 10.5 Tf
+<2d2d6c6973742d7265706f7274657273> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 262.986 Td
+/F1.0 10.5 Tf
+<4c69737420616c6c207265706f72746572732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 235.206 Td
+/F2.0 10.5 Tf
+<2d2d6f72646572> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+84.927 235.206 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+90.7965 235.206 Td
+/F4.0 10.5 Tf
+[<6465636c7c6c65787c72> 20.0195 <616e64>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 216.426 Td
+/F1.0 10.5 Tf
+[<54> 29.7852 <6573742063617365206f726465722e2044656661756c742069737420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+197.4638 216.426 Td
+/F3.0 10.5 Tf
+<6465636c> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+217.0148 216.426 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 188.646 Td
+/F2.0 10.5 Tf
+<2d2d726e672d73656564> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+100.2465 188.646 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+106.116 188.646 Td
+/F4.0 10.5 Tf
+<74696d657c6e756d626572> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 169.866 Td
+/F1.0 10.5 Tf
+[<5365742061207370656369666963207365656420666f722072> 20.0195 <616e646f6d206e756d626572732e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 142.086 Td
+/F2.0 10.5 Tf
+<2d2d7573652d636f6c6f72> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+103.6485 142.086 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.518 142.086 Td
+/F4.0 10.5 Tf
+<7965737c6e6f> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 123.306 Td
+/F1.0 10.5 Tf
+<53686f756c6420746865206f757470757420626520636f6c6f72697a65643f2044656661756c7420697320> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+274.4895 123.306 Td
+/F3.0 10.5 Tf
+<796573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+290.061 123.306 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 95.526 Td
+/F2.0 10.5 Tf
+<2d2d6c69626964656e74696679> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 76.746 Td
+/F1.0 10.5 Tf
+[<5265706f7274206e616d6520616e642076657273696f6e206163636f7264696e6720746f206c69626964656e74696679> 89.8438 <2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp2 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+49.24 14.388 Td
+/F1.0 9 Tf
+<3534> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+623 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 622 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp2 708 0 R
+>>
+>>
+>>
+endobj
+624 0 obj
+<< /Length 6432
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 793.926 Td
+/F2.0 10.5 Tf
+[<2d2d776169742d666f722d6b> 20.0195 <65797072657373>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+147.6433 793.926 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+153.5128 793.926 Td
+/F4.0 10.5 Tf
+<73746172747c657869747c626f7468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 775.146 Td
+/F1.0 10.5 Tf
+[<57> 49.8047 <6169747320666f722061206b> 20.0195 <65797072657373206265666f726520>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+202.2408 775.146 Td
+/F3.0 10.5 Tf
+<73746172747c657869747c626f7468> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+277.5888 775.146 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 747.366 Td
+/F2.0 10.5 Tf
+<2d2d62656e63686d61726b2d7265736f6c7574696f6e2d6d756c7469706c65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 728.586 Td
+/F1.0 10.5 Tf
+<4d756c7469706c65206f6620636c6f636b207265736f6c7574696f6e20746f2072756e2062656e63686d61726b732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 694.086 Td
+/F2.0 13 Tf
+[<32392e342e322e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 667.526 Td
+/F2.0 10.5 Tf
+<2d3f2c202d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 648.746 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 648.746 Td
+/F2.0 10.5 Tf
+<6f6467692074657374> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+231.9645 648.746 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 608.906 Td
+/F2.0 18 Tf
+[<32392e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 580.886 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 562.106 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 534.326 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 515.546 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 475.706 Td
+/F2.0 18 Tf
+<32392e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 447.686 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 447.686 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 447.686 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 447.686 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 447.686 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 407.846 Td
+/F2.0 18 Tf
+[<32392e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 379.826 Td
+/F2.0 10.5 Tf
+<6f6467692074657374> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+93.348 379.826 Td
+/F1.0 10.5 Tf
+[<20776173207772697474656e2062> 20.0195 <79204572696b204761727269736f6e2c2053696d6f6e204865756d6f732c20616e6420416e64726561204775617272> 20.0195 <6163696e6f2e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 335.714 Td
+/F2.0 22 Tf
+<33302e206f6467692076657273696f6e283129> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 294.466 Td
+/F2.0 18 Tf
+<33302e312e204e414d45> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 266.446 Td
+/F1.0 10.5 Tf
+[<6f6467695f76657273696f6e202d20646973706c61> 20.0195 <79207468652076657273696f6e206f66206f646769>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 226.606 Td
+/F2.0 18 Tf
+[<33302e322e2053> 20.0195 <594e4f50534953>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 198.586 Td
+/F2.0 10.5 Tf
 <6f6467692076657273696f6e> Tj
 ET
 
@@ -44660,7 +44166,548 @@ ET
 0.2 0.2 0.2 SCN
 
 BT
-113.8125 690.786 Td
+113.8125 198.586 Td
+/F1.0 10.5 Tf
+<205b> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+120.3015 198.586 Td
+/F3.0 10.5 Tf
+<4f5054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+160.6845 198.586 Td
+/F1.0 10.5 Tf
+<5dc9> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 158.746 Td
+/F2.0 18 Tf
+<33302e332e204445534352495054494f4e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+0.4583 Tw
+
+BT
+48.24 130.726 Td
+/F1.0 10.5 Tf
+[<546865206f6467692076657273696f6e28312920636f6d6d616e64207072696e7473207468652063757272656e74206769742076657273696f6e2077697468207461677320616e6420636f64656e616d6520746f207374646f757420286c696b> 20.0195 <65>] TJ
+ET
+
+
+0.0 Tw
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 114.946 Td
+/F3.0 10.5 Tf
+<762d34342d673839643032326220226261636b20746f206f6c642041424922> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+205.0995 114.946 Td
+/F1.0 10.5 Tf
+[<292e204f7074696f6e616c6c79> 89.8438 <2c206f6e6c79207468652072656c656173652c2076657273696f6e206f7220636f64656e616d652063616e206265207072696e7465642e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+q
+0.0 0.0 0.0 scn
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+/Stamp1 Do
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+535.978 14.388 Td
+/F1.0 9 Tf
+<3535> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+Q
+Q
+
+endstream
+endobj
+625 0 obj
+<< /Type /Page
+/Parent 3 0 R
+/MediaBox [0 0 595.28 841.89]
+/CropBox [0 0 595.28 841.89]
+/BleedBox [0 0 595.28 841.89]
+/TrimBox [0 0 595.28 841.89]
+/ArtBox [0 0 595.28 841.89]
+/Contents 624 0 R
+/Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font << /F2.0 17 0 R
+/F4.0 111 0 R
+/F1.0 8 0 R
+/F3.0 55 0 R
+>>
+/XObject << /Stamp1 707 0 R
+>>
+>>
+/Annots [629 0 R]
+>>
+endobj
+626 0 obj
+[625 0 R /XYZ 0 712.77 null]
+endobj
+627 0 obj
+[625 0 R /XYZ 0 632.93 null]
+endobj
+628 0 obj
+[625 0 R /XYZ 0 499.73 null]
+endobj
+629 0 obj
+<< /Border [0 0 0]
+/A << /Type /Action
+/S /URI
+/URI (https://github.com/vgteam/odgi/issues)
+>>
+/Subtype /Link
+/Rect [213.4151 444.62 401.1446 458.9]
+/Type /Annot
+>>
+endobj
+630 0 obj
+[625 0 R /XYZ 0 431.87 null]
+endobj
+631 0 obj
+[625 0 R /XYZ 0 364.01 null]
+endobj
+632 0 obj
+[625 0 R /XYZ 0 318.49 null]
+endobj
+633 0 obj
+[625 0 R /XYZ 0 250.63 null]
+endobj
+634 0 obj
+<< /Limits [(_synopsis_23) (_synopsis_5)]
+/Names [(_synopsis_23) 509 0 R (_synopsis_24) 523 0 R (_synopsis_25) 541 0 R (_synopsis_26) 559 0 R (_synopsis_27) 577 0 R (_synopsis_28) 595 0 R (_synopsis_29) 616 0 R (_synopsis_3) 125 0 R (_synopsis_30) 633 0 R (_synopsis_4) 144 0 R (_synopsis_5) 161 0 R]
+>>
+endobj
+635 0 obj
+[625 0 R /XYZ 0 182.77 null]
+endobj
+636 0 obj
+<< /Limits [(_description_25) (_description_7)]
+/Names [(_description_25) 542 0 R (_description_26) 562 0 R (_description_27) 578 0 R (_description_28) 598 0 R (_description_29) 617 0 R (_description_3) 126 0 R (_description_30) 635 0 R (_description_4) 145 0 R (_description_5) 162 0 R (_description_6) 199 0 R (_description_7) 213 0 R]
+>>
+endobj
+637 0 obj
+<< /Length 5207
+>>
+stream
+q
+/DeviceRGB cs
+0.2 0.2 0.2 scn
+/DeviceRGB CS
+0.2 0.2 0.2 SCN
+
+BT
+48.24 786.666 Td
+/F2.0 18 Tf
+<33302e342e204f5054494f4e53> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 751.926 Td
+/F2.0 13 Tf
+[<33302e342e312e2056> 60.0586 <657273696f6e204f7074696f6e73>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 725.366 Td
+/F2.0 10.5 Tf
+[<2d76> 49.8047 <2c202d2d76657273696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.6776 725.366 Td
+/F2.0 10.5 Tf
+<3d> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 706.586 Td
+/F1.0 10.5 Tf
+[<5072696e74206f6e6c79207468652076657273696f6e20286c696b> 20.0195 <6520>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+199.2568 706.586 Td
+/F3.0 10.5 Tf
+<762d34342d6738396430323262> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+270.3208 706.586 Td
+/F1.0 10.5 Tf
+<292e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 678.806 Td
+/F2.0 10.5 Tf
+<2d632c202d2d636f64656e616d65> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 660.026 Td
+/F1.0 10.5 Tf
+[<5072696e74206f6e6c792074686520636f64656e616d6520286c696b> 20.0195 <6520>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+213.1798 660.026 Td
+/F3.0 10.5 Tf
+<6261636b20746f206f6c6420414249> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+287.6878 660.026 Td
+/F1.0 10.5 Tf
+<292e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 632.246 Td
+/F2.0 10.5 Tf
+<2d722c202d2d72656c65617365> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 613.466 Td
+/F1.0 10.5 Tf
+[<5072696e74206f6e6c79207468652072656c6561736520286c696b> 20.0195 <6520>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+197.3878 613.466 Td
+/F3.0 10.5 Tf
+<76> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+203.0368 613.466 Td
+/F1.0 10.5 Tf
+<292e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 578.966 Td
+/F2.0 13 Tf
+[<33302e342e322e2050726f6772> 20.0195 <616d20496e666f726d6174696f6e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 552.406 Td
+/F2.0 10.5 Tf
+<2d682c202d2d68656c70> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 533.626 Td
+/F1.0 10.5 Tf
+<5072696e7420612068656c70206d65737361676520666f7220> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+186.8565 533.626 Td
+/F2.0 10.5 Tf
+<6f6467692076657273696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+252.429 533.626 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 493.786 Td
+/F2.0 18 Tf
+[<33302e352e20455849542053> 20.0195 <54> 60.0586 <41> 60.0586 <545553>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 465.766 Td
+/F2.0 10.5 Tf
+<30> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 446.986 Td
+/F1.0 10.5 Tf
+<537563636573732e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 419.206 Td
+/F2.0 10.5 Tf
+<31> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+63.24 400.426 Td
+/F1.0 10.5 Tf
+[<46> 40.0391 <61696c757265202873796e746178206f72207573616765206572726f723b20706172> 20.0195 <616d65746572206572726f723b2066696c652070726f63657373696e67206661696c7572653b20756e6578706563746564206572726f72292e>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 360.586 Td
+/F2.0 18 Tf
+<33302e362e2042554753> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 332.566 Td
+/F1.0 10.5 Tf
+<526566657220746f2074686520> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+109.056 332.566 Td
+/F2.0 10.5 Tf
+<6f646769> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+131.862 332.566 Td
+/F1.0 10.5 Tf
+[<206973737565207472> 20.0195 <61636b> 20.0195 <657220617420>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2588 0.5451 0.7922 scn
+0.2588 0.5451 0.7922 SCN
+
+BT
+213.4151 332.566 Td
+/F1.0 10.5 Tf
+<68747470733a2f2f6769746875622e636f6d2f76677465616d2f6f6467692f697373756573> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+401.1446 332.566 Td
+/F1.0 10.5 Tf
+<2e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 292.726 Td
+/F2.0 18 Tf
+[<33302e372e2041> 20.0195 <5554484f5253>] TJ
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+48.24 264.706 Td
+/F2.0 10.5 Tf
+<6f6467692076657273696f6e> Tj
+ET
+
+0.0 0.0 0.0 SCN
+0.0 0.0 0.0 scn
+0.2 0.2 0.2 scn
+0.2 0.2 0.2 SCN
+
+BT
+113.8125 264.706 Td
 /F1.0 10.5 Tf
 [<20776173207772697474656e2062> 20.0195 <792053696d6f6e204865756d6f732e>] TJ
 ET
@@ -44691,7 +44738,7 @@ Q
 
 endstream
 endobj
-641 0 obj
+638 0 obj
 << /Type /Page
 /Parent 3 0 R
 /MediaBox [0 0 595.28 841.89]
@@ -44699,40 +44746,53 @@ endobj
 /BleedBox [0 0 595.28 841.89]
 /TrimBox [0 0 595.28 841.89]
 /ArtBox [0 0 595.28 841.89]
-/Contents 640 0 R
+/Contents 637 0 R
 /Resources << /ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
 /Font << /F2.0 17 0 R
 /F1.0 8 0 R
+/F3.0 55 0 R
 >>
-/XObject << /Stamp2 707 0 R
+/XObject << /Stamp2 708 0 R
 >>
 >>
-/Annots [643 0 R]
+/Annots [644 0 R]
 >>
+endobj
+639 0 obj
+[638 0 R /XYZ 0 841.89 null]
+endobj
+640 0 obj
+[638 0 R /XYZ 0 770.61 null]
+endobj
+641 0 obj
+[638 0 R /XYZ 0 597.65 null]
 endobj
 642 0 obj
-[641 0 R /XYZ 0 841.89 null]
+[638 0 R /XYZ 0 517.81 null]
 endobj
 643 0 obj
+[638 0 R /XYZ 0 384.61 null]
+endobj
+644 0 obj
 << /Border [0 0 0]
 /A << /Type /Action
 /S /URI
 /URI (https://github.com/vgteam/odgi/issues)
 >>
 /Subtype /Link
-/Rect [213.4151 755.58 401.1446 769.86]
+/Rect [213.4151 329.5 401.1446 343.78]
 /Type /Annot
 >>
 endobj
-644 0 obj
-[641 0 R /XYZ 0 742.83 null]
-endobj
 645 0 obj
-<< /Limits [(_authors_26) (_authors_8)]
-/Names [(_authors_26) 571 0 R (_authors_27) 590 0 R (_authors_28) 609 0 R (_authors_29) 628 0 R (_authors_3) 140 0 R (_authors_30) 644 0 R (_authors_4) 158 0 R (_authors_5) 193 0 R (_authors_6) 207 0 R (_authors_7) 226 0 R (_authors_8) 246 0 R]
->>
+[638 0 R /XYZ 0 316.75 null]
 endobj
 646 0 obj
+<< /Limits [(_authors_26) (_authors_8)]
+/Names [(_authors_26) 572 0 R (_authors_27) 591 0 R (_authors_28) 612 0 R (_authors_29) 630 0 R (_authors_3) 140 0 R (_authors_30) 645 0 R (_authors_4) 158 0 R (_authors_5) 193 0 R (_authors_6) 207 0 R (_authors_7) 226 0 R (_authors_8) 246 0 R]
+>>
+endobj
+647 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_1)
 /Subtype /Link
@@ -44740,7 +44800,7 @@ endobj
 /Type /Annot
 >>
 endobj
-647 0 obj
+648 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_1)
 /Subtype /Link
@@ -44748,7 +44808,7 @@ endobj
 /Type /Annot
 >>
 endobj
-648 0 obj
+649 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_build1)
 /Subtype /Link
@@ -44756,7 +44816,7 @@ endobj
 /Type /Annot
 >>
 endobj
-649 0 obj
+650 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_build1)
 /Subtype /Link
@@ -44764,7 +44824,7 @@ endobj
 /Type /Annot
 >>
 endobj
-650 0 obj
+651 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_stats1)
 /Subtype /Link
@@ -44772,7 +44832,7 @@ endobj
 /Type /Annot
 >>
 endobj
-651 0 obj
+652 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_stats1)
 /Subtype /Link
@@ -44780,7 +44840,7 @@ endobj
 /Type /Annot
 >>
 endobj
-652 0 obj
+653 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_depth1)
 /Subtype /Link
@@ -44788,7 +44848,7 @@ endobj
 /Type /Annot
 >>
 endobj
-653 0 obj
+654 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_depth1)
 /Subtype /Link
@@ -44796,7 +44856,7 @@ endobj
 /Type /Annot
 >>
 endobj
-654 0 obj
+655 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_sort1)
 /Subtype /Link
@@ -44804,7 +44864,7 @@ endobj
 /Type /Annot
 >>
 endobj
-655 0 obj
+656 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_sort1)
 /Subtype /Link
@@ -44812,7 +44872,7 @@ endobj
 /Type /Annot
 >>
 endobj
-656 0 obj
+657 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_groom1)
 /Subtype /Link
@@ -44820,7 +44880,7 @@ endobj
 /Type /Annot
 >>
 endobj
-657 0 obj
+658 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_groom1)
 /Subtype /Link
@@ -44828,7 +44888,7 @@ endobj
 /Type /Annot
 >>
 endobj
-658 0 obj
+659 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_cover1)
 /Subtype /Link
@@ -44836,7 +44896,7 @@ endobj
 /Type /Annot
 >>
 endobj
-659 0 obj
+660 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_cover1)
 /Subtype /Link
@@ -44844,7 +44904,7 @@ endobj
 /Type /Annot
 >>
 endobj
-660 0 obj
+661 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_explode1)
 /Subtype /Link
@@ -44852,7 +44912,7 @@ endobj
 /Type /Annot
 >>
 endobj
-661 0 obj
+662 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_explode1)
 /Subtype /Link
@@ -44860,7 +44920,7 @@ endobj
 /Type /Annot
 >>
 endobj
-662 0 obj
+663 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_squeeze1)
 /Subtype /Link
@@ -44868,7 +44928,7 @@ endobj
 /Type /Annot
 >>
 endobj
-663 0 obj
+664 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_squeeze1)
 /Subtype /Link
@@ -44876,7 +44936,7 @@ endobj
 /Type /Annot
 >>
 endobj
-664 0 obj
+665 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_extract1)
 /Subtype /Link
@@ -44884,7 +44944,7 @@ endobj
 /Type /Annot
 >>
 endobj
-665 0 obj
+666 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_extract1)
 /Subtype /Link
@@ -44892,7 +44952,7 @@ endobj
 /Type /Annot
 >>
 endobj
-666 0 obj
+667 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_view1)
 /Subtype /Link
@@ -44900,7 +44960,7 @@ endobj
 /Type /Annot
 >>
 endobj
-667 0 obj
+668 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_view1)
 /Subtype /Link
@@ -44908,7 +44968,7 @@ endobj
 /Type /Annot
 >>
 endobj
-668 0 obj
+669 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_kmers1)
 /Subtype /Link
@@ -44916,7 +44976,7 @@ endobj
 /Type /Annot
 >>
 endobj
-669 0 obj
+670 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_kmers1)
 /Subtype /Link
@@ -44924,7 +44984,7 @@ endobj
 /Type /Annot
 >>
 endobj
-670 0 obj
+671 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_unitig1)
 /Subtype /Link
@@ -44932,7 +44992,7 @@ endobj
 /Type /Annot
 >>
 endobj
-671 0 obj
+672 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_unitig1)
 /Subtype /Link
@@ -44940,7 +45000,7 @@ endobj
 /Type /Annot
 >>
 endobj
-672 0 obj
+673 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_viz1)
 /Subtype /Link
@@ -44948,7 +45008,7 @@ endobj
 /Type /Annot
 >>
 endobj
-673 0 obj
+674 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_viz1)
 /Subtype /Link
@@ -44956,7 +45016,7 @@ endobj
 /Type /Annot
 >>
 endobj
-674 0 obj
+675 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_paths1)
 /Subtype /Link
@@ -44964,7 +45024,7 @@ endobj
 /Type /Annot
 >>
 endobj
-675 0 obj
+676 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_paths1)
 /Subtype /Link
@@ -44972,7 +45032,7 @@ endobj
 /Type /Annot
 >>
 endobj
-676 0 obj
+677 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_prune1)
 /Subtype /Link
@@ -44980,7 +45040,7 @@ endobj
 /Type /Annot
 >>
 endobj
-677 0 obj
+678 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_prune1)
 /Subtype /Link
@@ -44988,7 +45048,7 @@ endobj
 /Type /Annot
 >>
 endobj
-678 0 obj
+679 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_unchop1)
 /Subtype /Link
@@ -44996,7 +45056,7 @@ endobj
 /Type /Annot
 >>
 endobj
-679 0 obj
+680 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_unchop1)
 /Subtype /Link
@@ -45004,7 +45064,7 @@ endobj
 /Type /Annot
 >>
 endobj
-680 0 obj
+681 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_normalize1)
 /Subtype /Link
@@ -45012,7 +45072,7 @@ endobj
 /Type /Annot
 >>
 endobj
-681 0 obj
+682 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_normalize1)
 /Subtype /Link
@@ -45020,7 +45080,7 @@ endobj
 /Type /Annot
 >>
 endobj
-682 0 obj
+683 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_bin1)
 /Subtype /Link
@@ -45028,7 +45088,7 @@ endobj
 /Type /Annot
 >>
 endobj
-683 0 obj
+684 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_bin1)
 /Subtype /Link
@@ -45036,7 +45096,7 @@ endobj
 /Type /Annot
 >>
 endobj
-684 0 obj
+685 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_matrix1)
 /Subtype /Link
@@ -45044,7 +45104,7 @@ endobj
 /Type /Annot
 >>
 endobj
-685 0 obj
+686 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_matrix1)
 /Subtype /Link
@@ -45052,7 +45112,7 @@ endobj
 /Type /Annot
 >>
 endobj
-686 0 obj
+687 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_chop1)
 /Subtype /Link
@@ -45060,7 +45120,7 @@ endobj
 /Type /Annot
 >>
 endobj
-687 0 obj
+688 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_chop1)
 /Subtype /Link
@@ -45068,7 +45128,7 @@ endobj
 /Type /Annot
 >>
 endobj
-688 0 obj
+689 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_layout1)
 /Subtype /Link
@@ -45076,7 +45136,7 @@ endobj
 /Type /Annot
 >>
 endobj
-689 0 obj
+690 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_layout1)
 /Subtype /Link
@@ -45084,7 +45144,7 @@ endobj
 /Type /Annot
 >>
 endobj
-690 0 obj
+691 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_flatten1)
 /Subtype /Link
@@ -45092,7 +45152,7 @@ endobj
 /Type /Annot
 >>
 endobj
-691 0 obj
+692 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_flatten1)
 /Subtype /Link
@@ -45100,7 +45160,7 @@ endobj
 /Type /Annot
 >>
 endobj
-692 0 obj
+693 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_break1)
 /Subtype /Link
@@ -45108,7 +45168,7 @@ endobj
 /Type /Annot
 >>
 endobj
-693 0 obj
+694 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_break1)
 /Subtype /Link
@@ -45116,7 +45176,7 @@ endobj
 /Type /Annot
 >>
 endobj
-694 0 obj
+695 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_pathindex1)
 /Subtype /Link
@@ -45124,7 +45184,7 @@ endobj
 /Type /Annot
 >>
 endobj
-695 0 obj
+696 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_pathindex1)
 /Subtype /Link
@@ -45132,7 +45192,7 @@ endobj
 /Type /Annot
 >>
 endobj
-696 0 obj
+697 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_panpos1)
 /Subtype /Link
@@ -45140,7 +45200,7 @@ endobj
 /Type /Annot
 >>
 endobj
-697 0 obj
+698 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_panpos1)
 /Subtype /Link
@@ -45148,7 +45208,7 @@ endobj
 /Type /Annot
 >>
 endobj
-698 0 obj
+699 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_position1)
 /Subtype /Link
@@ -45156,7 +45216,7 @@ endobj
 /Type /Annot
 >>
 endobj
-699 0 obj
+700 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_position1)
 /Subtype /Link
@@ -45164,7 +45224,7 @@ endobj
 /Type /Annot
 >>
 endobj
-700 0 obj
+701 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_server1)
 /Subtype /Link
@@ -45172,7 +45232,7 @@ endobj
 /Type /Annot
 >>
 endobj
-701 0 obj
+702 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_server1)
 /Subtype /Link
@@ -45180,7 +45240,7 @@ endobj
 /Type /Annot
 >>
 endobj
-702 0 obj
+703 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_test1)
 /Subtype /Link
@@ -45188,7 +45248,7 @@ endobj
 /Type /Annot
 >>
 endobj
-703 0 obj
+704 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_test1)
 /Subtype /Link
@@ -45196,7 +45256,7 @@ endobj
 /Type /Annot
 >>
 endobj
-704 0 obj
+705 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_version1)
 /Subtype /Link
@@ -45204,41 +45264,13 @@ endobj
 /Type /Annot
 >>
 endobj
-705 0 obj
+706 0 obj
 << /Border [0 0 0]
 /Dest (_odgi_version1)
 /Subtype /Link
 /Rect [535.301 212.87 547.04 227.15]
 /Type /Annot
 >>
-endobj
-706 0 obj
-<< /Type /XObject
-/Subtype /Form
-/BBox [0 0 595.28 841.89]
-/Length 162
->>
-stream
-q
-/DeviceRGB cs
-0.0 0.0 0.0 scn
-/DeviceRGB CS
-0.0 0.0 0.0 SCN
-1 w
-0 J
-0 j
-[] 0 d
-q
-0.25 w
-/DeviceRGB CS
-0.8667 0.8667 0.8667 SCN
-48.24 30.0 m
-547.04 30.0 l
-S
-Q
-Q
-
-endstream
 endobj
 707 0 obj
 << /Type /XObject
@@ -45269,299 +45301,327 @@ Q
 endstream
 endobj
 708 0 obj
-<< /Type /Outlines
-/Count 32
-/First 709 0 R
-/Last 740 0 R
+<< /Type /XObject
+/Subtype /Form
+/BBox [0 0 595.28 841.89]
+/Length 162
 >>
+stream
+q
+/DeviceRGB cs
+0.0 0.0 0.0 scn
+/DeviceRGB CS
+0.0 0.0 0.0 SCN
+1 w
+0 J
+0 j
+[] 0 d
+q
+0.25 w
+/DeviceRGB CS
+0.8667 0.8667 0.8667 SCN
+48.24 30.0 m
+547.04 30.0 l
+S
+Q
+Q
+
+endstream
 endobj
 709 0 obj
-<< /Title <feff005200650066006500720065006e0063006500200044006f00630075006d0065006e0074006100740069006f006e00200066006f00720020004f004400470049002000760030002e0036002e0030>
-/Parent 708 0 R
-/Count 0
-/Next 710 0 R
-/Dest [7 0 R /XYZ 0 841.89 null]
+<< /Type /Outlines
+/Count 32
+/First 710 0 R
+/Last 741 0 R
 >>
 endobj
 710 0 obj
-<< /Title <feff005400610062006c00650020006f006600200043006f006e00740065006e00740073>
-/Parent 708 0 R
+<< /Title <feff005200650066006500720065006e0063006500200044006f00630075006d0065006e0074006100740069006f006e00200066006f00720020004f004400470049002000760030002e0036002e0030>
+/Parent 709 0 R
 /Count 0
 /Next 711 0 R
-/Prev 709 0 R
-/Dest [10 0 R /XYZ 0 841.89 null]
+/Dest [7 0 R /XYZ 0 841.89 null]
 >>
 endobj
 711 0 obj
-<< /Title <feff0031002e0020006f0064006700690020002800310029>
-/Parent 708 0 R
+<< /Title <feff005400610062006c00650020006f006600200043006f006e00740065006e00740073>
+/Parent 709 0 R
 /Count 0
 /Next 712 0 R
 /Prev 710 0 R
-/Dest [12 0 R /XYZ 0 841.89 null]
+/Dest [10 0 R /XYZ 0 841.89 null]
 >>
 endobj
 712 0 obj
-<< /Title <feff0032002e0020006f0064006700690020006200750069006c0064002800310029>
-/Parent 708 0 R
+<< /Title <feff0031002e0020006f0064006700690020002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 713 0 R
 /Prev 711 0 R
-/Dest [93 0 R /XYZ 0 290.88 null]
+/Dest [12 0 R /XYZ 0 841.89 null]
 >>
 endobj
 713 0 obj
-<< /Title <feff0033002e0020006f006400670069002000730074006100740073002800310029>
-/Parent 708 0 R
+<< /Title <feff0032002e0020006f0064006700690020006200750069006c0064002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 714 0 R
 /Prev 712 0 R
-/Dest [116 0 R /XYZ 0 541.77 null]
+/Dest [93 0 R /XYZ 0 290.88 null]
 >>
 endobj
 714 0 obj
-<< /Title <feff0034002e0020006f006400670069002000640065007000740068002800310029>
-/Parent 708 0 R
+<< /Title <feff0033002e0020006f006400670069002000730074006100740073002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 715 0 R
 /Prev 713 0 R
-/Dest [136 0 R /XYZ 0 541.77 null]
+/Dest [116 0 R /XYZ 0 541.77 null]
 >>
 endobj
 715 0 obj
-<< /Title <feff0035002e0020006f00640067006900200073006f00720074002800310029>
-/Parent 708 0 R
+<< /Title <feff0034002e0020006f006400670069002000640065007000740068002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 716 0 R
 /Prev 714 0 R
-/Dest [155 0 R /XYZ 0 674.97 null]
+/Dest [136 0 R /XYZ 0 541.77 null]
 >>
 endobj
 716 0 obj
-<< /Title <feff0036002e0020006f006400670069002000670072006f006f006d002800310029>
-/Parent 708 0 R
+<< /Title <feff0035002e0020006f00640067006900200073006f00720074002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 717 0 R
 /Prev 715 0 R
-/Dest [186 0 R /XYZ 0 204.33 null]
+/Dest [155 0 R /XYZ 0 674.97 null]
 >>
 endobj
 717 0 obj
-<< /Title <feff0037002e0020006f00640067006900200063006f007600650072002800310029>
-/Parent 708 0 R
+<< /Title <feff0036002e0020006f006400670069002000670072006f006f006d002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 718 0 R
 /Prev 716 0 R
-/Dest [209 0 R /XYZ 0 841.89 null]
+/Dest [186 0 R /XYZ 0 204.33 null]
 >>
 endobj
 718 0 obj
-<< /Title <feff0038002e0020006f0064006700690020006500780070006c006f00640065002800310029>
-/Parent 708 0 R
+<< /Title <feff0037002e0020006f00640067006900200063006f007600650072002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 719 0 R
 /Prev 717 0 R
-/Dest [219 0 R /XYZ 0 254.64 null]
+/Dest [209 0 R /XYZ 0 841.89 null]
 >>
 endobj
 719 0 obj
-<< /Title <feff0039002e0020006f006400670069002000730071007500650065007a0065002800310029>
-/Parent 708 0 R
+<< /Title <feff0038002e0020006f0064006700690020006500780070006c006f00640065002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 720 0 R
 /Prev 718 0 R
-/Dest [243 0 R /XYZ 0 674.97 null]
+/Dest [219 0 R /XYZ 0 254.64 null]
 >>
 endobj
 720 0 obj
-<< /Title <feff00310030002e0020006f00640067006900200065007800740072006100630074002800310029>
-/Parent 708 0 R
+<< /Title <feff0039002e0020006f006400670069002000730071007500650065007a0065002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 721 0 R
 /Prev 719 0 R
-/Dest [257 0 R /XYZ 0 410.57 null]
+/Dest [243 0 R /XYZ 0 674.97 null]
 >>
 endobj
 721 0 obj
-<< /Title <feff00310031002e0020006f00640067006900200076006900650077002800310029>
-/Parent 708 0 R
+<< /Title <feff00310030002e0020006f00640067006900200065007800740072006100630074002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 722 0 R
 /Prev 720 0 R
-/Dest [278 0 R /XYZ 0 541.77 null]
+/Dest [257 0 R /XYZ 0 330.73 null]
 >>
 endobj
 722 0 obj
-<< /Title <feff00310032002e0020006f0064006700690020006b006d006500720073002800310029>
-/Parent 708 0 R
+<< /Title <feff00310031002e0020006f00640067006900200076006900650077002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 723 0 R
 /Prev 721 0 R
-/Dest [291 0 R /XYZ 0 398.54 null]
+/Dest [277 0 R /XYZ 0 382.09 null]
 >>
 endobj
 723 0 obj
-<< /Title <feff00310033002e0020006f00640067006900200075006e0069007400690067002800310029>
-/Parent 708 0 R
+<< /Title <feff00310032002e0020006f0064006700690020006b006d006500720073002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 724 0 R
 /Prev 722 0 R
-/Dest [313 0 R /XYZ 0 841.89 null]
+/Dest [290 0 R /XYZ 0 224.13 null]
 >>
 endobj
 724 0 obj
-<< /Title <feff00310034002e0020006f006400670069002000760069007a002800310029>
-/Parent 708 0 R
+<< /Title <feff00310033002e0020006f00640067006900200075006e0069007400690067002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 725 0 R
 /Prev 723 0 R
-/Dest [326 0 R /XYZ 0 541.77 null]
+/Dest [311 0 R /XYZ 0 674.97 null]
 >>
 endobj
 725 0 obj
-<< /Title <feff00310035002e0020006f006400670069002000700061007400680073002800310029>
-/Parent 708 0 R
+<< /Title <feff00310034002e0020006f006400670069002000760069007a002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 726 0 R
 /Prev 724 0 R
-/Dest [350 0 R /XYZ 0 327.27 null]
+/Dest [326 0 R /XYZ 0 410.57 null]
 >>
 endobj
 726 0 obj
-<< /Title <feff00310036002e0020006f0064006700690020007000720075006e0065002800310029>
-/Parent 708 0 R
+<< /Title <feff00310035002e0020006f006400670069002000700061007400680073002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 727 0 R
 /Prev 725 0 R
-/Dest [369 0 R /XYZ 0 541.77 null]
+/Dest [350 0 R /XYZ 0 141.5 null]
 >>
 endobj
 727 0 obj
-<< /Title <feff00310037002e0020006f00640067006900200075006e00630068006f0070002800310029>
-/Parent 708 0 R
+<< /Title <feff00310036002e0020006f0064006700690020007000720075006e0065002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 728 0 R
 /Prev 726 0 R
-/Dest [391 0 R /XYZ 0 541.77 null]
+/Dest [367 0 R /XYZ 0 330.73 null]
 >>
 endobj
 728 0 obj
-<< /Title <feff00310038002e0020006f0064006700690020006e006f0072006d0061006c0069007a0065002800310029>
-/Parent 708 0 R
+<< /Title <feff00310037002e0020006f00640067006900200075006e00630068006f0070002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 729 0 R
 /Prev 727 0 R
-/Dest [404 0 R /XYZ 0 350.26 null]
+/Dest [390 0 R /XYZ 0 382.09 null]
 >>
 endobj
 729 0 obj
-<< /Title <feff00310039002e0020006f006400670069002000620069006e002800310029>
-/Parent 708 0 R
+<< /Title <feff00310038002e0020006f0064006700690020006e006f0072006d0061006c0069007a0065002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 730 0 R
 /Prev 728 0 R
-/Dest [417 0 R /XYZ 0 153.27 null]
+/Dest [403 0 R /XYZ 0 160.07 null]
 >>
 endobj
 730 0 obj
-<< /Title <feff00320030002e0020006f0064006700690020006d00610074007200690078002800310029>
-/Parent 708 0 R
+<< /Title <feff00310039002e0020006f006400670069002000620069006e002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 731 0 R
 /Prev 729 0 R
-/Dest [446 0 R /XYZ 0 463.38 null]
+/Dest [428 0 R /XYZ 0 742.83 null]
 >>
 endobj
 731 0 obj
-<< /Title <feff00320031002e0020006f006400670069002000630068006f0070002800310029>
-/Parent 708 0 R
+<< /Title <feff00320030002e0020006f0064006700690020006d00610074007200690078002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 732 0 R
 /Prev 730 0 R
-/Dest [460 0 R /XYZ 0 335.53 null]
+/Dest [446 0 R /XYZ 0 285.89 null]
 >>
 endobj
 732 0 obj
-<< /Title <feff00320032002e0020006f0064006700690020006c00610079006f00750074002800310029>
-/Parent 708 0 R
+<< /Title <feff00320031002e0020006f006400670069002000630068006f0070002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 733 0 R
 /Prev 731 0 R
-/Dest [485 0 R /XYZ 0 841.89 null]
+/Dest [457 0 R /XYZ 0 116.19 null]
 >>
 endobj
 733 0 obj
-<< /Title <feff00320033002e0020006f00640067006900200066006c0061007400740065006e002800310029>
-/Parent 708 0 R
+<< /Title <feff00320032002e0020006f0064006700690020006c00610079006f00750074002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 734 0 R
 /Prev 732 0 R
-/Dest [497 0 R /XYZ 0 350.26 null]
+/Dest [482 0 R /XYZ 0 541.77 null]
 >>
 endobj
 734 0 obj
-<< /Title <feff00320034002e0020006f00640067006900200062007200650061006b002800310029>
-/Parent 708 0 R
+<< /Title <feff00320033002e0020006f00640067006900200066006c0061007400740065006e002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 735 0 R
 /Prev 733 0 R
-/Dest [509 0 R /XYZ 0 137.49 null]
+/Dest [506 0 R /XYZ 0 841.89 null]
 >>
 endobj
 735 0 obj
-<< /Title <feff00320035002e0020006f006400670069002000700061007400680069006e006400650078002800310029>
-/Parent 708 0 R
+<< /Title <feff00320034002e0020006f00640067006900200062007200650061006b002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 736 0 R
 /Prev 734 0 R
-/Dest [534 0 R /XYZ 0 623.61 null]
+/Dest [517 0 R /XYZ 0 623.61 null]
 >>
 endobj
 736 0 obj
-<< /Title <feff00320036002e0020006f006400670069002000700061006e0070006f0073002800310029>
-/Parent 708 0 R
+<< /Title <feff00320035002e0020006f006400670069002000700061007400680069006e006400650078002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 737 0 R
 /Prev 735 0 R
-/Dest [550 0 R /XYZ 0 541.77 null]
+/Dest [533 0 R /XYZ 0 364.01 null]
 >>
 endobj
 737 0 obj
-<< /Title <feff00320037002e0020006f00640067006900200070006f0073006900740069006f006e002800310029>
-/Parent 708 0 R
+<< /Title <feff00320036002e0020006f006400670069002000700061006e0070006f0073002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 738 0 R
 /Prev 736 0 R
-/Dest [566 0 R /XYZ 0 383.54 null]
+/Dest [547 0 R /XYZ 0 279.67 null]
 >>
 endobj
 738 0 obj
-<< /Title <feff00320038002e0020006f0064006700690020007300650072007600650072002800310029>
-/Parent 708 0 R
+<< /Title <feff00320037002e0020006f00640067006900200070006f0073006900740069006f006e002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 739 0 R
 /Prev 737 0 R
-/Dest [585 0 R /XYZ 0 541.77 null]
+/Dest [574 0 R /XYZ 0 841.89 null]
 >>
 endobj
 739 0 obj
-<< /Title <feff00320039002e0020006f00640067006900200074006500730074002800310029>
-/Parent 708 0 R
+<< /Title <feff00320038002e0020006f0064006700690020007300650072007600650072002800310029>
+/Parent 709 0 R
 /Count 0
 /Next 740 0 R
 /Prev 738 0 R
-/Dest [603 0 R /XYZ 0 335.53 null]
+/Dest [584 0 R /XYZ 0 241.36 null]
 >>
 endobj
 740 0 obj
-<< /Title <feff00330030002e0020006f006400670069002000760065007200730069006f006e002800310029>
-/Parent 708 0 R
+<< /Title <feff00320039002e0020006f00640067006900200074006500730074002800310029>
+/Parent 709 0 R
 /Count 0
+/Next 741 0 R
 /Prev 739 0 R
-/Dest [627 0 R /XYZ 0 742.83 null]
+/Dest [611 0 R /XYZ 0 742.83 null]
 >>
 endobj
 741 0 obj
+<< /Title <feff00330030002e0020006f006400670069002000760065007200730069006f006e002800310029>
+/Parent 709 0 R
+/Count 0
+/Prev 740 0 R
+/Dest [625 0 R /XYZ 0 364.01 null]
+>>
+endobj
+742 0 obj
 << /Nums [0 << /P (i)
 >> 1 << /P (ii)
 >> 2 << /P (1)
@@ -45623,7 +45683,7 @@ endobj
 >>]
 >>
 endobj
-742 0 obj
+743 0 obj
 << /Length1 14216
 /Length 8875
 /Filter [/FlateDecode]
@@ -45661,10 +45721,10 @@ Q1düeê;W@$\ı@™F5®<e™G®1/˚{°>lEm®≠úÎ—¥ÌEœ`åûEÑLèŸlE6v	∏˚él≠Ïä0≈dóù0‚
 \I”,Z`Ü≈˛u®Ù›…ÄÑ9ˆ≤6…»aêïNÛ¡}‹h˘3i0≥“Ü3Z£èE`õ∞s(&≠’kJ jÀÃä’◊Î‚j  S+H5ò˚$ÃTÉ·ï@‹®ÖMVõíÂé∏ﬂﬁ±–’+~c`Cd˛ˇa÷çΩ}sÓ˜ãgàœ(Ù+A7‚“$ˆÛˇˆ£6
 endstream
 endobj
-743 0 obj
+744 0 obj
 << /Type /FontDescriptor
 /FontName /6f2aa1+NotoSerif
-/FontFile2 742 0 R
+/FontFile2 743 0 R
 /FontBBox [-212 -250 1246 1047]
 /Flags 6
 /StemV 0
@@ -45675,7 +45735,7 @@ endobj
 /XHeight 1098
 >>
 endobj
-744 0 obj
+745 0 obj
 << /Length 1286
 /Filter [/FlateDecode]
 >>
@@ -45685,10 +45745,10 @@ xúe◊Àn€FÜ·ΩÆBÀtHs&√@ënºËu{st‘í +ﬂ}˘Ω§i ∆/âúyæ_√!u¯ÙÙ””˘tﬂ~ª]ÍsøÔ«È‹n˝Ì
 ø‚ÌJº‚ÌJº‚Ìäπ‚Ì‚¨xªØxªØxáê+ﬁ!√äwπ‚BÆxábÆxáê+ﬁÅÔr≈;‡‡2‰ÕkÁŒúÒJºY≥eºYÜå7+|ú∆xãoSäå7+[∆õe»õ◊öyﬁ¢oV˚ÚÊµñ-„≠åã∑ÈÄ"ØÂ˛R¶Wç*ñ”4XqîÍCô^J˙[(£‡Æ^É1¬¬ª¢y]ï°»kπ}ºYM-x•˙Î»VÊzê∑Ã˛ [YE„VºY≥’Ÿ_}/7◊*ØY%´ÍØe„≠”´q+˝›:˜›.‚ø7ôJ„ã»€E°/â3Y(Yô*AàW	Rı›VJSÉ™Ç∂·:(u@c°D±]a*’Ìf)§9J≠ÒÊ)•o,#⁄\ÿZ>MçU°€\ÿjPS„{HS„ÁM™ïÙjªà∑í{fkîå∞yG·âm[z*EÔsaÎ›>ä&Ó”´”˙Ùj%uº‹Ó;•2^êù∆W√[’ﬂŒ¬ÆÚv˙[æœ˛2ÓÏØ≤u˙[ï¢≥Pö:ŸÁ¬VÃ°ß’Ö>ºMÜ¡Bi2.ƒ¶â«‹Ë‘á!Ø·Òd»kπ`Üºñ=oÃëqWﬁïwdJF(îL164ﬁU†—)ôx0E˙~ÍÒZ? æ=∂◊/∑€ˆƒŒØ’ıê~:˜o?$Æó´Œ“ˇøÁÜÛO
 endstream
 endobj
-745 0 obj
+746 0 obj
 [259 333 408 559 1000 1000 1000 220 346 346 500 559 250 310 250 288 559 559 559 559 559 559 559 559 559 559 286 286 559 559 559 500 1000 705 653 613 727 623 589 713 792 367 356 700 623 937 763 742 604 742 655 543 612 716 674 1046 660 625 591 359 1000 359 1000 458 1000 562 613 492 613 535 369 538 634 319 299 584 310 944 645 577 613 613 471 451 352 634 579 861 578 564 511 1000 559 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 634 1000 1000 1000 1000 1000 361 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 857 259 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 250 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000]
 endobj
-746 0 obj
+747 0 obj
 << /Length1 13012
 /Length 8628
 /Filter [/FlateDecode]
@@ -45733,10 +45793,10 @@ wL˝ZPÔ¸@a‘W5hıÄyh¡Òá·ü=ˇ÷${’«>‡u¸ﬂãcSc⁄÷æâ°~0ç1xjûjeüB˝•c·^0§1‡‘ªblt
 1íuoÔ]?Ò˛¸‚1LÚÕüuˇÓ˛Ò
 endstream
 endobj
-747 0 obj
+748 0 obj
 << /Type /FontDescriptor
 /FontName /bbfc52+NotoSerif-Bold
-/FontFile2 746 0 R
+/FontFile2 747 0 R
 /FontBBox [-212 -250 1306 1058]
 /Flags 6
 /StemV 0
@@ -45747,7 +45807,7 @@ endobj
 /XHeight 1098
 >>
 endobj
-748 0 obj
+749 0 obj
 << /Length 1286
 /Filter [/FlateDecode]
 >>
@@ -45757,10 +45817,10 @@ xúe◊Àn€FÜ·ΩÆBÀtHs&√@ënºËu{st‘í +ﬂ}˘Ω§i ∆/âúyæ_√!u¯ÙÙ””˘tﬂ~ª]ÍsøÔ«È‹n˝Ì
 ø‚ÌJº‚ÌJº‚Ìäπ‚Ì‚¨xªØxªØxáê+ﬁ!√äwπ‚BÆxábÆxáê+ﬁÅÔr≈;‡‡2‰ÕkÁŒúÒJºY≥eºYÜå7+|ú∆xãoSäå7+[∆õe»õ◊öyﬁ¢oV˚ÚÊµñ-„≠åã∑ÈÄ"ØÂ˛R¶Wç*ñ”4XqîÍCô^J˙[(£‡Æ^É1¬¬ª¢y]ï°»kπ}ºYM-x•˙Î»VÊzê∑Ã˛ [YE„VºY≥’Ÿ_}/7◊*ØY%´ÍØe„≠”´q+˝›:˜›.‚ø7ôJ„ã»€E°/â3Y(Yô*AàW	Rı›VJSÉ™Ç∂·:(u@c°D±]a*’Ìf)§9J≠ÒÊ)•o,#⁄\ÿZ>MçU°€\ÿjPS„{HS„ÁM™ïÙjªà∑í{fkîå∞yG·âm[z*EÔsaÎ›>ä&Ó”´”˙Ùj%uº‹Ó;•2^êù∆W√[’ﬂŒ¬ÆÚv˙[æœ˛2ÓÏØ≤u˙[ï¢≥Pö:ŸÁ¬VÃ°ß’Ö>ºMÜ¡Bi2.ƒ¶â«‹Ë‘á!Ø·Òd»kπ`Üºñ=oÃëqWﬁïwdJF(îL164ﬁU†—)ôx0E˙~ÍÒZ? æ=∂◊/∑€ˆƒŒØ’ıê~:˜o?$Æó´Œ“ˇøÁÜÛO
 endstream
 endobj
-749 0 obj
+750 0 obj
 [259 1000 1000 559 1000 1000 1000 1000 399 399 1000 1000 293 310 293 288 559 559 559 559 559 559 559 559 559 559 304 1000 1000 559 1000 549 1000 752 671 667 767 652 621 769 818 400 1000 733 653 952 788 787 638 787 707 585 652 747 698 1066 731 692 666 414 1000 414 1000 458 1000 599 648 526 648 570 407 560 666 352 345 636 352 985 666 612 645 647 522 487 404 666 605 855 645 579 528 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000]
 endobj
-750 0 obj
+751 0 obj
 << /Length1 8492
 /Length 5712
 /Filter [/FlateDecode]
@@ -45798,10 +45858,10 @@ lñÖo’®8,4ÿ0!<Ä√I	‰•pbK*U&UUÖ)ø†ÃT1Ge)Íß!zîpf5¡QÇL`“jö4ßﬂc]ÙCråˇ‹rèﬁ
 áÌ#V/7€i“ø©a¸ÑÛı˝Ìﬂú≠w	≤ª&ÕÖ~08˛¸Fˆ«s
 endstream
 endobj
-751 0 obj
+752 0 obj
 << /Type /FontDescriptor
 /FontName /640789+NotoSerif-Italic
-/FontFile2 750 0 R
+/FontFile2 751 0 R
 /FontBBox [-254 -250 1238 1047]
 /Flags 70
 /StemV 0
@@ -45812,7 +45872,7 @@ endobj
 /XHeight 1098
 >>
 endobj
-752 0 obj
+753 0 obj
 << /Length 1286
 /Filter [/FlateDecode]
 >>
@@ -45822,10 +45882,10 @@ xúe◊Àn€FÜ·ΩÆBÀtHs&√@ënºËu{st‘í +ﬂ}˘Ω§i ∆/âúyæ_√!u¯ÙÙ””˘tﬂ~ª]ÍsøÔ«È‹n˝Ì
 ø‚ÌJº‚ÌJº‚Ìäπ‚Ì‚¨xªØxªØxáê+ﬁ!√äwπ‚BÆxábÆxáê+ﬁÅÔr≈;‡‡2‰ÕkÁŒúÒJºY≥eºYÜå7+|ú∆xãoSäå7+[∆õe»õ◊öyﬁ¢oV˚ÚÊµñ-„≠åã∑ÈÄ"ØÂ˛R¶Wç*ñ”4XqîÍCô^J˙[(£‡Æ^É1¬¬ª¢y]ï°»kπ}ºYM-x•˙Î»VÊzê∑Ã˛ [YE„VºY≥’Ÿ_}/7◊*ØY%´ÍØe„≠”´q+˝›:˜›.‚ø7ôJ„ã»€E°/â3Y(Yô*AàW	Rı›VJSÉ™Ç∂·:(u@c°D±]a*’Ìf)§9J≠ÒÊ)•o,#⁄\ÿZ>MçU°€\ÿjPS„{HS„ÁM™ïÙjªà∑í{fkîå∞yG·âm[z*EÔsaÎ›>ä&Ó”´”˙Ùj%uº‹Ó;•2^êù∆W√[’ﬂŒ¬ÆÚv˙[æœ˛2ÓÏØ≤u˙[ï¢≥Pö:ŸÁ¬VÃ°ß’Ö>ºMÜ¡Bi2.ƒ¶â«‹Ë‘á!Ø·Òd»kπ`Üºñ=oÃëqWﬁïwdJF(îL164ﬁU†—)ôx0E˙~ÍÒZ? æ=∂◊/∑€ˆƒŒØ’ıê~:˜o?$Æó´Œ“ˇøÁÜÛO
 endstream
 endobj
-753 0 obj
+754 0 obj
 [259 333 408 1000 1000 1000 1000 1000 1000 1000 1000 1000 250 310 250 288 559 559 559 559 559 559 1000 1000 559 559 286 1000 1000 559 1000 1000 1000 705 653 1000 725 623 589 713 1000 367 1000 1000 623 1000 763 742 620 1000 664 543 612 729 1000 1000 1000 625 1000 1000 1000 1000 1000 458 1000 579 562 486 579 493 317 556 599 304 1000 568 304 895 599 574 577 560 467 463 368 599 538 1000 545 527 1000 1000 559 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000]
 endobj
-754 0 obj
+755 0 obj
 << /Length1 2332
 /Length 1148
 /Filter [/FlateDecode]
@@ -45840,10 +45900,10 @@ j'‰:èΩh∫zpì˚•VÂ[B:B(-B"ôb›Ê„K˙—ˇ°ã >\è˝Ó93t,èG¶Ó‡ù'ü©'R4¡ÂÊÙHÁUœvº#
 b_à„¥Ñ¸Ädä%cGQeT”øh™ñêX5|W´hHƒ◊D)F≈m¢a„æ`Q¡±´©*pÛ4Oûç&ôkµöÍ m	Í0™sM¸T∞ÏÕzó;VEt‘Pﬁ1L/ÑbUØh<≤M>^—rÊﬂ©¿¨:Dy¯‡Úƒ«Tî:EM∆:ÿBùqƒ”±ÆaÌı9dg„nŸ£.2P˝¿“ ç,B-?319[òå≥8xøzKTÃ4’†jkÙHÖ7Aì®¸˙¡Ftq∑£eû˛r£˜≥óéém(ùiqç}˚˚ªvF¸ﬂQ«fzI‹∂Ú˘∆8îï
 endstream
 endobj
-755 0 obj
+756 0 obj
 << /Type /FontDescriptor
 /FontName /cfcc73+NotoSerif
-/FontFile2 754 0 R
+/FontFile2 755 0 R
 /FontBBox [-212 -250 1246 1047]
 /Flags 6
 /StemV 0
@@ -45854,7 +45914,7 @@ endobj
 /XHeight 1098
 >>
 endobj
-756 0 obj
+757 0 obj
 << /Length 226
 /Filter [/FlateDecode]
 >>
@@ -45863,10 +45923,10 @@ xú]êœjƒ ∆Ô>≈∑áE„≠ BŸ^rËöˆåé©–®s»€wtó-Ù0Éﬂ¸Üœ·óÒyå°/…NX¡áË
 ni/a∆%D6Hp¡÷õÍ›Æ&3Ntl◊1˙J1˛AÊVÀß'óf|`¸≠8,!.p˙∫L§ß=Á\1VLkpËi—ã…ØfE‡;èé¸Pè31üGFê]◊069‹≤±XL\ê)!¥Ú^3åÓü%Ø¿ÏÌ∑)LIÇ:=Mı(;uÛﬂ~xœe˜R(R?Cœ“RÑà˜KÂî’ÍnGo¸
 endstream
 endobj
-757 0 obj
+758 0 obj
 [259 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000]
 endobj
-758 0 obj
+759 0 obj
 << /Length1 8728
 /Length 5580
 /Filter [/FlateDecode]
@@ -45905,10 +45965,10 @@ T£¥ÇH@aAà)L€a
 åAZúFªÆO?gjöÒõuÌÎ˛ÙËHåLÑÉ—uﬁˆ”BÖLåÜÜº¢˛`"HŒƒ"£±HñC8DŒíKlC+ÿ˙·K	Z«»&BCI0Ò∂FDòˆ… OÆ&¥òH"1Qa±≈CaÛmbÛP<jô∞@ qÈ	¯~,V®xúÊbÜ<ñmj¶ÈQx1÷7ñÛÆ]ªÃQV-öıtb&4_√y˝ﬂπ¨FΩÃ{“f†tN-£C·ÿ4¥ÿL,û"ë0Y=Ç'ˆN1πå•f+,–0:!Øù´!÷é!:<);DhÎTCyA¯≥Z˝N1§¨ÁR*úWË§ò„S#ñq≈¥••±vC†kÉâB±ææ¡RÕêÛ¥©Ö…ß%È”ê“Ø∂ù Ã√0∑iÈLÔÄﬂÛÀ—€2‹ü¡Ió…€˜/˝vÒ<ˇA€yª`’\O˛ïô÷
 endstream
 endobj
-759 0 obj
+760 0 obj
 << /Type /FontDescriptor
 /FontName /e3b334+NotoSerif-BoldItalic
-/FontFile2 758 0 R
+/FontFile2 759 0 R
 /FontBBox [-265 -250 1289 1058]
 /Flags 70
 /StemV 0
@@ -45919,7 +45979,7 @@ endobj
 /XHeight 1098
 >>
 endobj
-760 0 obj
+761 0 obj
 << /Length 1286
 /Filter [/FlateDecode]
 >>
@@ -45929,10 +45989,10 @@ xúe◊Àn€FÜ·ΩÆBÀtHs&√@ënºËu{st‘í +ﬂ}˘Ω§i ∆/âúyæ_√!u¯ÙÙ””˘tﬂ~ª]ÍsøÔ«È‹n˝Ì
 ø‚ÌJº‚ÌJº‚Ìäπ‚Ì‚¨xªØxªØxáê+ﬁ!√äwπ‚BÆxábÆxáê+ﬁÅÔr≈;‡‡2‰ÕkÁŒúÒJºY≥eºYÜå7+|ú∆xãoSäå7+[∆õe»õ◊öyﬁ¢oV˚ÚÊµñ-„≠åã∑ÈÄ"ØÂ˛R¶Wç*ñ”4XqîÍCô^J˙[(£‡Æ^É1¬¬ª¢y]ï°»kπ}ºYM-x•˙Î»VÊzê∑Ã˛ [YE„VºY≥’Ÿ_}/7◊*ØY%´ÍØe„≠”´q+˝›:˜›.‚ø7ôJ„ã»€E°/â3Y(Yô*AàW	Rı›VJSÉ™Ç∂·:(u@c°D±]a*’Ìf)§9J≠ÒÊ)•o,#⁄\ÿZ>MçU°€\ÿjPS„{HS„ÁM™ïÙjªà∑í{fkîå∞yG·âm[z*EÔsaÎ›>ä&Ó”´”˙Ùj%uº‹Ó;•2^êù∆W√[’ﬂŒ¬ÆÚv˙[æœ˛2ÓÏØ≤u˙[ï¢≥Pö:ŸÁ¬VÃ°ß’Ö>ºMÜ¡Bi2.ƒ¶â«‹Ë‘á!Ø·Òd»kπ`Üºñ=oÃëqWﬁïwdJF(îL164ﬁU†—)ôx0E˙~ÍÒZ? æ=∂◊/∑€ˆƒŒØ’ıê~:˜o?$Æó´Œ“ˇøÁÜÛO
 endstream
 endobj
-761 0 obj
+762 0 obj
 [1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 310 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 752 1000 667 1000 632 621 795 818 400 1000 1000 653 1000 788 791 663 1000 707 585 652 1000 1000 1000 1000 1000 1000 414 1000 414 1000 458 1000 665 623 527 665 535 1000 580 655 354 1000 1000 354 969 671 618 623 630 550 514 416 672 1000 1000 604 585 1000 1000 559 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000]
 endobj
-762 0 obj
+763 0 obj
 << /Length1 4904
 /Length 3340
 /Filter [/FlateDecode]
@@ -45952,10 +46012,10 @@ e∂Úä ?/¯ˇÔC®ƒ}¯˜	©®œ◊óÎÀΩÂﬁ¸róﬁão}˜ﬁ`__ﬁÔ?ü7ò˜<Wo}–s˙¥ÁAÎÓ–˜æ¢Ωã+b)[ _x
 úEi˘!±p§xUñŸ.ñ¸BùÉ›-•tdß”” ˘/vw$∆
 endstream
 endobj
-763 0 obj
+764 0 obj
 << /Type /FontDescriptor
 /FontName /43494f+mplus1mn-regular
-/FontFile2 762 0 R
+/FontFile2 763 0 R
 /FontBBox [0 -230 1000 860]
 /Flags 4
 /StemV 0
@@ -45966,7 +46026,7 @@ endobj
 /XHeight 0
 >>
 endobj
-764 0 obj
+765 0 obj
 << /Length 1286
 /Filter [/FlateDecode]
 >>
@@ -45976,11 +46036,11 @@ xúe◊Àn€FÜ·ΩÆBÀtHs&√@ënºËu{st‘í +ﬂ}˘Ω§i ∆/âúyæ_√!u¯ÙÙ””˘tﬂ~ª]ÍsøÔ«È‹n˝Ì
 ø‚ÌJº‚ÌJº‚Ìäπ‚Ì‚¨xªØxªØxáê+ﬁ!√äwπ‚BÆxábÆxáê+ﬁÅÔr≈;‡‡2‰ÕkÁŒúÒJºY≥eºYÜå7+|ú∆xãoSäå7+[∆õe»õ◊öyﬁ¢oV˚ÚÊµñ-„≠åã∑ÈÄ"ØÂ˛R¶Wç*ñ”4XqîÍCô^J˙[(£‡Æ^É1¬¬ª¢y]ï°»kπ}ºYM-x•˙Î»VÊzê∑Ã˛ [YE„VºY≥’Ÿ_}/7◊*ØY%´ÍØe„≠”´q+˝›:˜›.‚ø7ôJ„ã»€E°/â3Y(Yô*AàW	Rı›VJSÉ™Ç∂·:(u@c°D±]a*’Ìf)§9J≠ÒÊ)•o,#⁄\ÿZ>MçU°€\ÿjPS„{HS„ÁM™ïÙjªà∑í{fkîå∞yG·âm[z*EÔsaÎ›>ä&Ó”´”˙Ùj%uº‹Ó;•2^êù∆W√[’ﬂŒ¬ÆÚv˙[æœ˛2ÓÏØ≤u˙[ï¢≥Pö:ŸÁ¬VÃ°ß’Ö>ºMÜ¡Bi2.ƒ¶â«‹Ë‘á!Ø·Òd»kπ`Üºñ=oÃëqWﬁïwdJF(îL164ﬁU†—)ôx0E˙~ÍÒZ? æ=∂◊/∑€ˆƒŒØ’ıê~:˜o?$Æó´Œ“ˇøÁÜÛO
 endstream
 endobj
-765 0 obj
+766 0 obj
 [500 1000 1000 1000 1000 1000 1000 1000 1000 1000 500 1000 500 500 500 500 500 1000 1000 1000 1000 1000 1000 1000 1000 1000 500 1000 1000 500 1000 1000 1000 500 1000 1000 1000 1000 1000 500 500 500 1000 1000 1000 1000 500 1000 500 1000 500 500 500 1000 1000 1000 1000 1000 1000 500 1000 500 1000 500 1000 500 500 500 500 500 500 500 500 500 1000 500 500 500 500 500 500 1000 500 500 500 500 500 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000 1000]
 endobj
 xref
-0 766
+0 767
 0000000000 65535 f 
 0000000015 00000 n 
 0000000344 00000 n 
@@ -46224,534 +46284,535 @@ xref
 0000288392 00000 n 
 0000288438 00000 n 
 0000288484 00000 n 
-0000296214 00000 n 
-0000296603 00000 n 
-0000296649 00000 n 
-0000296832 00000 n 
-0000296878 00000 n 
-0000296924 00000 n 
-0000296970 00000 n 
-0000297016 00000 n 
-0000297062 00000 n 
-0000297392 00000 n 
-0000297438 00000 n 
-0000297484 00000 n 
-0000297530 00000 n 
-0000297576 00000 n 
-0000304971 00000 n 
-0000305360 00000 n 
-0000305406 00000 n 
-0000305452 00000 n 
-0000305498 00000 n 
-0000305681 00000 n 
-0000305727 00000 n 
+0000296188 00000 n 
+0000296577 00000 n 
+0000296623 00000 n 
+0000296806 00000 n 
+0000296852 00000 n 
+0000296898 00000 n 
+0000296944 00000 n 
+0000296990 00000 n 
+0000297036 00000 n 
+0000297366 00000 n 
+0000297412 00000 n 
+0000297458 00000 n 
+0000297504 00000 n 
+0000297550 00000 n 
+0000304437 00000 n 
+0000304826 00000 n 
+0000304872 00000 n 
+0000304918 00000 n 
+0000304964 00000 n 
+0000305010 00000 n 
+0000305193 00000 n 
+0000305239 00000 n 
+0000305528 00000 n 
+0000305574 00000 n 
+0000305620 00000 n 
+0000305666 00000 n 
+0000305970 00000 n 
 0000306016 00000 n 
-0000306062 00000 n 
-0000306108 00000 n 
-0000306154 00000 n 
-0000306200 00000 n 
-0000306246 00000 n 
-0000306292 00000 n 
-0000314956 00000 n 
-0000315341 00000 n 
-0000315387 00000 n 
-0000315433 00000 n 
-0000315735 00000 n 
-0000315781 00000 n 
-0000315827 00000 n 
-0000322476 00000 n 
-0000322865 00000 n 
-0000322911 00000 n 
-0000322957 00000 n 
-0000323140 00000 n 
-0000323186 00000 n 
-0000323232 00000 n 
-0000323278 00000 n 
-0000323324 00000 n 
-0000323370 00000 n 
-0000323416 00000 n 
-0000323462 00000 n 
-0000323508 00000 n 
-0000330408 00000 n 
-0000330783 00000 n 
-0000330828 00000 n 
-0000330874 00000 n 
-0000330920 00000 n 
-0000331103 00000 n 
-0000331148 00000 n 
-0000331194 00000 n 
-0000331240 00000 n 
-0000331286 00000 n 
-0000331331 00000 n 
-0000331377 00000 n 
-0000338952 00000 n 
-0000339341 00000 n 
-0000339387 00000 n 
-0000339433 00000 n 
-0000339479 00000 n 
-0000339525 00000 n 
-0000339571 00000 n 
-0000339617 00000 n 
-0000339800 00000 n 
-0000339846 00000 n 
-0000348629 00000 n 
-0000349018 00000 n 
-0000349064 00000 n 
-0000349110 00000 n 
-0000349156 00000 n 
-0000349202 00000 n 
-0000349397 00000 n 
-0000349443 00000 n 
-0000349489 00000 n 
-0000349864 00000 n 
-0000349910 00000 n 
-0000349956 00000 n 
-0000350002 00000 n 
-0000358124 00000 n 
-0000358521 00000 n 
-0000358567 00000 n 
-0000358613 00000 n 
-0000358796 00000 n 
-0000358842 00000 n 
-0000358888 00000 n 
-0000358934 00000 n 
-0000358980 00000 n 
-0000359026 00000 n 
-0000359150 00000 n 
-0000359196 00000 n 
-0000359242 00000 n 
-0000370767 00000 n 
-0000371152 00000 n 
-0000371198 00000 n 
-0000371244 00000 n 
-0000371290 00000 n 
-0000381409 00000 n 
-0000381798 00000 n 
-0000381844 00000 n 
-0000381890 00000 n 
-0000382016 00000 n 
-0000382062 00000 n 
-0000388581 00000 n 
-0000388952 00000 n 
-0000388998 00000 n 
-0000389044 00000 n 
-0000389090 00000 n 
-0000389136 00000 n 
-0000389182 00000 n 
-0000389501 00000 n 
-0000389547 00000 n 
-0000389593 00000 n 
-0000389639 00000 n 
-0000399809 00000 n 
-0000400180 00000 n 
-0000400226 00000 n 
-0000400272 00000 n 
-0000400318 00000 n 
-0000400364 00000 n 
-0000400410 00000 n 
-0000400843 00000 n 
-0000408718 00000 n 
-0000409107 00000 n 
-0000409153 00000 n 
-0000409571 00000 n 
-0000409617 00000 n 
-0000409800 00000 n 
-0000409846 00000 n 
-0000409892 00000 n 
-0000409938 00000 n 
-0000409984 00000 n 
-0000410030 00000 n 
-0000410076 00000 n 
-0000410122 00000 n 
-0000419652 00000 n 
-0000420023 00000 n 
-0000420069 00000 n 
-0000420115 00000 n 
-0000420161 00000 n 
-0000420207 00000 n 
-0000420687 00000 n 
-0000420733 00000 n 
-0000420779 00000 n 
-0000428263 00000 n 
-0000428652 00000 n 
-0000428698 00000 n 
-0000428744 00000 n 
-0000428927 00000 n 
-0000428973 00000 n 
-0000429019 00000 n 
-0000429065 00000 n 
-0000429111 00000 n 
-0000429157 00000 n 
-0000429203 00000 n 
-0000429249 00000 n 
-0000429295 00000 n 
-0000436417 00000 n 
-0000436814 00000 n 
-0000436860 00000 n 
-0000436906 00000 n 
-0000436952 00000 n 
-0000436998 00000 n 
-0000437181 00000 n 
-0000437227 00000 n 
-0000437273 00000 n 
-0000437319 00000 n 
-0000437365 00000 n 
-0000437411 00000 n 
-0000437540 00000 n 
-0000445130 00000 n 
-0000445519 00000 n 
-0000445565 00000 n 
-0000445611 00000 n 
-0000445657 00000 n 
-0000445703 00000 n 
-0000445749 00000 n 
-0000445795 00000 n 
-0000446048 00000 n 
-0000446231 00000 n 
-0000446277 00000 n 
-0000446323 00000 n 
-0000446369 00000 n 
-0000461711 00000 n 
-0000462116 00000 n 
-0000462162 00000 n 
-0000462208 00000 n 
-0000462333 00000 n 
-0000462510 00000 n 
-0000462693 00000 n 
-0000462739 00000 n 
-0000462785 00000 n 
-0000462831 00000 n 
-0000462877 00000 n 
-0000474172 00000 n 
-0000474543 00000 n 
-0000474589 00000 n 
-0000474842 00000 n 
-0000474888 00000 n 
-0000481701 00000 n 
-0000482090 00000 n 
-0000482135 00000 n 
-0000482180 00000 n 
-0000482363 00000 n 
-0000482409 00000 n 
-0000482455 00000 n 
-0000482501 00000 n 
-0000482544 00000 n 
-0000482845 00000 n 
-0000482891 00000 n 
-0000483228 00000 n 
-0000483273 00000 n 
-0000483319 00000 n 
-0000490458 00000 n 
-0000490833 00000 n 
-0000490879 00000 n 
-0000490925 00000 n 
-0000490971 00000 n 
-0000491017 00000 n 
-0000491200 00000 n 
-0000491246 00000 n 
-0000491535 00000 n 
-0000491581 00000 n 
-0000491627 00000 n 
-0000491673 00000 n 
-0000491719 00000 n 
-0000499700 00000 n 
-0000500089 00000 n 
-0000500135 00000 n 
-0000500181 00000 n 
-0000500227 00000 n 
-0000500273 00000 n 
-0000500319 00000 n 
-0000500365 00000 n 
-0000500411 00000 n 
-0000500457 00000 n 
-0000500640 00000 n 
-0000500686 00000 n 
-0000511306 00000 n 
-0000511703 00000 n 
-0000511749 00000 n 
-0000511795 00000 n 
-0000511841 00000 n 
-0000511887 00000 n 
-0000512063 00000 n 
-0000512238 00000 n 
-0000512284 00000 n 
-0000512330 00000 n 
-0000512376 00000 n 
-0000512422 00000 n 
-0000518679 00000 n 
-0000519054 00000 n 
-0000519100 00000 n 
-0000519146 00000 n 
-0000519192 00000 n 
-0000519238 00000 n 
-0000519421 00000 n 
-0000519467 00000 n 
-0000519513 00000 n 
-0000519559 00000 n 
-0000519605 00000 n 
-0000519651 00000 n 
-0000527414 00000 n 
-0000527803 00000 n 
-0000527849 00000 n 
-0000527895 00000 n 
-0000527941 00000 n 
-0000527987 00000 n 
-0000528033 00000 n 
-0000528079 00000 n 
-0000528261 00000 n 
-0000528307 00000 n 
-0000528353 00000 n 
-0000537106 00000 n 
-0000537495 00000 n 
-0000537541 00000 n 
-0000537587 00000 n 
-0000537633 00000 n 
-0000537829 00000 n 
-0000537875 00000 n 
-0000537921 00000 n 
-0000538431 00000 n 
-0000538619 00000 n 
-0000538841 00000 n 
-0000538887 00000 n 
-0000538933 00000 n 
-0000538979 00000 n 
-0000548863 00000 n 
-0000549289 00000 n 
-0000549335 00000 n 
-0000549517 00000 n 
-0000549563 00000 n 
-0000549609 00000 n 
-0000549655 00000 n 
-0000549701 00000 n 
-0000549747 00000 n 
-0000549920 00000 n 
-0000550048 00000 n 
-0000550222 00000 n 
-0000550268 00000 n 
-0000550314 00000 n 
-0000550360 00000 n 
-0000550969 00000 n 
-0000560268 00000 n 
-0000560686 00000 n 
-0000560732 00000 n 
-0000561223 00000 n 
-0000561269 00000 n 
-0000561452 00000 n 
-0000561498 00000 n 
-0000561544 00000 n 
-0000561590 00000 n 
-0000561636 00000 n 
-0000561682 00000 n 
-0000561814 00000 n 
-0000561988 00000 n 
-0000562034 00000 n 
-0000562080 00000 n 
-0000562126 00000 n 
-0000568278 00000 n 
-0000568667 00000 n 
-0000568712 00000 n 
-0000568758 00000 n 
-0000568804 00000 n 
-0000568987 00000 n 
-0000569032 00000 n 
-0000569078 00000 n 
-0000569124 00000 n 
-0000569170 00000 n 
-0000569215 00000 n 
-0000569261 00000 n 
-0000569633 00000 n 
-0000580748 00000 n 
-0000581120 00000 n 
-0000581166 00000 n 
-0000581212 00000 n 
-0000581258 00000 n 
-0000581304 00000 n 
-0000591444 00000 n 
-0000591878 00000 n 
-0000591924 00000 n 
-0000591970 00000 n 
-0000592299 00000 n 
-0000592482 00000 n 
-0000592528 00000 n 
-0000592574 00000 n 
-0000592945 00000 n 
-0000592991 00000 n 
-0000593037 00000 n 
-0000593083 00000 n 
-0000593277 00000 n 
-0000593469 00000 n 
-0000593600 00000 n 
-0000593776 00000 n 
-0000593822 00000 n 
-0000593868 00000 n 
-0000601160 00000 n 
-0000601557 00000 n 
-0000601603 00000 n 
-0000601649 00000 n 
-0000601695 00000 n 
-0000601741 00000 n 
-0000601924 00000 n 
-0000601970 00000 n 
-0000602016 00000 n 
-0000602062 00000 n 
-0000602351 00000 n 
-0000602397 00000 n 
-0000602443 00000 n 
-0000602620 00000 n 
-0000610307 00000 n 
-0000610678 00000 n 
-0000610724 00000 n 
-0000610770 00000 n 
-0000619372 00000 n 
-0000619761 00000 n 
-0000619807 00000 n 
-0000619853 00000 n 
-0000619899 00000 n 
-0000620080 00000 n 
-0000626573 00000 n 
-0000626930 00000 n 
-0000626976 00000 n 
-0000627022 00000 n 
-0000627068 00000 n 
-0000627114 00000 n 
-0000627435 00000 n 
-0000627481 00000 n 
-0000627839 00000 n 
-0000627885 00000 n 
-0000627931 00000 n 
-0000628289 00000 n 
-0000628335 00000 n 
-0000628381 00000 n 
-0000629974 00000 n 
-0000630336 00000 n 
-0000630382 00000 n 
-0000630565 00000 n 
-0000630611 00000 n 
-0000630916 00000 n 
-0000631035 00000 n 
-0000631156 00000 n 
-0000631280 00000 n 
-0000631406 00000 n 
-0000631531 00000 n 
-0000631657 00000 n 
-0000631781 00000 n 
-0000631906 00000 n 
-0000632029 00000 n 
-0000632153 00000 n 
-0000632277 00000 n 
-0000632402 00000 n 
-0000632527 00000 n 
-0000632652 00000 n 
-0000632778 00000 n 
+0000314675 00000 n 
+0000315060 00000 n 
+0000315106 00000 n 
+0000315152 00000 n 
+0000315198 00000 n 
+0000315244 00000 n 
+0000321358 00000 n 
+0000321733 00000 n 
+0000321779 00000 n 
+0000321825 00000 n 
+0000321871 00000 n 
+0000321917 00000 n 
+0000322099 00000 n 
+0000322145 00000 n 
+0000322191 00000 n 
+0000322237 00000 n 
+0000322283 00000 n 
+0000322329 00000 n 
+0000322375 00000 n 
+0000329936 00000 n 
+0000330325 00000 n 
+0000330371 00000 n 
+0000330417 00000 n 
+0000330463 00000 n 
+0000330509 00000 n 
+0000330555 00000 n 
+0000330738 00000 n 
+0000330784 00000 n 
+0000330830 00000 n 
+0000330876 00000 n 
+0000330922 00000 n 
+0000338241 00000 n 
+0000338612 00000 n 
+0000338658 00000 n 
+0000338704 00000 n 
+0000338750 00000 n 
+0000338796 00000 n 
+0000338842 00000 n 
+0000338888 00000 n 
+0000338934 00000 n 
+0000347477 00000 n 
+0000347874 00000 n 
+0000347920 00000 n 
+0000348103 00000 n 
+0000348149 00000 n 
+0000348195 00000 n 
+0000348241 00000 n 
+0000348287 00000 n 
+0000348333 00000 n 
+0000348527 00000 n 
+0000348573 00000 n 
+0000348619 00000 n 
+0000348994 00000 n 
+0000349040 00000 n 
+0000349086 00000 n 
+0000357016 00000 n 
+0000357413 00000 n 
+0000357459 00000 n 
+0000357505 00000 n 
+0000357551 00000 n 
+0000357734 00000 n 
+0000357780 00000 n 
+0000357826 00000 n 
+0000357872 00000 n 
+0000357918 00000 n 
+0000357964 00000 n 
+0000358088 00000 n 
+0000368037 00000 n 
+0000368408 00000 n 
+0000368454 00000 n 
+0000368500 00000 n 
+0000368546 00000 n 
+0000379076 00000 n 
+0000379479 00000 n 
+0000379525 00000 n 
+0000379571 00000 n 
+0000379617 00000 n 
+0000379663 00000 n 
+0000379789 00000 n 
+0000387123 00000 n 
+0000387494 00000 n 
+0000387540 00000 n 
+0000387586 00000 n 
+0000387632 00000 n 
+0000387678 00000 n 
+0000387724 00000 n 
+0000387769 00000 n 
+0000388088 00000 n 
+0000398644 00000 n 
+0000399015 00000 n 
+0000399061 00000 n 
+0000399107 00000 n 
+0000399153 00000 n 
+0000399199 00000 n 
+0000399245 00000 n 
+0000399291 00000 n 
+0000406637 00000 n 
+0000407026 00000 n 
+0000407072 00000 n 
+0000407118 00000 n 
+0000407551 00000 n 
+0000407597 00000 n 
+0000408015 00000 n 
+0000408061 00000 n 
+0000408244 00000 n 
+0000408290 00000 n 
+0000408336 00000 n 
+0000408382 00000 n 
+0000408428 00000 n 
+0000408474 00000 n 
+0000418884 00000 n 
+0000419255 00000 n 
+0000419301 00000 n 
+0000419347 00000 n 
+0000419393 00000 n 
+0000419439 00000 n 
+0000419485 00000 n 
+0000419531 00000 n 
+0000420011 00000 n 
+0000426439 00000 n 
+0000426828 00000 n 
+0000426874 00000 n 
+0000426920 00000 n 
+0000426966 00000 n 
+0000427012 00000 n 
+0000427194 00000 n 
+0000427240 00000 n 
+0000427286 00000 n 
+0000427332 00000 n 
+0000427378 00000 n 
+0000427424 00000 n 
+0000427470 00000 n 
+0000434553 00000 n 
+0000434942 00000 n 
+0000434988 00000 n 
+0000435034 00000 n 
+0000435080 00000 n 
+0000435126 00000 n 
+0000435172 00000 n 
+0000435218 00000 n 
+0000435401 00000 n 
+0000435447 00000 n 
+0000435493 00000 n 
+0000435539 00000 n 
+0000444589 00000 n 
+0000444986 00000 n 
+0000445032 00000 n 
+0000445078 00000 n 
+0000445204 00000 n 
+0000445250 00000 n 
+0000445296 00000 n 
+0000445342 00000 n 
+0000445388 00000 n 
+0000445434 00000 n 
+0000445480 00000 n 
+0000445733 00000 n 
+0000445914 00000 n 
+0000459905 00000 n 
+0000460310 00000 n 
+0000460356 00000 n 
+0000460402 00000 n 
+0000460448 00000 n 
+0000460494 00000 n 
+0000460540 00000 n 
+0000460666 00000 n 
+0000460842 00000 n 
+0000461026 00000 n 
+0000461072 00000 n 
+0000461118 00000 n 
+0000473112 00000 n 
+0000473483 00000 n 
+0000473529 00000 n 
+0000473575 00000 n 
+0000473621 00000 n 
+0000473874 00000 n 
+0000480351 00000 n 
+0000480726 00000 n 
+0000480772 00000 n 
+0000480818 00000 n 
+0000480864 00000 n 
+0000481046 00000 n 
+0000481092 00000 n 
+0000481138 00000 n 
+0000481184 00000 n 
+0000481230 00000 n 
+0000481531 00000 n 
+0000487664 00000 n 
+0000488053 00000 n 
+0000488099 00000 n 
+0000488436 00000 n 
+0000488482 00000 n 
+0000488528 00000 n 
+0000488574 00000 n 
+0000488620 00000 n 
+0000488666 00000 n 
+0000488712 00000 n 
+0000488894 00000 n 
+0000488940 00000 n 
+0000489229 00000 n 
+0000489275 00000 n 
+0000498039 00000 n 
+0000498410 00000 n 
+0000498456 00000 n 
+0000498502 00000 n 
+0000498548 00000 n 
+0000498594 00000 n 
+0000498640 00000 n 
+0000498686 00000 n 
+0000498732 00000 n 
+0000498778 00000 n 
+0000498824 00000 n 
+0000507575 00000 n 
+0000507980 00000 n 
+0000508026 00000 n 
+0000508072 00000 n 
+0000508255 00000 n 
+0000508301 00000 n 
+0000508347 00000 n 
+0000508393 00000 n 
+0000508439 00000 n 
+0000508485 00000 n 
+0000508661 00000 n 
+0000508836 00000 n 
+0000508882 00000 n 
+0000508928 00000 n 
+0000517184 00000 n 
+0000517573 00000 n 
+0000517619 00000 n 
+0000517665 00000 n 
+0000517711 00000 n 
+0000517757 00000 n 
+0000517803 00000 n 
+0000517849 00000 n 
+0000518032 00000 n 
+0000518078 00000 n 
+0000526024 00000 n 
+0000526395 00000 n 
+0000526441 00000 n 
+0000526487 00000 n 
+0000526533 00000 n 
+0000526579 00000 n 
+0000526625 00000 n 
+0000526671 00000 n 
+0000526717 00000 n 
+0000526763 00000 n 
+0000526809 00000 n 
+0000535160 00000 n 
+0000535557 00000 n 
+0000535603 00000 n 
+0000535785 00000 n 
+0000535831 00000 n 
+0000535877 00000 n 
+0000535923 00000 n 
+0000535969 00000 n 
+0000536015 00000 n 
+0000536211 00000 n 
+0000536257 00000 n 
+0000536303 00000 n 
+0000536813 00000 n 
+0000537001 00000 n 
+0000537223 00000 n 
+0000537269 00000 n 
+0000546627 00000 n 
+0000547053 00000 n 
+0000547099 00000 n 
+0000547145 00000 n 
+0000547191 00000 n 
+0000547373 00000 n 
+0000547419 00000 n 
+0000547465 00000 n 
+0000547511 00000 n 
+0000547557 00000 n 
+0000547603 00000 n 
+0000547776 00000 n 
+0000547903 00000 n 
+0000548075 00000 n 
+0000555990 00000 n 
+0000556379 00000 n 
+0000556425 00000 n 
+0000556471 00000 n 
+0000556517 00000 n 
+0000557126 00000 n 
+0000557172 00000 n 
+0000557663 00000 n 
+0000557709 00000 n 
+0000557892 00000 n 
+0000557938 00000 n 
+0000557984 00000 n 
+0000558030 00000 n 
+0000558076 00000 n 
+0000566187 00000 n 
+0000566605 00000 n 
+0000566651 00000 n 
+0000566782 00000 n 
+0000566956 00000 n 
+0000567002 00000 n 
+0000567048 00000 n 
+0000567094 00000 n 
+0000567140 00000 n 
+0000567186 00000 n 
+0000567232 00000 n 
+0000567415 00000 n 
+0000567461 00000 n 
+0000577954 00000 n 
+0000578339 00000 n 
+0000578385 00000 n 
+0000578431 00000 n 
+0000578477 00000 n 
+0000578523 00000 n 
+0000578569 00000 n 
+0000578941 00000 n 
+0000578987 00000 n 
+0000579033 00000 n 
+0000586476 00000 n 
+0000586865 00000 n 
+0000586911 00000 n 
+0000586957 00000 n 
+0000587003 00000 n 
+0000587049 00000 n 
+0000587378 00000 n 
+0000587561 00000 n 
+0000587607 00000 n 
+0000587653 00000 n 
+0000588024 00000 n 
+0000588070 00000 n 
+0000588116 00000 n 
+0000598091 00000 n 
+0000598525 00000 n 
+0000598571 00000 n 
+0000598764 00000 n 
+0000598956 00000 n 
+0000599088 00000 n 
+0000599263 00000 n 
+0000599309 00000 n 
+0000599355 00000 n 
+0000599401 00000 n 
+0000599447 00000 n 
+0000599493 00000 n 
+0000599539 00000 n 
+0000599721 00000 n 
+0000605973 00000 n 
+0000606362 00000 n 
+0000606408 00000 n 
+0000606454 00000 n 
+0000606500 00000 n 
+0000606789 00000 n 
+0000606835 00000 n 
+0000606881 00000 n 
+0000607060 00000 n 
+0000607106 00000 n 
+0000607152 00000 n 
+0000607533 00000 n 
+0000616794 00000 n 
+0000617165 00000 n 
+0000623651 00000 n 
+0000624040 00000 n 
+0000624086 00000 n 
+0000624132 00000 n 
+0000624178 00000 n 
+0000624360 00000 n 
+0000624406 00000 n 
+0000624452 00000 n 
+0000624498 00000 n 
+0000624544 00000 n 
+0000624865 00000 n 
+0000624911 00000 n 
+0000625269 00000 n 
+0000630530 00000 n 
+0000630905 00000 n 
+0000630951 00000 n 
+0000630997 00000 n 
+0000631043 00000 n 
+0000631089 00000 n 
+0000631135 00000 n 
+0000631317 00000 n 
+0000631363 00000 n 
+0000631668 00000 n 
+0000631787 00000 n 
+0000631908 00000 n 
+0000632032 00000 n 
+0000632158 00000 n 
+0000632283 00000 n 
+0000632409 00000 n 
+0000632533 00000 n 
+0000632658 00000 n 
+0000632781 00000 n 
 0000632905 00000 n 
-0000633032 00000 n 
-0000633159 00000 n 
-0000633286 00000 n 
-0000633413 00000 n 
-0000633536 00000 n 
-0000633660 00000 n 
-0000633785 00000 n 
-0000633910 00000 n 
-0000634036 00000 n 
-0000634162 00000 n 
-0000634285 00000 n 
-0000634408 00000 n 
-0000634532 00000 n 
-0000634657 00000 n 
-0000634781 00000 n 
-0000634906 00000 n 
-0000635032 00000 n 
-0000635158 00000 n 
-0000635286 00000 n 
-0000635415 00000 n 
-0000635538 00000 n 
-0000635661 00000 n 
-0000635786 00000 n 
-0000635912 00000 n 
-0000636034 00000 n 
-0000636158 00000 n 
-0000636284 00000 n 
-0000636410 00000 n 
-0000636537 00000 n 
+0000633029 00000 n 
+0000633154 00000 n 
+0000633279 00000 n 
+0000633404 00000 n 
+0000633530 00000 n 
+0000633657 00000 n 
+0000633784 00000 n 
+0000633911 00000 n 
+0000634038 00000 n 
+0000634165 00000 n 
+0000634288 00000 n 
+0000634412 00000 n 
+0000634537 00000 n 
+0000634662 00000 n 
+0000634788 00000 n 
+0000634914 00000 n 
+0000635037 00000 n 
+0000635160 00000 n 
+0000635284 00000 n 
+0000635409 00000 n 
+0000635533 00000 n 
+0000635658 00000 n 
+0000635784 00000 n 
+0000635910 00000 n 
+0000636038 00000 n 
+0000636167 00000 n 
+0000636290 00000 n 
+0000636413 00000 n 
+0000636538 00000 n 
 0000636664 00000 n 
-0000636789 00000 n 
-0000636914 00000 n 
-0000637043 00000 n 
-0000637172 00000 n 
-0000637298 00000 n 
-0000637424 00000 n 
-0000637552 00000 n 
-0000637680 00000 n 
-0000637805 00000 n 
-0000637931 00000 n 
-0000638054 00000 n 
-0000638178 00000 n 
-0000638305 00000 n 
+0000636786 00000 n 
+0000636910 00000 n 
+0000637036 00000 n 
+0000637162 00000 n 
+0000637289 00000 n 
+0000637416 00000 n 
+0000637541 00000 n 
+0000637666 00000 n 
+0000637795 00000 n 
+0000637924 00000 n 
+0000638050 00000 n 
+0000638176 00000 n 
+0000638304 00000 n 
 0000638432 00000 n 
-0000638703 00000 n 
-0000638974 00000 n 
-0000639052 00000 n 
-0000639317 00000 n 
-0000639509 00000 n 
-0000639677 00000 n 
-0000639865 00000 n 
-0000640054 00000 n 
-0000640243 00000 n 
-0000640428 00000 n 
+0000638557 00000 n 
+0000638683 00000 n 
+0000638806 00000 n 
+0000638930 00000 n 
+0000639057 00000 n 
+0000639184 00000 n 
+0000639455 00000 n 
+0000639726 00000 n 
+0000639804 00000 n 
+0000640069 00000 n 
+0000640261 00000 n 
+0000640429 00000 n 
 0000640617 00000 n 
 0000640806 00000 n 
-0000641003 00000 n 
-0000641200 00000 n 
-0000641401 00000 n 
-0000641590 00000 n 
-0000641783 00000 n 
-0000641980 00000 n 
-0000642165 00000 n 
-0000642358 00000 n 
-0000642551 00000 n 
-0000642748 00000 n 
-0000642957 00000 n 
-0000643142 00000 n 
-0000643339 00000 n 
-0000643528 00000 n 
-0000643725 00000 n 
-0000643926 00000 n 
-0000644119 00000 n 
-0000644328 00000 n 
-0000644525 00000 n 
-0000644730 00000 n 
-0000644927 00000 n 
-0000645116 00000 n 
-0000645303 00000 n 
-0000646300 00000 n 
-0000655267 00000 n 
-0000655481 00000 n 
-0000656844 00000 n 
-0000657894 00000 n 
-0000666614 00000 n 
-0000666833 00000 n 
-0000668196 00000 n 
-0000669261 00000 n 
-0000675064 00000 n 
-0000675288 00000 n 
-0000676651 00000 n 
-0000677732 00000 n 
-0000678971 00000 n 
-0000679185 00000 n 
-0000679487 00000 n 
-0000680625 00000 n 
-0000686296 00000 n 
-0000686524 00000 n 
-0000687887 00000 n 
-0000688987 00000 n 
-0000692418 00000 n 
-0000692630 00000 n 
-0000693993 00000 n 
+0000640995 00000 n 
+0000641180 00000 n 
+0000641369 00000 n 
+0000641558 00000 n 
+0000641755 00000 n 
+0000641952 00000 n 
+0000642153 00000 n 
+0000642342 00000 n 
+0000642535 00000 n 
+0000642732 00000 n 
+0000642917 00000 n 
+0000643109 00000 n 
+0000643302 00000 n 
+0000643499 00000 n 
+0000643708 00000 n 
+0000643893 00000 n 
+0000644090 00000 n 
+0000644279 00000 n 
+0000644476 00000 n 
+0000644677 00000 n 
+0000644870 00000 n 
+0000645079 00000 n 
+0000645276 00000 n 
+0000645481 00000 n 
+0000645678 00000 n 
+0000645867 00000 n 
+0000646054 00000 n 
+0000647051 00000 n 
+0000656018 00000 n 
+0000656232 00000 n 
+0000657595 00000 n 
+0000658645 00000 n 
+0000667365 00000 n 
+0000667584 00000 n 
+0000668947 00000 n 
+0000670012 00000 n 
+0000675815 00000 n 
+0000676039 00000 n 
+0000677402 00000 n 
+0000678483 00000 n 
+0000679722 00000 n 
+0000679936 00000 n 
+0000680238 00000 n 
+0000681376 00000 n 
+0000687047 00000 n 
+0000687275 00000 n 
+0000688638 00000 n 
+0000689738 00000 n 
+0000693169 00000 n 
+0000693381 00000 n 
+0000694744 00000 n 
 trailer
-<< /Size 766
+<< /Size 767
 /Root 2 0 R
 /Info 1 0 R
 >>
 startxref
-695091
+695842
 %%EOF

--- a/docs/asciidocs/odgi_docs.xml
+++ b/docs/asciidocs/odgi_docs.xml
@@ -1338,6 +1338,17 @@ This argument only works when <emphasis>-Y, --path-sgd</emphasis> was specified.
 </varlistentry>
 </variablelist>
 </section>
+<section xml:id="_threading_6">
+<title>Threading</title>
+<variablelist>
+<varlistentry>
+<term><emphasis role="strong">-t, --threads</emphasis>=<emphasis>N</emphasis></term>
+<listitem>
+<simpara>Number of threads to use.</simpara>
+</listitem>
+</varlistentry>
+</variablelist>
+</section>
 <section xml:id="_processing_information_6">
 <title>Processing Information</title>
 <variablelist>
@@ -1480,7 +1491,7 @@ Be careful to use it with very complex graphs.</simpara>
 </varlistentry>
 </variablelist>
 </section>
-<section xml:id="_threading_6">
+<section xml:id="_threading_7">
 <title>Threading</title>
 <variablelist>
 <varlistentry>
@@ -1680,7 +1691,7 @@ of furcations at edges or by not considering nodes above a given node degree lim
 </varlistentry>
 </variablelist>
 </section>
-<section xml:id="_threading_7">
+<section xml:id="_threading_8">
 <title>Threading</title>
 <variablelist>
 <varlistentry>
@@ -2162,7 +2173,7 @@ with [<emphasis role="strong">-H, --haplotypes</emphasis>]. Prints an additional
 </varlistentry>
 </variablelist>
 </section>
-<section xml:id="_threading_8">
+<section xml:id="_threading_9">
 <title>Threading</title>
 <variablelist>
 <varlistentry>
@@ -2321,7 +2332,7 @@ fitting into these conditions.</simpara>
 </varlistentry>
 </variablelist>
 </section>
-<section xml:id="_threading_9">
+<section xml:id="_threading_10">
 <title>Threading</title>
 <variablelist>
 <varlistentry>
@@ -2414,7 +2425,7 @@ fitting into these conditions.</simpara>
 </varlistentry>
 </variablelist>
 </section>
-<section xml:id="_threading_10">
+<section xml:id="_threading_11">
 <title>Threading</title>
 <variablelist>
 <varlistentry>
@@ -2859,7 +2870,7 @@ Each value is the coverage of a specific node of a specific path.</simpara>
 </varlistentry>
 </variablelist>
 </section>
-<section xml:id="_threading_11">
+<section xml:id="_threading_12">
 <title>Threading</title>
 <variablelist>
 <varlistentry>
@@ -3480,7 +3491,7 @@ between <literal>--source</literal> and <literal>--target</literal>].</simpara>
 </varlistentry>
 </variablelist>
 </section>
-<section xml:id="_threading_12">
+<section xml:id="_threading_13">
 <title>Threading</title>
 <variablelist>
 <varlistentry>

--- a/docs/asciidocs/odgi_squeeze.adoc
+++ b/docs/asciidocs/odgi_squeeze.adoc
@@ -43,6 +43,12 @@ The odgi squeeze(1) command merges multiple graphs into the same file.
   Compact the node ID space in each input file before imploding.
 
 
+=== Threading
+
+*-t, --threads*=_N_::
+  Number of threads to use.
+
+
 === Processing Information
 
 *-P, --progress*::

--- a/src/subcommand/squeeze_main.cpp
+++ b/src/subcommand/squeeze_main.cpp
@@ -158,30 +158,31 @@ namespace odgi {
                     });
                 });
 
-                // Copy the paths over
-                std::vector<path_handle_t> paths;
-                paths.reserve(graph.get_path_count());
-                graph.for_each_path_handle([&](const path_handle_t path) {
-                    paths.push_back(path);
-                });
+                // Copy the paths
+                std::vector<std::pair<path_handle_t, path_handle_t>> old_and_new_paths;
+                old_and_new_paths.reserve(graph.get_path_count());
 
-#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
-                for (auto p : paths) {
-                    std::string new_path_name = graph.get_path_name(p);
+                graph.for_each_path_handle([&](const path_handle_t old_path_handle) {
+                    std::string new_path_name = graph.get_path_name(old_path_handle);
                     if (_add_suffix) {
                         new_path_name += separator + std::to_string(input_graph_rank);
                     }
 
                     path_handle_t new_path_handle = squeezed_graph.create_path_handle(
-                            new_path_name, graph.get_is_circular(p));
+                            new_path_name, graph.get_is_circular(old_path_handle));
 
-                    graph.for_each_step_in_path(p, [&](const step_handle_t &step) {
+                    old_and_new_paths.push_back({old_path_handle, new_path_handle});
+                });
+
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
+                for (auto old_new_path : old_and_new_paths) {
+                    graph.for_each_step_in_path(old_new_path.first, [&](const step_handle_t &step) {
                         handle_t old_handle = graph.get_handle_of_step(step);
                         handle_t new_handle = squeezed_graph.get_handle(
                                 graph.get_id(old_handle) + shift_id,
                                 graph.get_is_reverse(old_handle));
 
-                        squeezed_graph.append_step(new_path_handle, new_handle);
+                        squeezed_graph.append_step(old_new_path.second, new_handle);
                     });
                 }
 

--- a/src/subcommand/squeeze_main.cpp
+++ b/src/subcommand/squeeze_main.cpp
@@ -183,8 +183,6 @@ namespace odgi {
 
                         squeezed_graph.append_step(new_path_handle, new_handle);
                     });
-
-
                 }
 
                 shift_id = max_id;


### PR DESCRIPTION
This PR parallelizes the path embedding phase.

```master/odgi squeeze -f paths.txt -o output.og -P```
```
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:55.30
Maximum resident set size (kbytes): 2647460
```

`branch/odgi squeeze -f paths.txt -o output.og -P -t 16`
```
Elapsed (wall clock) time (h:mm:ss or m:ss): 0:12.39
Maximum resident set size (kbytes): 2662304
```
