### PR TITLE
Extract lace

### DIFF
--- a/src/algorithms/subgraph/extract.cpp
+++ b/src/algorithms/subgraph/extract.cpp
@@ -357,6 +357,7 @@ namespace odgi {
                         if (!subgraph.has_node(source.get_id(source.get_handle_of_step(step)))) {
                             if (in_match) {
                                 lace_start = step;
+                                in_match = false;
                             }
                         } else {
                             if (!in_match) {

--- a/src/algorithms/subgraph/extract.hpp
+++ b/src/algorithms/subgraph/extract.hpp
@@ -35,6 +35,9 @@ namespace odgi {
         void extract_id_range(const graph_t &source, const nid_t &id1, const nid_t &id2, graph_t &subgraph,
                               const std::string &progress_message = "");
 
+        void embed_lace_paths(graph_t &source, graph_t &subgraph,
+                              const std::vector<path_handle_t>& lace_paths);
+
     }
 }
 #endif //ODGI_EXTRACT_H

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -394,6 +394,22 @@ namespace odgi {
             algorithms::add_subpaths_to_subgraph(source, source_paths, subgraph, num_threads,
                                                  show_progress ? "[odgi::extract] adding subpaths" : "");
 
+            // force embed the paths
+            subgraph.for_each_path_handle(
+                [&](const path_handle_t& path) {
+                    handle_t last;
+                    step_handle_t begin_step = subgraph.path_begin(path);
+                    subgraph.for_each_step_in_path(
+                        path,
+                        [&](const step_handle_t &step) {
+                            handle_t h = subgraph.get_handle_of_step(step);
+                            if (step != begin_step) {
+                                subgraph.create_edge(last, h);
+                            }
+                            last = h;
+                        });
+                });
+
             // This should not be necessary, if the extraction works correctly
             // subgraph.remove_orphan_edges();
         };


### PR DESCRIPTION
This lets us lace together a selected subset of paths during the extraction process.

The parts of these paths that would be removed are simply dropped back into the graph as new nodes and reconnected to the source path. Then the extraction yields a graph in which these selected sequences are provided in full.