### PR TITLE
Beautify commands overview

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,7 @@ man_pages = [
      [EG], 1),
     ('man/odgi_build', 'odgi_build', u'Construct a dynamic succinct variation graph in ODGI format from a GFAv1.',
      [EG], 1),
-    ('man/odgi_chop', 'odgi_chop', u'Divide nodes into smaller pieces.',
+    ('man/odgi_chop', 'odgi_chop', u'Divide nodes into smaller pieces preserving node topology and order.',
      [EG, AG], 1),
     ('man/odgi_cover', 'odgi_cover', u'Cover the graph with paths.',
      [AG], 1),

--- a/docs/rst/commands/odgi_chop.rst
+++ b/docs/rst/commands/odgi_chop.rst
@@ -4,7 +4,7 @@
 odgi chop
 #########
 
-Divide nodes into smaller pieces.
+Divide nodes into smaller pieces preserving node topology and order.
 
 SYNOPSIS
 ========

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -23,5 +23,4 @@ sed -i "s|$CUR_VER|$CUR_VER,|g" ../src/version.cpp
 LINE=$(($LINE + 1))
 sed -i "$LINE i \ \ \ \ {\"v$NEW_VER\", \"$NEW_CODENAME\"}" ../src/version.cpp
 
-cd ../docs/asciidocs/
-bash generate_asciidocs.sh
+# TODO generate updated documentation

--- a/src/subcommand/bin_main.cpp
+++ b/src/subcommand/bin_main.cpp
@@ -295,7 +295,7 @@ int main_bin(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_bin("bin", "bin path information across the graph",
+static Subcommand odgi_bin("bin", "Binning of pangenome sequence and path information in the graph.",
                               PIPELINE, 3, main_bin);
 
 

--- a/src/subcommand/break_main.cpp
+++ b/src/subcommand/break_main.cpp
@@ -113,7 +113,7 @@ int main_break(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_break("break", "break cycles in the graph",
+static Subcommand odgi_break("break", "Break cycles in the graph and drop its paths.",
                               PIPELINE, 3, main_break);
 
 

--- a/src/subcommand/build_main.cpp
+++ b/src/subcommand/build_main.cpp
@@ -94,7 +94,7 @@ int main_build(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_build("build", "build dynamic succinct variation graph",
+static Subcommand odgi_build("build", "Construct a dynamic succinct variation graph in ODGI format from a GFAv1.",
                               PIPELINE, 3, main_build);
 
 

--- a/src/subcommand/chop_main.cpp
+++ b/src/subcommand/chop_main.cpp
@@ -18,7 +18,7 @@ namespace odgi {
         argv[0] = (char *) prog_name.c_str();
         --argc;
 
-        args::ArgumentParser parser("Divide nodes into smaller pieces.");
+        args::ArgumentParser parser("Divide nodes into smaller pieces preserving node topology and order.");
         args::Group mandatory_opts(parser, "[ MANDATORY ARGUMENTS ]");
         args::ValueFlag<std::string> dg_in_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*.", {'i', "idx"});
         args::ValueFlag<std::string> dg_out_file(mandatory_opts, "FILE", "Write the chopped succinct variation graph in ODGI format to *FILE*. A file ending of *.og* is recommended.",
@@ -103,7 +103,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_chop("chop", "chop long nodes into short ones while preserving topology and node order",
+    static Subcommand odgi_chop("chop", "Divide nodes into smaller pieces preserving node topology and order.",
                                 PIPELINE, 3, main_chop);
 
 

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -142,7 +142,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_cover("cover", "find a path cover of the graph",
+    static Subcommand odgi_cover("cover", "Cover the graph with paths.",
                                  PIPELINE, 3, main_cover);
 
 

--- a/src/subcommand/degree_main.cpp
+++ b/src/subcommand/degree_main.cpp
@@ -168,7 +168,7 @@ int main_degree(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_degree("degree", "node degree information",
+static Subcommand odgi_degree("degree", "Describe the graph in terms of node degree.",
                               PIPELINE, 3, main_degree);
 
 

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -572,7 +572,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_depth("depth", "find the depth of graph as defined by query criteria",
+    static Subcommand odgi_depth("depth", "Find the depth of a graph as defined by query criteria. Without specifying any non-mandatory options, it prints in a tab-delimited format path, start, end, and mean.depth to stdout.",
                                  PIPELINE, 3, main_depth);
 
 }

--- a/src/subcommand/draw_main.cpp
+++ b/src/subcommand/draw_main.cpp
@@ -154,7 +154,7 @@ int main_draw(int argc, char **argv) {
     return 0;
 }
 
-static Subcommand odgi_draw("draw", "draw previously-determined 2D layouts of the graph with diverse annotations",
+static Subcommand odgi_draw("draw", "Draw previously-determined 2D layouts of the graph with diverse annotations.",
                             PIPELINE, 3, main_draw);
 
 

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -271,7 +271,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_explode("explode", "breaks a graph into connected components",
+    static Subcommand odgi_explode("explode", "Breaks a graph into connected components storing each component in its own file.",
                                    PIPELINE, 3, main_explode);
 
 }

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -543,7 +543,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_extract("extract", "extract parts of the graph using paths, positions, and nodes",
+    static Subcommand odgi_extract("extract", "Extract subgraphs or parts of a graph defined by query criteria.",
                                    PIPELINE, 3, main_extract);
 
 }

--- a/src/subcommand/flatten_main.cpp
+++ b/src/subcommand/flatten_main.cpp
@@ -131,7 +131,7 @@ int main_flatten(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_flatten("flatten", "project the graph sequence and paths into FASTA and BED",
+static Subcommand odgi_flatten("flatten", "Generate linearizations of a graph.",
                                PIPELINE, 3, main_flatten);
 
 

--- a/src/subcommand/groom_main.cpp
+++ b/src/subcommand/groom_main.cpp
@@ -87,7 +87,7 @@ int main_groom(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_groom("groom", "resolve spurious inverting links",
+static Subcommand odgi_groom("groom", "Resolve spurious inverting links.",
                               PIPELINE, 3, main_groom);
 
 

--- a/src/subcommand/kmers_main.cpp
+++ b/src/subcommand/kmers_main.cpp
@@ -171,7 +171,7 @@ int main_kmers(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_kmers("kmers", "process and dump the kmers of the graph",
+static Subcommand odgi_kmers("kmers", "Display and characterize the kmer space of a graph.",
                               PIPELINE, 3, main_kmers);
 
 

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -418,7 +418,7 @@ int main_layout(int argc, char **argv) {
     return 0;
 }
 
-static Subcommand odgi_layout("layout", "use path guided SGD to make 2D layouts of the graph",
+static Subcommand odgi_layout("layout", "Establish 2D layouts of the graph using path-guided stochastic gradient descent (the graph must be sorted and id-compacted).",
                                PIPELINE, 3, main_layout);
 
 

--- a/src/subcommand/matrix_main.cpp
+++ b/src/subcommand/matrix_main.cpp
@@ -67,7 +67,7 @@ int main_matrix(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_matrix("matrix", "graph topology in sparse matrix form",
+static Subcommand odgi_matrix("matrix", "Write the graph topology in sparse matrix formats.",
                               PIPELINE, 3, main_matrix);
 
 

--- a/src/subcommand/normalize_main.cpp
+++ b/src/subcommand/normalize_main.cpp
@@ -94,7 +94,7 @@ int main_normalize(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_normalize("normalize", "compact unitigs and simplify redundant furcations",
+static Subcommand odgi_normalize("normalize", "Compact unitigs and simplify redundant furcations.",
                                  PIPELINE, 3, main_normalize);
 
 

--- a/src/subcommand/overlap_main.cpp
+++ b/src/subcommand/overlap_main.cpp
@@ -269,7 +269,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_overlap("overlap", "find the paths touched by the input paths",
+    static Subcommand odgi_overlap("overlap", "Find the paths touched by given input paths.",
                                  PIPELINE, 3, main_overlap);
 
 }

--- a/src/subcommand/panpos_main.cpp
+++ b/src/subcommand/panpos_main.cpp
@@ -79,7 +79,7 @@ namespace odgi {
     }
 
     static Subcommand odgi_panpos("panpos",
-            "get the pangenome position for a given path and nucleotide position (1-based)",
+            "Get the pangenome position of a given path and nucleotide position (1-based).",
                                      PIPELINE, 3, main_panpos);
 
 }

--- a/src/subcommand/pathindex_main.cpp
+++ b/src/subcommand/pathindex_main.cpp
@@ -98,7 +98,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_pathindex("pathindex", "create a path index for a given graph",
+    static Subcommand odgi_pathindex("pathindex", "Create a path index for a given graph.",
                                      PIPELINE, 3, main_pathindex);
 
 }

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -344,7 +344,7 @@ int main_paths(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_paths("paths", "interrogation and manipulation of paths",
+static Subcommand odgi_paths("paths", "Interrogate the embedded paths of a graph. Does not print anything to stdout by default!",
                               PIPELINE, 3, main_paths);
 
 

--- a/src/subcommand/position_main.cpp
+++ b/src/subcommand/position_main.cpp
@@ -742,7 +742,7 @@ int main_position(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_position("position", "coordinate projections between nodes and paths",
+static Subcommand odgi_position("position", "Find, translate, and liftover graph and path positions between graphs. Results are printed to stdout.",
                                 PIPELINE, 3, main_position);
 
 

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -194,7 +194,7 @@ int main_prune(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_prune("prune", "prune the graph based on depth or topological complexity",
+static Subcommand odgi_prune("prune", "Remove complex parts of the graph.",
                               PIPELINE, 3, main_prune);
 
 

--- a/src/subcommand/server_main.cpp
+++ b/src/subcommand/server_main.cpp
@@ -152,7 +152,7 @@ namespace odgi {
     }
 
     static Subcommand odgi_server("server",
-                                  "start a HTTP server with a given index file to query a pangenome position",
+                                  "Start a basic HTTP server with a given path index file to go from *path:position* to *pangenome:position* very efficiently.",
                                   PIPELINE, 3, main_server);
 
 }

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -457,7 +457,7 @@ int main_sort(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_sort("sort", "sort a variation graph",
+static Subcommand odgi_sort("sort", "Apply different kind of sorting algorithms to a graph. The most prominent one is the PG-SGD sorting algorithm.",
                               PIPELINE, 3, main_sort);
 
 

--- a/src/subcommand/squeeze_main.cpp
+++ b/src/subcommand/squeeze_main.cpp
@@ -221,7 +221,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_squeeze("squeeze", "squeezes multiple graphs into the same file",
+    static Subcommand odgi_squeeze("squeeze", "Squeezes multiple graphs in ODGI format into the same file in ODGI format.",
                                    PIPELINE, 3, main_squeeze);
 
 

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -820,7 +820,7 @@ for (uint64_t k = 0; k < path_names.size(); ++k) {
     return 0;
 }
 
-static Subcommand odgi_stats("stats", "describe the graph and its path relationships",
+static Subcommand odgi_stats("stats", "Metrics describing a variation graph and its path relationship.",
                               PIPELINE, 3, main_stats);
 
 

--- a/src/subcommand/test_main.cpp
+++ b/src/subcommand/test_main.cpp
@@ -21,5 +21,5 @@ int main_test(int argc, char** argv){
 }
 
 // Register subcommand
-static Subcommand odgi_test("test", "run unit tests", DEVELOPMENT, 5, main_test);
+static Subcommand odgi_test("test", "Run unit tests.", DEVELOPMENT, 5, main_test);
 

--- a/src/subcommand/unchop_main.cpp
+++ b/src/subcommand/unchop_main.cpp
@@ -90,7 +90,7 @@ int main_unchop(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_unchop("unchop", "merge unitigs into single nodes",
+static Subcommand odgi_unchop("unchop", "Merge unitigs into a single node preserving the node order.",
                               PIPELINE, 3, main_unchop);
 
 

--- a/src/subcommand/unitig_main.cpp
+++ b/src/subcommand/unitig_main.cpp
@@ -203,7 +203,7 @@ int main_unitig(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_unitig("unitig", "emit the unitigs of the graph",
+static Subcommand odgi_unitig("unitig", "Output unitigs of the graph.",
                               PIPELINE, 3, main_unitig);
 
 

--- a/src/subcommand/validate_main.cpp
+++ b/src/subcommand/validate_main.cpp
@@ -100,7 +100,7 @@ namespace odgi {
     }
 
     static Subcommand odgi_validate("validate",
-                                    "validate the graph (currently, it checks if the paths are consistent with the graph topology)",
+                                    "Validate a graph checking if the paths are consistent with the graph topology.",
                                     PIPELINE, 3, main_validate);
 
 }

--- a/src/subcommand/version_main.cpp
+++ b/src/subcommand/version_main.cpp
@@ -52,7 +52,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_version("version", "get the git version of odgi",
+    static Subcommand odgi_version("version", "Print the version of ODGI to stdout.",
                                    PIPELINE, 3, main_version);
 
 }

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -72,7 +72,7 @@ int main_view(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_view("view", "projection of graphs into other formats",
+static Subcommand odgi_view("view", "Project a graph into other formats.",
                              PIPELINE, 3, main_view);
 
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -1210,6 +1210,6 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_viz("viz", "visualize the graph",PIPELINE, 3, main_viz);
+    static Subcommand odgi_viz("viz", "Visualize a variation graph in 1D.",PIPELINE, 3, main_viz);
 
 }

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -37,7 +37,7 @@ const unordered_map<string, string> Version::codenames = {
     {"v0.4.1", "back to old ABI"},
     {"v0.5.0", "fastify everything"},
     {"v0.5.1", "Phoenix"},
-    {"0.6", "Locality"}
+    {"0.6", "Domani"}
     // Add more codenames here
 };
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -37,7 +37,7 @@ const unordered_map<string, string> Version::codenames = {
     {"v0.4.1", "back to old ABI"},
     {"v0.5.0", "fastify everything"},
     {"v0.5.1", "Phoenix"},
-    {"v0.6.0", "Locality"}
+    {"0.6", "Locality"}
     // Add more codenames here
 };
 


### PR DESCRIPTION
This beautifies the `odgi` commands overview and fixes the version codename.

Before:
```
odgi: optimized dynamic genome/graph implementation, version 0.6

usage: odgi <command> [options]

Overview of available commands:
  -- bin           bin path information across the graph
  -- break         break cycles in the graph
  -- build         build dynamic succinct variation graph
  -- chop          chop long nodes into short ones while preserving topology and node order
  -- cover         find a path cover of the graph
  -- degree        node degree information
  -- depth         find the depth of graph as defined by query criteria
  -- draw          draw previously-determined 2D layouts of the graph with diverse annotations
  -- explode       breaks a graph into connected components
  -- extract       extract parts of the graph using paths, positions, and nodes
  -- flatten       project the graph sequence and paths into FASTA and BED
  -- groom         resolve spurious inverting links
  -- kmers         process and dump the kmers of the graph
  -- layout        use path guided SGD to make 2D layouts of the graph
  -- matrix        graph topology in sparse matrix form
  -- normalize     compact unitigs and simplify redundant furcations
  -- overlap       find the paths touched by the input paths
  -- panpos        get the pangenome position for a given path and nucleotide position (1-based)
  -- pathindex     create a path index for a given graph
  -- paths         interrogation and manipulation of paths
  -- position      coordinate projections between nodes and paths
  -- prune         prune the graph based on depth or topological complexity
  -- server        start a HTTP server with a given index file to query a pangenome position
  -- sort          sort a variation graph
  -- squeeze       squeezes multiple graphs into the same file
  -- stats         describe the graph and its path relationships
  -- unchop        merge unitigs into single nodes
  -- unitig        emit the unitigs of the graph
  -- validate      validate the graph (currently, it checks if the paths are consistent with the graph topology)
  -- version       get the git version of odgi
  -- view          projection of graphs into other formats
  -- viz           visualize the graph
  ```
After:
```
odgi: optimized dynamic genome/graph implementation, version 0.6-2-gd0f2d6f "Domani"

usage: odgi <command> [options]

Overview of available commands:
  -- bin           Binning of pangenome sequence and path information in the graph.
  -- break         Break cycles in the graph and drop its paths.
  -- build         Construct a dynamic succinct variation graph in ODGI format from a GFAv1.
  -- chop          Divide nodes into smaller pieces preserving node topology and order.
  -- cover         Cover the graph with paths.
  -- degree        Describe the graph in terms of node degree.
  -- depth         Find the depth of a graph as defined by query criteria. Without specifying any non-mandatory options, it prints in a tab-delimited format path, start, end, and mean.depth to stdout.
  -- draw          Draw previously-determined 2D layouts of the graph with diverse annotations.
  -- explode       Breaks a graph into connected components storing each component in its own file.
  -- extract       Extract subgraphs or parts of a graph defined by query criteria.
  -- flatten       Generate linearizations of a graph.
  -- groom         Resolve spurious inverting links.
  -- kmers         Display and characterize the kmer space of a graph.
  -- layout        Establish 2D layouts of the graph using path-guided stochastic gradient descent (the graph must be sorted and id-compacted).
  -- matrix        Write the graph topology in sparse matrix formats.
  -- normalize     Compact unitigs and simplify redundant furcations.
  -- overlap       Find the paths touched by given input paths.
  -- panpos        Get the pangenome position of a given path and nucleotide position (1-based).
  -- pathindex     Create a path index for a given graph.
  -- paths         Interrogate the embedded paths of a graph. Does not print anything to stdout by default!
  -- position      Find, translate, and liftover graph and path positions between graphs. Results are printed to stdout.
  -- prune         Remove complex parts of the graph.
  -- server        Start a basic HTTP server with a given path index file to go from *path:position* to *pangenome:position* very efficiently.
  -- sort          Apply different kind of sorting algorithms to a graph. The most prominent one is the PG-SGD sorting algorithm.
  -- squeeze       Squeezes multiple graphs in ODGI format into the same file in ODGI format.
  -- stats         Metrics describing a variation graph and its path relationship.
  -- unchop        Merge unitigs into a single node preserving the node order.
  -- unitig        Output unitigs of the graph.
  -- validate      Validate a graph checking if the paths are consistent with the graph topology.
  -- version       Print the version of ODGI to stdout.
  -- view          Project a graph into other formats.
  -- viz           Visualize a variation graph in 1D.
  ```