### PR TITLE
new option -y,--yaml for odgi stats

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,13 @@ sys.path.insert(0, os.path.abspath('../lib/'))
 # -- Project information -----------------------------------------------------
 
 project = u'odgi'
-copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision v0.6,0-993dc1b'
+copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision v0.6,0-922230f'
 author = u'Andrea Guarracino, Simon Heumos, ... , Pjotr Prins, Erik Garrison'
 
 # The short X.Y version
 version = 'v0.6,0'
 # The full version, including alpha/beta/rc tags
-release = '993dc1b'
+release = '922230f'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/rst/commands/odgi_stats.rst
+++ b/docs/rst/commands/odgi_stats.rst
@@ -80,6 +80,12 @@ Sorting Goodness Eval Options
 | **-p, --path-statistics**
 | Display the statistics (mean links length or sum path nodes distances) for each path.
 
+IO Format Options
+-----------------
+
+| **-y, --yaml**
+| Setting this option prints all statistics in YAML format instead of pseudo TSV to stdout. Not applicable to *-N,--nondeterministic-edges*!
+
 Threading
 ---------
 


### PR DESCRIPTION
This ensures that `odgi stats`' output can be formatted in a nice, standardized human and machine readable way, aka the YAML format. This is a prerequisite for the `odgi` MultiQC module currently developed at https://github.com/ewels/MultiQC/pull/1340.