### PR TITLE
Untangle self depth

### DIFF
--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -350,11 +350,8 @@ segment_map_t::get_matches(
         for_segment_on_node(
             node_id,
             [&](const uint64_t& segment_id, const bool& segment_rev) {
-                // HACK warning -- this doesn't handle multiplicity of our query path
-                // we skip self matches
-                if (query_path != graph.get_path_handle_of_step(get_segment_cut(segment_id))) {
-                    target_isec[segment_id].incr(node_length, is_rev != segment_rev);
-                }
+                // n.b. we do not skip self matches
+                target_isec[segment_id].incr(node_length, is_rev != segment_rev);
             });
     }
     // compute the jaccards
@@ -469,6 +466,9 @@ void untangle(
     std::vector<path_handle_t> paths;
     paths.insert(paths.end(), queries.begin(), queries.end());
     paths.insert(paths.end(), targets.begin(), targets.end());
+    std::sort(paths.begin(), paths.end());
+    paths.erase(std::unique(paths.begin(), paths.end()),
+                paths.end());
     auto step_pos = make_step_index(graph, paths, num_threads);
 
     // collect all possible cuts

--- a/src/algorithms/untangle.hpp
+++ b/src/algorithms/untangle.hpp
@@ -78,6 +78,12 @@ ska::flat_hash_map<step_handle_t, uint64_t> make_step_index(
     const std::vector<path_handle_t>& paths,
     const size_t& num_threads);
 
+double self_mean_coverage(
+    const PathHandleGraph& graph,
+    const path_handle_t& path,
+    const step_handle_t& begin,
+    const step_handle_t& end);
+
 void map_segments(
     const PathHandleGraph& graph,
     const path_handle_t& path,


### PR DESCRIPTION
This makes it possible to get self-depth information directly from the untangle algorithm. The mean self-coverage is given in the last column of BED output. It's thus possible to do things like:

```
f=LPA_L.human.fa.9c17efa.7748b33.1b41467.smooth.og
odgi untangle -i $f \
        -r $(odgi paths -i $f -L | grep CHM13) \
        -q $(odgi paths -i $f -L | grep CHM13) \
        -t 16 -m 256 \
    | bedtools sort -i - \
    | cut -f 1-3,9 \
    | awk '$4 > 1.5' \
    | bedtools merge -i - -c 4 -o mean
```

To make CNV variant calls:

```
LPA_L__CHM13__pri__ID.1 332170  461860  23.09397571
```

(Here we see that CHM13 has ~23 copies of the LPA locus.)