### PR TITLE
Id increment fix

### DIFF
--- a/src/gfa_to_handle.hpp
+++ b/src/gfa_to_handle.hpp
@@ -33,7 +33,8 @@ std::map<char, uint64_t> gfa_line_counts(const char* filename);
 /// Handle graph must be empty when passed into function.
 void gfa_to_handle(const string& gfa_filename,
                    handlegraph::MutablePathMutableHandleGraph* graph,
-                   uint64_t n_threads = 1,
-                   bool show_progress = false);
+                   bool compact_ids,
+                   uint64_t n_threads,
+                   bool show_progress);
 
 }

--- a/src/subcommand/build_main.cpp
+++ b/src/subcommand/build_main.cpp
@@ -29,6 +29,7 @@ int main_build(int argc, char** argv) {
     args::Group graph_files_io(parser, "[ Graph Files IO ]");
     args::Flag to_gfa(graph_files_io, "to_gfa", "Write the graph to stdout in GFAv1 format.", {'G', "to-gfa"});
     args::Group graph_sorting(parser, "[ Graph Sorting ]");
+    args::Flag optimize(graph_sorting, "optimize", "Compact the graph id space into a dense integer range.", {'O', "optimize"});
     args::Flag toposort(graph_sorting, "sort", "Apply a general topological sort to the graph and order the node ids"
                                         "  accordingly. A bidirected adaptation of Kahn’s topological sort (1962)"
                                         "  is used, which can handle components with no heads or tails. Here, both heads and tails are taken into account.", {'s', "sort"});
@@ -74,7 +75,7 @@ int main_build(int argc, char** argv) {
     	return 1;
     }
     if (gfa_filename.size()) {
-        gfa_to_handle(gfa_filename, &graph, args::get(nthreads), args::get(progress));
+        gfa_to_handle(gfa_filename, &graph, args::get(optimize), args::get(nthreads), args::get(progress));
     }
 
     const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -72,7 +72,7 @@ namespace utils {
 																				   "To save time in the future, please use odgi build -i=[FILE], --idx=[FILE] -o=[FILE], --out=[FILE] "
 																				   "to generate a graph in ODGI format. Such a graph can be supplied to all ODGI subcommands. Building graph in ODGI format from given GFA." << std::endl;
 			}
-			gfa_to_handle(infile, &graph, num_threads, progress);
+			gfa_to_handle(infile, &graph, false, num_threads, progress);
 			graph.set_number_of_threads(num_threads);
 		} else {
 			ifstream f(infile.c_str());


### PR DESCRIPTION
Now, we don't try to use the id_increment optimization. Instead, users can optimize the graph (compact its node ids to 1-N) in `odgi build` with the `-O` flag.

@mrvollger this should fix some problems you ran into recently.