### PR TITLE
odgi `viz`, `depth`, `degree`, and `stats` can work with not optimized, but compacted graphs

### DIFF
--- a/src/algorithms/depth.cpp
+++ b/src/algorithms/depth.cpp
@@ -131,15 +131,15 @@ void for_each_path_range_depth(const PathHandleGraph& graph,
     }
     // precompute depths for all handles in parallel
     std::vector<uint64_t> depths(graph.get_node_count() + 1);
+    const uint64_t shift = graph.min_node_id();
+    if (graph.max_node_id() - shift >= graph.get_node_count()){
+        std::cerr << "[depth::for_each_path_range_depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+        exit(1);
+    }
     graph.for_each_handle(
         [&](const handle_t& h) {
             auto id = graph.get_id(h);
-            if (id >= depths.size()) {
-                // require optimized graph to use vector rather than a hash table
-                std::cerr << "[odgi::depth] error: graph is not optimized, apply odgi sort -O" << std::endl;
-                assert(false);
-            }
-            auto& d = depths[id];
+            auto& d = depths[id - shift];
             if (subset_paths) {
                 graph.for_each_step_on_handle(
                     h,
@@ -190,7 +190,7 @@ void for_each_path_range_depth(const PathHandleGraph& graph,
                     active_ranges.push_back(std::make_pair(*range_itr++, 0));
                 }
                 // compute coverage on node
-                auto& d = depths[graph.get_id(handle)];
+                auto& d = depths[graph.get_id(handle) - shift];
                 // add coverage to active ranges
                 for (auto& r : active_ranges) {
                     auto l = node_length;

--- a/src/algorithms/depth.cpp
+++ b/src/algorithms/depth.cpp
@@ -133,7 +133,7 @@ void for_each_path_range_depth(const PathHandleGraph& graph,
     std::vector<uint64_t> depths(graph.get_node_count() + 1);
     const uint64_t shift = graph.min_node_id();
     if (graph.max_node_id() - shift >= graph.get_node_count()){
-        std::cerr << "[depth::for_each_path_range_depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+        std::cerr << "[depth::for_each_path_range_depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
         exit(1);
     }
     graph.for_each_handle(

--- a/src/algorithms/depth.cpp
+++ b/src/algorithms/depth.cpp
@@ -102,6 +102,11 @@ void for_each_path_range_depth(const PathHandleGraph& graph,
                                const std::vector<path_range_t>& _path_ranges,
                                const std::vector<bool>& paths_to_consider,
                                const std::function<void(const path_range_t&, const double&)>& func) {
+	const uint64_t shift = graph.min_node_id();
+	if (graph.max_node_id() - shift >= graph.get_node_count()){
+		std::cerr << "[depth::for_each_path_range_depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+		exit(1);
+	}
     // are we subsetting?
     const bool subset_paths = !paths_to_consider.empty();
     // sort path ranges
@@ -131,11 +136,6 @@ void for_each_path_range_depth(const PathHandleGraph& graph,
     }
     // precompute depths for all handles in parallel
     std::vector<uint64_t> depths(graph.get_node_count() + 1);
-    const uint64_t shift = graph.min_node_id();
-    if (graph.max_node_id() - shift >= graph.get_node_count()){
-        std::cerr << "[depth::for_each_path_range_depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-        exit(1);
-    }
     graph.for_each_handle(
         [&](const handle_t& h) {
             auto id = graph.get_id(h);

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -147,13 +147,13 @@ size_t graph_t::get_node_count() const {
 /// Return the smallest ID in the graph, or some smaller number if the
 /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t graph_t::min_node_id() const {
-    return _min_node_id;
+    return _min_node_id + _id_increment;
 }
 
 /// Return the largest ID in the graph, or some larger number if the
 /// largest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t graph_t::max_node_id() const {
-    return _max_node_id;
+    return _max_node_id + _id_increment;
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/src/subcommand/degree_main.cpp
+++ b/src/subcommand/degree_main.cpp
@@ -129,7 +129,7 @@ int main_degree(int argc, char** argv) {
         std::vector<uint64_t> degrees(graph.get_node_count() + 1);
         const uint64_t shift = graph.min_node_id();
         if (graph.max_node_id() - shift >= graph.get_node_count()){
-            std::cerr << "[odgi::degree] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+            std::cerr << "[odgi::degree] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
             exit(1);
         }
         graph.for_each_handle(

--- a/src/subcommand/degree_main.cpp
+++ b/src/subcommand/degree_main.cpp
@@ -127,20 +127,20 @@ int main_degree(int argc, char** argv) {
 
         // precompute degrees for all handles in parallel
         std::vector<uint64_t> degrees(graph.get_node_count() + 1);
+        const uint64_t shift = graph.min_node_id();
+        if (graph.max_node_id() - shift >= graph.get_node_count()){
+            std::cerr << "[odgi::degree] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+            exit(1);
+        }
         graph.for_each_handle(
             [&](const handle_t& h) {
                 auto id = graph.get_id(h);
-                if (id >= degrees.size()) {
-                    // require optimized graph to use vector rather than a hash table
-                    std::cerr << "[odgi::degree] error: graph is not optimized, apply odgi sort -O" << std::endl;
-                    assert(false);
-                }
-                degrees[id] = graph.get_degree(h, false) + graph.get_degree(h, true);
+                degrees[id - shift] = graph.get_degree(h, false) + graph.get_degree(h, true);
             }, true);
 
         auto in_bounds =
             [&](const handle_t &handle) {
-                uint64_t degree = degrees[graph.get_id(handle)];
+                uint64_t degree = degrees[graph.get_id(handle) - shift];
                 return _windows_in ? (degree >= windows_in_min && degree <= windows_in_max) : (degree < windows_out_min || degree > windows_out_max);
             };
 

--- a/src/subcommand/degree_main.cpp
+++ b/src/subcommand/degree_main.cpp
@@ -99,6 +99,13 @@ int main_degree(int argc, char** argv) {
     }
 
     omp_set_num_threads((int) num_threads);
+	const uint64_t shift = graph.min_node_id();
+	if (_windows_in || _windows_out) {
+		if (graph.max_node_id() - shift >= graph.get_node_count()){
+			std::cerr << "[odgi::degree] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+			exit(1);
+		}
+	}
 
     if (_summarize) {
         uint64_t total_edges = 0;
@@ -127,11 +134,6 @@ int main_degree(int argc, char** argv) {
 
         // precompute degrees for all handles in parallel
         std::vector<uint64_t> degrees(graph.get_node_count() + 1);
-        const uint64_t shift = graph.min_node_id();
-        if (graph.max_node_id() - shift >= graph.get_node_count()){
-            std::cerr << "[odgi::degree] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-            exit(1);
-        }
         graph.for_each_handle(
             [&](const handle_t& h) {
                 auto id = graph.get_id(h);

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -139,6 +139,13 @@ namespace odgi {
         }
 
         omp_set_num_threads((int) num_threads);
+		const uint64_t shift = graph.min_node_id();
+		if (_windows_in || _windows_out) {
+			if (graph.max_node_id() - shift >= graph.get_node_count()){
+				std::cerr << "[odgi::depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+				exit(1);
+			}
+		}
 
         std::vector<bool> paths_to_consider;
         if (_subset_paths) {
@@ -470,11 +477,6 @@ namespace odgi {
 
             // precompute depths for all handles in parallel
             std::vector<uint64_t> depths(graph.get_node_count() + 1);
-            const uint64_t shift = graph.min_node_id();
-            if (graph.max_node_id() - shift >= graph.get_node_count()){
-                std::cerr << "[odgi::depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-                exit(1);
-            }
 
             graph.for_each_handle(
                 [&](const handle_t& h) {

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -470,20 +470,22 @@ namespace odgi {
 
             // precompute depths for all handles in parallel
             std::vector<uint64_t> depths(graph.get_node_count() + 1);
+            const uint64_t shift = graph.min_node_id();
+            if (graph.max_node_id() - shift >= graph.get_node_count()){
+                std::cerr << "[odgi::depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+                exit(1);
+            }
+
             graph.for_each_handle(
                 [&](const handle_t& h) {
-                    auto id = graph.get_id(h);
-                    if (id >= depths.size()) {
-                        // require optimized graph to use vector rather than a hash table
-                        std::cerr << "[odgi::depth] error: graph is not optimized, apply odgi sort -O" << std::endl;
-                        assert(false);
-                    }
-                    depths[id] = get_graph_node_depth(graph, id, paths_to_consider).first;
+                    auto id = graph.get_id(h) - shift;
+
+                    depths[id - shift] = get_graph_node_depth(graph, id, paths_to_consider).first;
                 }, true);
 
             auto in_bounds =
                 [&](const handle_t &handle) {
-                    uint64_t depth = depths[graph.get_id(handle)];
+                    uint64_t depth = depths[graph.get_id(handle) - shift];
                     return _windows_in ? (depth >= windows_in_min && depth <= windows_in_max) : (depth < windows_out_min || depth > windows_out_max);
                 };
 

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -472,7 +472,7 @@ namespace odgi {
             std::vector<uint64_t> depths(graph.get_node_count() + 1);
             const uint64_t shift = graph.min_node_id();
             if (graph.max_node_id() - shift >= graph.get_node_count()){
-                std::cerr << "[odgi::depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+                std::cerr << "[odgi::depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
                 exit(1);
             }
 

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -142,7 +142,15 @@ int main_stats(int argc, char** argv) {
         }
     }
 
-    if (yaml) {
+	const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
+
+    if (args::get(mean_links_length) || args::get(sum_of_path_node_distances) || yaml) {
+		if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
+			std::cerr << "[odgi::stats] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+			exit(1);
+		}
+    }
+	if (yaml) {
     	std::cout << "---" << std::endl;
     }
 
@@ -261,11 +269,6 @@ int main_stats(int argc, char** argv) {
     if (args::get(mean_links_length) || args::get(sum_of_path_node_distances) || yaml) {
         // This vector is needed for computing the metrics in 1D and for detecting gap-links
         std::vector<uint64_t> position_map(graph.get_node_count() + 1);
-        const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
-        if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
-            std::cerr << "[odgi::stats] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-            exit(1);
-        }
 
         // These vectors are needed for computing the metrics in 2D
         std::vector<double> X, Y;

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -261,6 +261,11 @@ int main_stats(int argc, char** argv) {
     if (args::get(mean_links_length) || args::get(sum_of_path_node_distances) || yaml) {
         // This vector is needed for computing the metrics in 1D and for detecting gap-links
         std::vector<uint64_t> position_map(graph.get_node_count() + 1);
+        const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
+        if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
+            std::cerr << "[odgi::stats] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+            exit(1);
+        }
 
         // These vectors are needed for computing the metrics in 2D
         std::vector<double> X, Y;

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -142,13 +142,6 @@ int main_stats(int argc, char** argv) {
         }
     }
 
-    /// we need to check in advance if the graph is compacted
-	const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
-	if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
-		std::cerr << "[odgi::stats] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-		exit(1);
-	}
-
     if (yaml) {
     	std::cout << "---" << std::endl;
     }

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -284,6 +284,7 @@ int main_stats(int argc, char** argv) {
     if (args::get(mean_links_length) || args::get(sum_of_path_node_distances) || yaml) {
         // This vector is needed for computing the metrics in 1D and for detecting gap-links
         std::vector<uint64_t> position_map(graph.get_node_count() + 1);
+        const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
 
         // These vectors are needed for computing the metrics in 2D
         std::vector<double> X, Y;
@@ -306,26 +307,31 @@ int main_stats(int argc, char** argv) {
             }
         }
 
-        uint64_t len = 0;
-        nid_t last_node_id = graph.min_node_id();
-        graph.for_each_handle([&](const handle_t &h) {
-            nid_t node_id = graph.get_id(h);
-            if (node_id - last_node_id > 1) {
-                std::cerr << "[odgi::stats] error: The graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
+        {
+            uint64_t len = 0;
+            if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
+                std::cerr << "[odgi::stats] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
                 exit(1);
             }
-            last_node_id = node_id;
 
-            position_map[number_bool_packing::unpack_number(h)] = len;
+            nid_t last_node_id = graph.min_node_id();
+            graph.for_each_handle([&](const handle_t &h) {
+                const nid_t node_id = graph.get_id(h);
+                if (node_id - last_node_id > 1) {
+                    std::cerr << "[odgi::stats] error: the node IDs are not contiguous. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+                    exit(1);
+                }
+                last_node_id = node_id;
 
-#ifdef debug_odgi_stats
-            std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << number_bool_packing::unpack_number(h) << ") = " << len << std::endl;
+                position_map[number_bool_packing::unpack_number(h) - shift] = len;
+                uint64_t hl = graph.get_length(h);
+                len += hl;
+#ifdef debug_odgi_viz
+                std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << number_bool_packing::unpack_number(h) << ") = " << len << std::endl;
 #endif
-
-            uint64_t hl = graph.get_length(h);
-            len += hl;
-        });
-        position_map[position_map.size() - 1] = len;
+            });
+            position_map[position_map.size() - 1] = len;
+        }
 
         if (args::get(mean_links_length) || yaml){
             bool _dont_penalize_gap_links = args::get(dont_penalize_gap_links);
@@ -391,17 +397,17 @@ int main_stats(int argc, char** argv) {
 
                             if (layout_in_file) {
                                 // 2D metric
-                                double dx = X[2 * unpacked_h + number_bool_packing::unpack_number(h)] - X[2 * unpacked_i + number_bool_packing::unpack_bit(i)];
-                                double dy = Y[2 * unpacked_h + number_bool_packing::unpack_number(h)] - Y[2 * unpacked_i + number_bool_packing::unpack_bit(i)];
+                                double dx = X[2 * (unpacked_h - shift) + number_bool_packing::unpack_number(h)] - X[2 * (unpacked_i - shift) + number_bool_packing::unpack_bit(i)];
+                                double dy = Y[2 * (unpacked_h - shift) + number_bool_packing::unpack_number(h)] - Y[2 * (unpacked_i - shift) + number_bool_packing::unpack_bit(i)];
 
                                 sum_2D_space += sqrt(dx * dx + dy * dy);
                             }else{
                                 // 1D metric (in node space and int nucleotide space)
                                 sum_node_space += _info_b - _info_a;
-                                sum_nt_space += position_map[_info_b] - position_map[_info_a];
+                                sum_nt_space += position_map[_info_b - shift] - position_map[_info_a - shift];
 
 #ifdef debug_odgi_stats
-                                std::cerr << _info_b << " - " << _info_a << ": " << position_map[_info_b] - position_map[_info_a] << std::endl;
+                                std::cerr << _info_b << " - " << _info_a << ": " << position_map[_info_b - shift] - position_map[_info_a - shift] << std::endl;
 #endif
                             }
                         }else if (dont_penalize_gap_links){
@@ -553,8 +559,8 @@ int main_stats(int argc, char** argv) {
 
                         if (layout_in_file) {
                             // 2D metric
-                            double dx = X[2 * unpacked_a + number_bool_packing::unpack_number(h)] - X[2 * unpacked_b + number_bool_packing::unpack_bit(i)];
-                            double dy = Y[2 * unpacked_a + number_bool_packing::unpack_number(h)] - Y[2 * unpacked_b + number_bool_packing::unpack_bit(i)];
+                            double dx = X[2 * (unpacked_a - shift) + number_bool_packing::unpack_number(h)] - X[2 * (unpacked_b - shift) + number_bool_packing::unpack_bit(i)];
+                            double dy = Y[2 * (unpacked_a - shift) + number_bool_packing::unpack_number(h)] - Y[2 * (unpacked_b - shift) + number_bool_packing::unpack_bit(i)];
 
                             euclidean_distance_2D = sqrt(dx * dx + dy * dy);
                             sum_path_node_dist_2D_space += euclidean_distance_2D;
@@ -570,11 +576,11 @@ int main_stats(int argc, char** argv) {
                             }
 
 #ifdef debug_odgi_stats
-                            std::cerr << unpacked_b << " - " << unpacked_a << ": " << position_map[unpacked_b] - position_map[unpacked_a] << " * " << weight << std::endl;
+                            std::cerr << unpacked_b << " - " << unpacked_a << ": " << position_map[unpacked_b - shift] - position_map[unpacked_a - shift] << " * " << weight << std::endl;
 #endif
 
                             sum_path_node_dist_node_space += weight * (unpacked_b - unpacked_a);
-                            sum_path_node_dist_nt_space += weight * (position_map[unpacked_b] - position_map[unpacked_a]);
+                            sum_path_node_dist_nt_space += weight * (position_map[unpacked_b - shift] - position_map[unpacked_a - shift]);
                         }
 
                         if (_penalize_diff_orientation && (number_bool_packing::unpack_bit(h) != number_bool_packing::unpack_bit(i))){
@@ -582,7 +588,7 @@ int main_stats(int argc, char** argv) {
                                 sum_path_node_dist_2D_space += 2 * euclidean_distance_2D;
                             }else{
                                 sum_path_node_dist_node_space += 2 * (unpacked_b - unpacked_a);
-                                sum_path_node_dist_nt_space += 2 * (position_map[unpacked_b] - position_map[unpacked_a]);
+                                sum_path_node_dist_nt_space += 2 * (position_map[unpacked_b - shift] - position_map[unpacked_a - shift]);
                             }
 
                             num_penalties_diff_orientation++;

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -247,11 +247,16 @@ namespace odgi {
         const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
         uint64_t len = 0;
         {
+            if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
+                std::cerr << "[odgi::viz] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+                exit(1);
+            }
+
             nid_t last_node_id = graph.min_node_id();
             graph.for_each_handle([&](const handle_t &h) {
                 const nid_t node_id = graph.get_id(h);
                 if (node_id - last_node_id > 1) {
-                    std::cerr << "[odgi::viz] error: the graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
+                    std::cerr << "[odgi::viz] error: the node IDs are not contiguous. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
                     exit(1);
                 }
                 last_node_id = node_id;
@@ -259,7 +264,6 @@ namespace odgi {
                 position_map[number_bool_packing::unpack_number(h) - shift] = len;
                 uint64_t hl = graph.get_length(h);
                 len += hl;
-
 #ifdef debug_odgi_viz
                 std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << number_bool_packing::unpack_number(h) << ") = " << len << std::endl;
 #endif

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -248,7 +248,7 @@ namespace odgi {
         uint64_t len = 0;
         {
             if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
-                std::cerr << "[odgi::viz] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+                std::cerr << "[odgi::viz] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
                 exit(1);
             }
 
@@ -256,7 +256,7 @@ namespace odgi {
             graph.for_each_handle([&](const handle_t &h) {
                 const nid_t node_id = graph.get_id(h);
                 if (node_id - last_node_id > 1) {
-                    std::cerr << "[odgi::viz] error: the node IDs are not contiguous. Please run 'odgi sort' using -O, --optimize to optimize the graph" << std::endl;
+                    std::cerr << "[odgi::viz] error: the node IDs are not contiguous. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
                     exit(1);
                 }
                 last_node_id = node_id;

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -251,21 +251,12 @@ namespace odgi {
                 std::cerr << "[odgi::viz] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
                 exit(1);
             }
-
-            nid_t last_node_id = graph.min_node_id();
             graph.for_each_handle([&](const handle_t &h) {
-                const nid_t node_id = graph.get_id(h);
-                if (node_id - last_node_id > 1) {
-                    std::cerr << "[odgi::viz] error: the node IDs are not contiguous. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-                    exit(1);
-                }
-                last_node_id = node_id;
-
                 position_map[number_bool_packing::unpack_number(h) - shift] = len;
                 uint64_t hl = graph.get_length(h);
                 len += hl;
 #ifdef debug_odgi_viz
-                std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << number_bool_packing::unpack_number(h) << ") = " << len << std::endl;
+                std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << (number_bool_packing::unpack_number(h) - shift) << ") = " << len << std::endl;
 #endif
             });
             position_map[position_map.size() - 1] = len;


### PR DESCRIPTION
This tackles the problem encountered here https://github.com/pangenome/odgi/pull/301

This could be extended also for odgi `sort`, `layout`, and `pathindex`, but it would require changes in the XP index.