### PR TITLE
Unquadratic untangle

### DIFF
--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -131,10 +131,15 @@ uint64_t path_step_index_t::n_steps_on_node(const nid_t& id) const {
 
 std::pair<bool, step_handle_t>
 path_step_index_t::get_next_step_on_node(const nid_t& id, const step_handle_t& step) const {
+    //std::cerr << "path_step_index_t Get next step on node" << std::endl;
     auto node_idx = get_node_idx(id);
-    auto next_idx = get_node_idx(id+1);
+    //std::cerr << "path_step_index_t node_idx " << node_idx << std::endl;
+    auto next_idx = node_offset[node_idx+1];
+    //std::cerr << "path_step_index_t next_idx " << next_idx << std::endl;
     auto step_idx = get_step_idx(step);
+    //std::cerr << "path_step_index_t step_idx " << step_idx << std::endl;
     bool has_next = step_idx + 1 < next_idx;
+    //std::cerr << "path_step_index_t has_next " << has_next << std::endl;
     if (has_next) {
         return std::make_pair(true, node_steps[step_idx+1]);
     } else {

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -31,12 +31,129 @@ step_index_t::step_index_t(const PathHandleGraph& graph,
     }
 }
 
-const uint64_t& step_index_t::get_position(const step_handle_t& step) {
+const uint64_t& step_index_t::get_position(const step_handle_t& step) const {
     return pos[step_mphf->lookup(step)];
 }
 
 step_index_t::~step_index_t(void) {
     delete step_mphf;
+}
+
+
+// path step index
+
+path_step_index_t::path_step_index_t(const PathHandleGraph& graph,
+                                     const path_handle_t& path,
+                                     const uint64_t& nthreads) {
+    // iterate through the paths, recording steps in the structure we'll use to build the mphf
+    {
+        std::vector<step_handle_t> steps;
+        std::vector<nid_t> nodes;
+        graph.for_each_step_in_path(
+            path, [&](const step_handle_t& step) {
+                steps.push_back(step);
+                nodes.push_back(graph.get_id(graph.get_handle_of_step(step)));
+            });
+        steps.push_back(graph.path_end(path));
+        // sort the steps, nb. they're unique
+        ips4o::parallel::sort(steps.begin(), steps.end(), std::less<>(), nthreads);
+        // build the hash function (quietly)
+        step_mphf = new boophf_step_t(steps.size(), steps, nthreads, 2.0, false, false);
+
+        ips4o::parallel::sort(nodes.begin(), nodes.end(), std::less<>(), nthreads);
+        // then take unique positions
+        nodes.erase(std::unique(nodes.begin(),
+                                nodes.end()),
+                    nodes.end());
+        // build the hash function (quietly)
+        node_mphf = new boophf_uint64_t(nodes.size(), nodes, nthreads, 2.0, false, false);
+        node_count = nodes.size();
+        step_count = steps.size();
+    }
+
+    {
+        // here, we sort steps by handle and then position
+        // and build our handle->step list and step->offset maps
+        // these are steps sorted by the bbhash of their node id, and then their offset in the path
+        std::vector<std::tuple<uint64_t, uint64_t, step_handle_t>> steps_by_node;
+        uint64_t offset = 0;
+        graph.for_each_step_in_path(
+            path, [&](const step_handle_t& step) {
+                steps_by_node.push_back(std::make_tuple(node_mphf->lookup(graph.get_id(graph.get_handle_of_step(step))),
+                                                        offset,
+                                                        step));
+                offset += graph.get_length(graph.get_handle_of_step(step));
+            });
+
+        node_offset.resize(node_count+1);
+        step_offset.resize(step_count+1);
+        ips4o::parallel::sort(steps_by_node.begin(), steps_by_node.end(), std::less<>(), nthreads);
+        uint64_t last_idx = 0;
+        for (auto& node_step : steps_by_node) {
+            auto& idx = std::get<0>(node_step);
+            //auto& offset = std::get<1>(node_step); // just used for sorting
+            auto& step = std::get<2>(node_step);
+            //std::cerr << "idx = " << idx << " " << as_integers(step)[0] << ":" << as_integers(step)[1] << std::endl;
+            if (idx != last_idx) {
+                node_offset[idx] = node_steps.size();
+            }
+            step_offset[step_mphf->lookup(step)] = node_steps.size();
+            node_steps.push_back(step);
+            last_idx = idx;
+        }
+        if (last_idx != node_count-1) {
+            std::cerr << "last_idx vs node count " << last_idx << " " << node_count << std::endl;
+            std::cerr << "[odgi::algorithms::stepindex] unexpected mismatch between last_idx and node_count" << std::endl;
+            std::abort();
+        }
+        node_offset[node_count] = node_steps.size();
+        step_offset[step_count] = node_steps.size();
+    }
+}
+
+path_step_index_t::~path_step_index_t(void) {
+    delete node_mphf;
+    delete step_mphf;
+}
+
+uint64_t path_step_index_t::get_node_idx(const nid_t& id) const {
+    return node_mphf->lookup(id);
+}
+
+uint64_t path_step_index_t::get_step_idx(const step_handle_t& step) const {
+    return step_mphf->lookup(step);
+}
+
+uint64_t path_step_index_t::n_steps_on_node(const nid_t& id) const {
+    auto idx = get_node_idx(id);
+    return node_offset[idx+1] - node_offset[idx];
+}
+
+std::pair<bool, step_handle_t>
+path_step_index_t::get_next_step_on_node(const nid_t& id, const step_handle_t& step) const {
+    auto node_idx = get_node_idx(id);
+    auto next_idx = get_node_idx(id+1);
+    auto step_idx = get_step_idx(step);
+    bool has_next = step_idx + 1 < next_idx;
+    if (has_next) {
+        return std::make_pair(true, node_steps[step_idx+1]);
+    } else {
+        step_handle_t empty_step;
+        return std::make_pair(false, empty_step);
+    }
+}
+
+std::pair<bool, step_handle_t>
+path_step_index_t::get_prev_step_on_node(const nid_t& id, const step_handle_t& step) const {
+    auto node_idx = get_node_idx(id);
+    auto step_idx = get_step_idx(step);
+    bool has_prev = step_idx > node_idx;
+    if (has_prev) {
+        return std::make_pair(true, node_steps[step_idx-1]);
+    } else {
+        step_handle_t empty_step;
+        return std::make_pair(false, empty_step);
+    }
 }
 
 }

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -41,15 +41,50 @@ struct step_handle_hasher_t {
 };
 
 typedef boomphf::mphf<step_handle_t, step_handle_hasher_t> boophf_step_t;
+typedef boomphf::mphf<uint64_t, boomphf::SingleHashFunctor<uint64_t>> boophf_uint64_t;
 
 struct step_index_t {
     step_index_t(const PathHandleGraph& graph,
                  const std::vector<path_handle_t>& paths,
                  const uint64_t& nthreads);
     ~step_index_t(void);
-    const uint64_t& get_position(const step_handle_t& step);
+    const uint64_t& get_position(const step_handle_t& step) const;
+    // map from step to position in its path
     boophf_step_t* step_mphf = nullptr;
     std::vector<uint64_t> pos;
+};
+
+// index of a single path's steps designed for efficient iteration
+// over steps on a single handle
+// in practice
+struct path_step_index_t {
+    path_step_index_t(const PathHandleGraph& graph,
+                      const path_handle_t& paths,
+                      const uint64_t& nthreads);
+    ~path_step_index_t(void);
+    // map from node id in the path to an index in node_offsets
+    boophf_uint64_t* node_mphf = nullptr;
+    // map to the beginning of a range in node_steps
+    std::vector<uint64_t> node_offset;
+    // record the steps in positional order by node (index given in node_offset)
+    std::vector<step_handle_t> node_steps;
+    // map from step to an index in step_offset
+    boophf_step_t* step_mphf = nullptr;
+    // index in handle_steps for the given step
+    std::vector<uint64_t> step_offset;
+    uint64_t node_count = 0;
+    uint64_t step_count = 0;
+    // get the idx of a node
+    uint64_t get_node_idx(const nid_t& id) const;
+    // get the idx of a step
+    uint64_t get_step_idx(const step_handle_t& step) const;
+    // compute how many steps we have on the given node
+    uint64_t n_steps_on_node(const nid_t& id) const;
+    // these functions require, but do not check, that our step is in the indexed path
+    // next step on node (sorted by position in path), (false, _) if there is no next step
+    std::pair<bool, step_handle_t> get_next_step_on_node(const nid_t& id, const step_handle_t& step) const;
+    // prev step on node (sorted by position in path), (false, _) if there is no next step
+    std::pair<bool, step_handle_t> get_prev_step_on_node(const nid_t& id, const step_handle_t& step) const;
 };
 
 }

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -498,12 +498,13 @@ void untangle(
     //std::cerr << "[odgi::algorithms::untangle] step index contains " << step_pos.size() << " steps" << std::endl;
     // collect all possible cuts
     // we'll use this to drive the subsequent segmentation
-    std::cerr << "[odgi::algorithms::untangle] establishing initial cuts" << std::endl;
+    int threads_per = std::max(1, (int)std::floor((double)num_threads/(double)paths.size()));
+    std::cerr << "[odgi::algorithms::untangle] establishing initial cuts for " << paths.size() << " paths" << std::endl;
     atomicbitvector::atomic_bv_t cut_nodes(graph.get_node_count()+1);
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
     for (auto& path : paths) {
         // test path_step_index_t
-        auto self_index = path_step_index_t(graph, path, 1);
+        auto self_index = path_step_index_t(graph, path, threads_per);
         std::vector<step_handle_t> cuts
             = merge_cuts(
                 untangle_cuts(graph,
@@ -540,7 +541,7 @@ void untangle(
     std::cout << "#query.name\tquery.start\tquery.end\tref.name\tref.start\tref.end\tscore\tinv\tself.cov" << std::endl;
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
     for (auto& query : queries) {
-        auto self_index = path_step_index_t(graph, query, 1);
+        auto self_index = path_step_index_t(graph, query, threads_per);
         std::vector<step_handle_t> cuts
             = merge_cuts(
                 untangle_cuts(graph,

--- a/src/algorithms/untangle.hpp
+++ b/src/algorithms/untangle.hpp
@@ -36,7 +36,7 @@ public:
     std::vector<int64_t> segments;
     segment_map_t(const PathHandleGraph& graph,
                   const std::vector<path_handle_t>& paths,
-                  const std::function<uint64_t(const step_handle_t&)>& get_step_pos,
+                  const step_index_t& step_index,
                   const std::function<bool(const handle_t&)>& is_cut,
                   const uint64_t& merge_dist,
                   const size_t& num_threads);
@@ -57,20 +57,20 @@ std::vector<step_handle_t> untangle_cuts(
     const PathHandleGraph& graph,
     const step_handle_t& start,
     const step_handle_t& end,
-    const std::function<uint64_t(const step_handle_t&)>& get_step_pos,
-    //const ska::flat_hash_map<step_handle_t, uint64_t>& step_pos,
+    const step_index_t& step_index,
+    const path_step_index_t& self_index,
     const std::function<bool(const handle_t&)>& is_cut);
 
 std::vector<step_handle_t> merge_cuts(
     const std::vector<step_handle_t>& cuts,
     const uint64_t& dist,
-    const std::function<uint64_t(const step_handle_t&)>& get_step_pos);
+    const step_index_t& step_index);
 
 void write_cuts(
     const PathHandleGraph& graph,
     const path_handle_t& path,
     const std::vector<step_handle_t>& cuts,
-    const std::function<uint64_t(const step_handle_t&)>& get_step_pos);
+    const step_index_t& step_index);
 
 void self_dotplot(
     const PathHandleGraph& graph,
@@ -92,7 +92,7 @@ void map_segments(
     const path_handle_t& path,
     const std::vector<step_handle_t>& cuts,
     const segment_map_t& target_segments,
-    const std::function<uint64_t(const step_handle_t&)>& get_step_pos);
+    const step_index_t& step_index);
 
 void untangle(
     const PathHandleGraph& graph,

--- a/src/algorithms/untangle.hpp
+++ b/src/algorithms/untangle.hpp
@@ -92,13 +92,17 @@ void map_segments(
     const path_handle_t& path,
     const std::vector<step_handle_t>& cuts,
     const segment_map_t& target_segments,
-    const step_index_t& step_index);
+    const step_index_t& step_index,
+    const uint64_t& n_best,
+    const double& min_jaccard);
 
 void untangle(
     const PathHandleGraph& graph,
     const std::vector<path_handle_t>& queries,
     const std::vector<path_handle_t>& targets,
     const uint64_t& merge_dist,
+    const uint64_t& n_best,
+    const double& min_jaccard,
     const size_t& num_threads);
 
 }

--- a/src/subcommand/untangle_main.cpp
+++ b/src/subcommand/untangle_main.cpp
@@ -38,6 +38,10 @@ int main_untangle(int argc, char **argv) {
                        {'R', "target-paths"});
     args::ValueFlag<uint64_t> merge_dist(untangling_opts, "N", "Merge segments shorter than this length into previous segments.",
                                          {'m', "merge-dist"});
+    args::ValueFlag<uint64_t> _best_n_mappings(untangling_opts, "N", "Report up to the Nth best target (reference) mapping for each query segment (default: 1).",
+                                               {'n', "n-best"});
+    args::ValueFlag<double> _jaccard_threshold(untangling_opts, "F", "Report target mappings >= the given jaccard threshold, with 0 <= F <= 1.0 (default: 0.0).",
+                                               {'j', "min-jaccard"});
     args::Group debugging_opts(parser, "[ Debugging Options ]");
     args::Flag make_self_dotplot(debugging_opts, "DOTPLOT", "Render a table showing the positional dotplot of the query against itself.",
                                  {'s', "self-dotplot"});
@@ -170,6 +174,8 @@ int main_untangle(int argc, char **argv) {
                              query_paths,
                              target_paths,
                              args::get(merge_dist),
+                             (_best_n_mappings ? args::get(_best_n_mappings) : 1),
+                             (_jaccard_threshold ? args::get(_jaccard_threshold) : 0.0),
                              num_threads);
     }
 


### PR DESCRIPTION
This speeds up untangling by adjusting it to not experience quadratic blowups in deep regions. A single-path step index is created to help expedite the discovery of the next-closest self step on a given node. An additional feature lets us get the n-best mappings above a given jaccard threshold for each query segment. This can be used to make segdup tracks in a format similar to those made by @mrvollger.