### PR TITLE
Grey viz

### DIFF
--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -120,6 +120,9 @@ namespace odgi {
         args::ValueFlag<std::string> colorbrewer_palette(bin_opts, "SCHEME:N", "Use the colorbrewer palette specified by the given SCHEME, with the number of levels N."
                                                                                " Specifiy 'show' to see available palettes.",
                                                                                {'B', "colorbrewer-palette"});
+        args::Flag no_grey_depth(bin_opts, "bool", "Use the colorbrewer palette for <0.5x and ~1x coverage bins."
+                                 " By default, these bins are light and neutral grey.",
+                                 {'G', "no-grey-depth"});
 
         /// Gradient mode
         args::Group grad_mode_opts(parser, "[ Gradient Mode Options ]");
@@ -1022,15 +1025,13 @@ namespace odgi {
                     colorbrewer::palette_t cov_colors;
                     std::vector<double> cov_cuts;
                     if (_color_by_mean_depth) {
-                        // colorbrewer PRGn 8-color
-                        // https://colorbrewer2.org/?type=diverging&scheme=PRGn&n=8
                         if (colorbrewer_palette) {
                             const auto parts = split(args::get(colorbrewer_palette), ':');
                             cov_colors = colorbrewer::get_palette(parts.front(), std::stoi(parts.back()));
                         } else {
                             cov_colors = colorbrewer::get_palette("Spectral", 11);
                         }
-                        {
+                        if (!args::get(no_grey_depth)) {
                             std::reverse(cov_colors.begin(),
                                          cov_colors.end());
                             cov_colors.push_back({128,128,128});

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -1030,7 +1030,14 @@ namespace odgi {
                         } else {
                             cov_colors = colorbrewer::get_palette("Spectral", 11);
                         }
-
+                        {
+                            std::reverse(cov_colors.begin(),
+                                         cov_colors.end());
+                            cov_colors.push_back({128,128,128});
+                            cov_colors.push_back({196,196,196});
+                            std::reverse(cov_colors.begin(),
+                                         cov_colors.end());
+                        }
                         uint64_t i = 0;
                         cov_cuts.resize(cov_colors.size());
                         double depth = 0.5;


### PR DESCRIPTION
Use grey rather than colorbrewer for <0.5x and 1x bins in odgi viz. This can be disabled with `-G`.