### PR TITLE
correct a mistake with the multicomponent layout

### DIFF
--- a/src/algorithms/layout.cpp
+++ b/src/algorithms/layout.cpp
@@ -23,13 +23,12 @@ void to_tsv(std::ostream &out, const std::vector<double> &X, const std::vector<d
     out << std::setprecision(std::numeric_limits<double>::digits10 + 1);
     out << "idx" << "\t" << "X" << "\t" << "Y" << "\t" << "component" << std::endl;
 
-    uint64_t idx = 0;
     for (uint64_t num_component = 0; num_component < weak_components.size(); ++num_component) {
         for (auto& handle :  weak_components[num_component]) {
             uint64_t pos = 2 * number_bool_packing::unpack_number(handle);
 
-            out << idx++ << "\t" << X[pos] << "\t" << Y[pos] << "\t" << num_component <<std::endl;
-            out << idx++ << "\t" << X[pos + 1] << "\t" << Y[pos + 1] << "\t" << num_component<< std::endl;
+            out << as_integer(handle) << "\t" << X[pos] << "\t" << Y[pos] << "\t" << num_component <<std::endl;
+            out << as_integer(handle)+1 << "\t" << X[pos + 1] << "\t" << Y[pos + 1] << "\t" << num_component<< std::endl;
         }
     }
 


### PR DESCRIPTION
We need to print the handle index rather than the index in the order of our traversal of the weakly connected components. This was primarily affecting gfaestus.