### PR TITLE
Little `odgi build` optimization (in ` gfa_to_handle`)

### DIFF
--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -12,7 +12,7 @@ std::map<char, uint64_t> gfa_line_counts(const char* filename) {
     }
     string line;
     size_t i = 0;
-    bool seen_newline = true;
+    //bool seen_newline = true;
     std::map<char, uint64_t> counts;
     while (i < gfa_filesize) {
         if (i == 0 || gfa_buf[i-1] == '\n') {
@@ -41,7 +41,7 @@ void gfa_to_handle(const string& gfa_filename,
     // in parallel scan over the file to count edges and sequences
     {
         std::thread x(
-            [&](void) {
+            [&]() {
                 gg.for_each_sequence_line_in_file(
                     filename,
                     [&](gfak::sequence_elem s) {
@@ -66,7 +66,7 @@ void gfa_to_handle(const string& gfa_filename,
         }
         gg.for_each_sequence_line_in_file(
             filename,
-            [&](gfak::sequence_elem s) {
+            [&](const gfak::sequence_elem& s) {
                 uint64_t id = stol(s.name);
                 graph->create_handle(s.sequence, id - id_increment);
                 if (progress) progress_meter->increment(1);
@@ -84,7 +84,7 @@ void gfa_to_handle(const string& gfa_filename,
         }
         gg.for_each_edge_line_in_file(
             filename,
-            [&](gfak::edge_elem e) {
+            [&](const gfak::edge_elem& e) {
                 if (e.source_name.empty()) return;
                 handlegraph::handle_t a = graph->get_handle(stol(e.source_name) - id_increment, !e.source_orientation_forward);
                 handlegraph::handle_t b = graph->get_handle(stol(e.sink_name) - id_increment, !e.sink_orientation_forward);
@@ -104,7 +104,7 @@ void gfa_to_handle(const string& gfa_filename,
         }
         gfa_path_queue_t path_queue;
         std::mutex logging_mutex;
-        std::atomic<bool> work_todo;
+        std::atomic<bool> work_todo{};
         uint64_t idx = 0;
         auto worker =
             [&](uint64_t tid) {

--- a/src/subcommand/build_main.cpp
+++ b/src/subcommand/build_main.cpp
@@ -69,13 +69,15 @@ int main_build(int argc, char** argv) {
         std::cerr << "[odgi::build] error: please specify an output file to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
-    std::string gfa_filename = args::get(gfa_file);
-    if (!std::filesystem::exists(gfa_filename)) {
-    	std::cerr << "[odgi::build] error: the given file \"" << gfa_filename << "\" does not exist. Please specify an existing input file via -g=[FILE], --gfa=[FILE]." << std::endl;
-    	return 1;
-    }
-    if (gfa_filename.size()) {
-        gfa_to_handle(gfa_filename, &graph, args::get(optimize), args::get(nthreads), args::get(progress));
+    {
+        const std::string gfa_filename = args::get(gfa_file);
+        if (!std::filesystem::exists(gfa_filename)) {
+            std::cerr << "[odgi::build] error: the given file \"" << gfa_filename << "\" does not exist. Please specify an existing input file via -g=[FILE], --gfa=[FILE]." << std::endl;
+            return 1;
+        }
+        if (!gfa_filename.empty()) {
+            gfa_to_handle(gfa_filename, &graph, args::get(optimize), args::get(nthreads), args::get(progress));
+        }
     }
 
     const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;


### PR DESCRIPTION
I was investigating on this problem https://github.com/pangenome/pggb/issues/133. We could avoid the `logic_error` by checking if the step is an empty string, but it could be better to avoid invalid input files _a priori_.