### PR TITLE
`odgi extract`: make it possible to extract from a subgraph and fix impolite memory accesses

### DIFF
--- a/src/algorithms/subgraph/region.cpp
+++ b/src/algorithms/subgraph/region.cpp
@@ -8,18 +8,19 @@ namespace odgi {
     void parse_region(const std::string& target, std::string& name, int64_t& start, int64_t& end) {
         start = -1;
         end = -1;
-        size_t foundFirstColon = target.find(":");
+        const size_t foundLastColon = target.find_last_of(":");
+
         // we only have a single string, use the whole sequence as the target
-        if (foundFirstColon == std::string::npos) {
+        if (foundLastColon == std::string::npos) {
             name = target;
         } else {
-            name = target.substr(0, foundFirstColon);
-            size_t foundRangeDash = target.find("-", foundFirstColon);
+            name = target.substr(0, foundLastColon);
+            size_t foundRangeDash = target.find("-", foundLastColon);
             if (foundRangeDash == std::string::npos) {
-                start = atoi(target.substr(foundFirstColon + 1).c_str());
+                start = atoi(target.substr(foundLastColon + 1).c_str());
                 end = start;
             } else {
-                start = atoi(target.substr(foundFirstColon + 1, foundRangeDash - foundRangeDash - 1).c_str());
+                start = atoi(target.substr(foundLastColon + 1, foundRangeDash - foundRangeDash - 1).c_str());
                 end = atoi(target.substr(foundRangeDash + 1).c_str());
             }
         }

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -501,13 +501,13 @@ namespace odgi {
                     algorithms::for_handle_in_path_range(
                         graph, path_handle, path_range.begin.offset, path_range.end.offset,
                         [&](const handle_t& handle) {
-                            keep_bv.set(graph.get_id(handle));
+                            keep_bv.set(graph.get_id(handle) - shift);
                         });
                 }
-                for (auto id : keep_bv) {
-                    const handle_t h = graph.get_handle(id);
+                for (auto id_shifted : keep_bv) {
+                    const handle_t h = graph.get_handle(id_shifted + shift);
                     subgraph.create_handle(graph.get_sequence(h),
-                                           id);
+                                           id_shifted + shift);
                 }
             }
 

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -150,16 +150,11 @@ namespace odgi {
             }
         }
 
-        if (_full_range) {
-        	if (!graph.is_optimized()) {
-				std::cerr
-						<< "[odgi::extract] error: the graph is not optimized. "
-						   "To extract the full ranges, please run 'odgi sort' using -O, --optimize."
-						<< std::endl;
-				exit(1);
-        	}
+        const uint64_t shift = graph.min_node_id();
+        if (graph.max_node_id() - shift >= graph.get_node_count()){
+            std::cerr << "[odgi::extract] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+            exit(1);
         }
-
 
         // Prepare all paths for parallelize the next step (actually, not all paths are always present in the subgraph)
         std::vector<path_handle_t> paths;

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -271,10 +271,10 @@ namespace odgi {
         {
             std::string nucleotide_range = args::get(_nucleotide_range);
             if (!nucleotide_range.empty()) {
-                const size_t foundFirstColon = nucleotide_range.find_last_of(':');
+                const size_t foundLastColon = nucleotide_range.find_last_of(':');
                 std::string path_name;
-                if (foundFirstColon != string::npos) {
-                    path_name = nucleotide_range.substr(0, foundFirstColon);
+                if (foundLastColon != string::npos) {
+                    path_name = nucleotide_range.substr(0, foundLastColon);
 
                     if (!graph.has_path(path_name)) {
                         std::cerr
@@ -283,7 +283,7 @@ namespace odgi {
                         return 1;
                     }
 
-                    nucleotide_range = nucleotide_range.substr(foundFirstColon + 1);
+                    nucleotide_range = nucleotide_range.substr(foundLastColon + 1);
                 }
 
                 const std::regex regex("-");


### PR DESCRIPTION
Together with #319, this makes `odgi extract` more general and robust, allowing us to extract a subgraph from another subgraph.