### PR TITLE
Revert "no jemalloc"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -514,7 +514,8 @@ set(odgi_LIBS
   "${mondriaan_LIB}/libmondriaan.a"
   "${libbf_LIB}/libbf.a"
   "-ldl"
-  "-latomic")
+  "-latomic"
+  jemalloc)
   #"-lefence") # for malloc error checking
   #"-ltcmalloc") # for heap profiling
 


### PR DESCRIPTION
This reverts commit 954db0b71fb326416e2026338e17a9c09354aff0.