### PR TITLE
`odgi extract`: be more specific about path lacing options

### DIFF
--- a/docs/rst/commands/odgi_extract.rst
+++ b/docs/rst/commands/odgi_extract.rst
@@ -68,7 +68,7 @@ Extract Options
 
 | **-E, --full-range**
 | Collects all nodes in the sorted order of the graph in the min and max
-  position touched by the given path ranges. Be careful to use it with
+  position touched by the given path ranges. This ensures that all the paths of the subgraph are not split by node, but that the nodes are laced together again. Comparable to **-R, --lace-paths=FILE**, but specifically for all paths in the resulting subgraph. Be careful to use it with
   very complex graphs.
 
 | **-p, --paths-to-extract**\ =\ *FILE*

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -54,7 +54,7 @@ namespace odgi {
                                                     "Find the node(s) in the path range(s) specified in the given BED FILE.",
                                                     {'b', "bed-file"});
         args::Flag _full_range(extract_opts, "full_range",
-                               "Collects all nodes in the sorted order of the graph in the min and max positions touched by the given path ranges. "
+                               "Collects all nodes in the sorted order of the graph in the min and max positions touched by the given path ranges. This ensures that all the paths of the subgraph are not split by node, but that the nodes are laced together again. Comparable to **-R, --lace-paths=FILE**, but specifically for all paths in the resulting subgraph. "
                                "Be careful to use it with very complex graphs.",
                                {'E', "full-range"});
         args::ValueFlag<std::string> _path_names_file(extract_opts, "FILE",


### PR DESCRIPTION
I just ran into a problem where I could produce a subgraph with the paths laced back together, because the documentation of the option `-E, --full-range` was insufficient. Fixed with this PR.