### PR TITLE
Untangly drops

### DIFF
--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -458,8 +458,10 @@ void map_segments(
             for (auto& mapping : target_mapping) {
                 ++nth_best;
                 if (nth_best > n_best) break;
-                auto& score = mapping.jaccard;
-                if (score >= min_jaccard) {
+                double jaccard = mapping.jaccard > 1.0 ? 1.0 : mapping.jaccard;
+                if (jaccard >= min_jaccard) {
+                    double dist = -log(2.0 * jaccard / (1. + jaccard));
+                    if (dist > 1.0) dist = 1.0;
                     auto& idx = mapping.segment_id; // segment index
                     auto& target_begin = target_segments.get_segment_cut(idx);
                     auto target_begin_pos = step_index.get_position(target_begin);
@@ -481,7 +483,8 @@ void map_segments(
                         << 0 << "\t"
                         << std::max(target_end_pos - target_begin_pos, end_pos - begin_pos) << "\t"
                         << 255 << "\t"
-                        << "jc:f:" << score << "\t"
+                        << "id:f:" << (double) 1.0 - dist << "\t"
+                        << "jc:f:" << jaccard << "\t"
                         << "sc:f:" << self_coverage << "\t"
                         << "nb:i:" << nth_best << "\t"
                         << std::endl;
@@ -493,7 +496,7 @@ void map_segments(
                         << target_name << "\t"
                         << target_begin_pos << "\t"
                         << target_end_pos << "\t"       // chrom2 end (1-based)
-                        << score << "\t"
+                        << jaccard << "\t"
                         << (mapping.is_inv ? "-" : "+") << "\t"
                         << self_coverage << "\t"
                         << nth_best << std::endl;

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -472,12 +472,12 @@ void map_segments(
                         std::cout << query_name << "\t"
                         << path_to_len[path] << "\t"
                         << begin_pos << "\t"
-                        << end_pos - 1 << "\t"          // Query end (0-based; BED-like; open)
+                        << end_pos << "\t"          // Query end (0-based; BED-like; open)
                         << (mapping.is_inv ? "-" : "+") << "\t"
                         << target_name << "\t"
                         << path_to_len[target_path] << "\t"
                         << target_begin_pos << "\t"
-                        << target_end_pos -1 << "\t"    // Target end (0-based; BED-like; open)
+                        << target_end_pos << "\t"    // Target end (0-based; BED-like; open)
                         << 0 << "\t"
                         << std::max(target_end_pos - target_begin_pos, end_pos - begin_pos) << "\t"
                         << 255 << "\t"


### PR DESCRIPTION
Avoid dropping alignments (using wfmash) of untangle PAF output.

The trick is to give a reasonable estimate of identity in the PAF. In wfmash, this is used to adjust high-order WFA alignment parameters.