### PR TITLE
wfmash expects id:f: to be [0-100]

### DIFF
--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -483,7 +483,7 @@ void map_segments(
                         << 0 << "\t"
                         << std::max(target_end_pos - target_begin_pos, end_pos - begin_pos) << "\t"
                         << 255 << "\t"
-                        << "id:f:" << (double) 1.0 - dist * (double) 100 << "\t"
+                        << "id:f:" << ((double) 1.0 - dist) * (double) 100 << "\t"
                         << "jc:f:" << jaccard << "\t"
                         << "sc:f:" << self_coverage << "\t"
                         << "nb:i:" << nth_best << "\t"


### PR DESCRIPTION
This fixes a silly bug with odgi untangle / wfmash collaboration.

wfmash wants the id:f: tag to be in the range of 0-100.

odgi untangle was emitting it in [0-1]. Oops!