### PR TITLE
adios FASTA option `odgi bin`

### DIFF
--- a/docs/rst/commands/odgi_bin.rst
+++ b/docs/rst/commands/odgi_bin.rst
@@ -54,12 +54,6 @@ MANDATORY OPTIONS
 | **-i, --idx**\ =\ *FILE*
 | Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!
 
-FASTA Options
--------------
-
-| **-f, --fasta**\ =\ *FILE*
-| Write the pangenome sequence to *FILE* in FASTA format.
-
 Bin Options
 -----------
 

--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -29,7 +29,6 @@ namespace odgi {
                                                     const std::vector<std::pair<uint64_t, uint64_t>> &,
                                                     const std::map<uint64_t, algorithms::path_info_t> &)> &handle_path,
                            const std::function<void(const uint64_t &, const std::string &)> &handle_sequence,
-                           const std::function<void(const string &)> &handle_fasta,
                            uint64_t num_bins,
                            uint64_t bin_width,
                            bool drop_gap_links,
@@ -57,8 +56,6 @@ namespace odgi {
             for (uint64_t i = 0; i < num_bins; ++i) {
                 handle_sequence(i + 1, graph_seq.substr(i * bin_width, bin_width));
             }
-            // write out pangenome sequence if wished so
-            handle_fasta(graph_seq);
             graph_seq.clear(); // clean up
             std::unordered_map<path_handle_t, uint64_t> path_length;
             uint64_t gap_links_removed = 0;

--- a/src/algorithms/bin_path_info.hpp
+++ b/src/algorithms/bin_path_info.hpp
@@ -37,7 +37,6 @@ namespace odgi {
                                                     const std::vector<std::pair<uint64_t, uint64_t>> &,
                                                     const std::map<uint64_t, algorithms::path_info_t> &)> &handle_path,
                            const std::function<void(const uint64_t &, const std::string &)> &handle_sequence,
-                           const std::function<void(const std::string&)> &handle_fasta,
                            uint64_t num_bins = 0,
                            uint64_t bin_width = 0,
                            bool drop_gap_links = false,


### PR DESCRIPTION
We already have the possibility to write the pangenomic sequence into a FASTA file via `odgi flatten`. Removing redundancy.