### PR TITLE
`odgi untangle` power up - also include the segments at the tips of each query path

### DIFF
--- a/src/algorithms/path_jaccard.cpp
+++ b/src/algorithms/path_jaccard.cpp
@@ -27,6 +27,7 @@ namespace odgi {
 						std::cerr << "MIN: " << min_max_walk_dist.first << " MAX: " << min_max_walk_dist.second << std::endl;
 #endif
 			std::vector<step_jaccard_t> target_jaccard_indices;
+			// we were able to walk the given maximum walking distance in both directions, this greatly simplifies the algorithm
 			if (min_max_walk_dist.first >= walking_dist && min_max_walk_dist.second >= walking_dist) {
 				/// for the query:
 				// walk the given walking_dist first to the left (we might not be able to do the full walk)
@@ -36,6 +37,7 @@ namespace odgi {
 				ska::flat_hash_map<nid_t, uint64_t> query_set = collect_nodes_in_walking_dist(graph, walking_dist, walking_dist, cur_step);
 				// TODO we can precollect all sets so here we don't have to do the walks anymore
 				for (step_handle_t& target_step : target_step_handles) {
+					// we count which node identifier we saw how many times
 					ska::flat_hash_map<nid_t, uint64_t> target_set = collect_nodes_in_walking_dist(graph, walking_dist, walking_dist, target_step);
 					ska::flat_hash_map<nid_t, uint64_t> union_set;
 					for (auto& query_item : query_set) {
@@ -68,6 +70,7 @@ namespace odgi {
 							std::cerr << "Jaccard index of query " << query_path_name << " and target " << target_path << ": " << jaccard << ". Direction: " << walk_from_front << std::endl;
 #endif
 				}
+				// more complex algorithm
 			} else {
 				ska::flat_hash_map<nid_t, uint64_t> query_set_min_max = collect_nodes_in_walking_dist_from_map(
 						graph,

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -428,6 +428,57 @@ double self_mean_coverage(
     return (double)sum / (double)bp;
 }
 
+uint64_t query_hits_target_front(
+		const PathHandleGraph& graph,
+		const path_handle_t& query,
+		const atomicbitvector::atomic_bv_t targets_node_idx) {
+	// currently we don't care about self mapping
+	bool tip_reached_target = false;
+	step_handle_t cur_step = graph.path_begin(query);
+	handle_t cur_h = graph.get_handle_of_step(cur_step);
+	uint64_t cur_id = graph.get_id(cur_h);
+	while (!tip_reached_target) {
+		if (targets_node_idx.test(cur_id)) {
+			tip_reached_target = true;
+			return cur_id;
+		}
+		if (graph.has_next_step(cur_step)) {
+			cur_step = graph.get_next_step(cur_step);
+			cur_h = graph.get_handle_of_step(cur_step);
+			cur_id = graph.get_id(cur_h);
+		} else {
+			tip_reached_target = true;
+		}
+	}
+	return 0;
+}
+
+uint64_t query_hits_target_back(
+		const PathHandleGraph& graph,
+		const path_handle_t& query,
+		const atomicbitvector::atomic_bv_t targets_node_idx) {
+	// currently we don't care about self mapping
+	bool tip_reached_target = false;
+	step_handle_t cur_step = graph.path_back(query);
+	handle_t cur_h = graph.get_handle_of_step(cur_step);
+	uint64_t cur_id = graph.get_id(cur_h);
+	while (!tip_reached_target) {
+		if (targets_node_idx.test(cur_id)) {
+			tip_reached_target = true;
+			return cur_id;
+		}
+		if (graph.has_previous_step(cur_step)) {
+			cur_step = graph.get_previous_step(cur_step);
+			cur_h = graph.get_handle_of_step(cur_step);
+			cur_id = graph.get_id(cur_h);
+		} else {
+			tip_reached_target = true;
+		}
+	}
+	return 0;
+}
+
+
 void map_segments(
     const PathHandleGraph& graph,
     const path_handle_t& path,
@@ -532,6 +583,16 @@ void untangle(
     //std::cerr << "[odgi::algorithms::untangle] building step index" << std::endl;
     //auto step_pos = make_step_index(graph, paths, num_threads);
     step_index_t step_index(graph, paths, num_threads, progress);
+
+	// which nodes are traversed by our target paths?
+	atomicbitvector::atomic_bv_t target_nodes(graph.get_node_count() + 1);
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
+	for (auto& target : targets) {
+		graph.for_each_step_in_path(
+				target, [&](const step_handle_t& step) {
+					target_nodes.set(graph.get_id(graph.get_handle_of_step(step)), true);
+				});
+	}
     /*
     auto get_position = [&](const step_handle_t& step) {
         return step_index.get_position(step);
@@ -560,6 +621,13 @@ void untangle(
         for (auto& step : cuts) {
             cut_nodes.set(graph.get_id(graph.get_handle_of_step(step)));
         }
+		// TODO also add the nodes here where the query path touches the target for the first time
+		// we start from the front until we found a target node
+		uint64_t node_id_front = query_hits_target_front(graph, path, target_nodes);
+		cut_nodes.set(node_id_front, true);
+		// we start from the back until we found a target node
+		uint64_t node_id_back = query_hits_target_back(graph, path, target_nodes);
+		cut_nodes.set(node_id_back, true);
         //std::cerr << "setup" << std::endl;
         //write_cuts(graph, path, cuts, step_pos);
     }

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -584,17 +584,17 @@ void untangle(
     //auto step_pos = make_step_index(graph, paths, num_threads);
     step_index_t step_index(graph, paths, num_threads, progress);
 
-	// which nodes are traversed by our target paths?
-	atomicbitvector::atomic_bv_t target_nodes(graph.get_node_count() + 1);
+    // which nodes are traversed by our target paths?
+    atomicbitvector::atomic_bv_t target_nodes(graph.get_node_count() + 1);
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
-	for (auto& target : targets) {
-		graph.for_each_step_in_path(
-				target, [&](const step_handle_t& step) {
-					target_nodes.set(graph.get_id(graph.get_handle_of_step(step)), true);
-				});
-	}
+    for (auto& target : targets) {
+        graph.for_each_step_in_path(
+            target, [&](const step_handle_t& step) {
+                target_nodes.set(graph.get_id(graph.get_handle_of_step(step)), true);
+            });
+    }
     /*
-    auto get_position = [&](const step_handle_t& step) {
+      auto get_position = [&](const step_handle_t& step) {
         return step_index.get_position(step);
     };
     */
@@ -621,15 +621,13 @@ void untangle(
         for (auto& step : cuts) {
             cut_nodes.set(graph.get_id(graph.get_handle_of_step(step)));
         }
-		// TODO also add the nodes here where the query path touches the target for the first time
-		// we start from the front until we found a target node
-		uint64_t node_id_front = query_hits_target_front(graph, path, target_nodes);
-		cut_nodes.set(node_id_front, true);
-		// we start from the back until we found a target node
-		uint64_t node_id_back = query_hits_target_back(graph, path, target_nodes);
-		cut_nodes.set(node_id_back, true);
-        //std::cerr << "setup" << std::endl;
-        //write_cuts(graph, path, cuts, step_pos);
+        // also add the nodes here where the query path touches the target for the first time
+        // we start from the front until we found a target node
+        uint64_t node_id_front = query_hits_target_front(graph, path, target_nodes);
+        cut_nodes.set(node_id_front, true);
+        // we start from the back until we found a target node
+        uint64_t node_id_back = query_hits_target_back(graph, path, target_nodes);
+        cut_nodes.set(node_id_back, true);
     }
 
     //auto step_pos = make_step_index(graph, queries);


### PR DESCRIPTION
Trying to teach `odgi untangle` to also incorporate the tips of each query path when untangling them.

- [X] Implement prototype.
- [x] Test prototype on small scale data.
- [x] Test prototype on large scale data.