### PR TITLE
Cleaned the `odgi` menu

### DIFF
--- a/docs/rst/commands/odgi_matrix.rst
+++ b/docs/rst/commands/odgi_matrix.rst
@@ -4,7 +4,7 @@
 odgi matrix
 #########
 
-Write the graph topology in sparse matrix formats.
+Write the graph topology in sparse matrix format.
 
 SYNOPSIS
 ========

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -575,7 +575,7 @@ namespace odgi {
         return 0;
     }
 
-    static Subcommand odgi_depth("depth", "Find the depth of a graph as defined by query criteria. Without specifying any non-mandatory options, it prints in a tab-delimited format path, start, end, and mean.depth to stdout.",
+    static Subcommand odgi_depth("depth", "Find the depth of a graph as defined by query criteria.",
                                  PIPELINE, 3, main_depth);
 
 }

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -54,7 +54,9 @@ namespace odgi {
                                                     "Find the node(s) in the path range(s) specified in the given BED FILE.",
                                                     {'b', "bed-file"});
         args::Flag _full_range(extract_opts, "full_range",
-                               "Collects all nodes in the sorted order of the graph in the min and max positions touched by the given path ranges. This ensures that all the paths of the subgraph are not split by node, but that the nodes are laced together again. Comparable to **-R, --lace-paths=FILE**, but specifically for all paths in the resulting subgraph. "
+                               "Collects all nodes in the sorted order of the graph in the min and max positions touched by the given path ranges. "
+                               "This ensures that all the paths of the subgraph are not split by node, but that the nodes are laced together again. "
+                               "Comparable to **-R, --lace-paths=FILE**, but specifically for all paths in the resulting subgraph. "
                                "Be careful to use it with very complex graphs.",
                                {'E', "full-range"});
         args::ValueFlag<std::string> _path_names_file(extract_opts, "FILE",
@@ -434,7 +436,7 @@ namespace odgi {
                 subgraph.create_edge(edge.first, edge.second);
             }
 
-            if (show_progress) {
+            if (show_progress && edges_to_create.size() > 0) {
                 std::cerr << "[odgi::extract] fixed " << edges_to_create.size() << " edge(s)" << std::endl;
             }
 

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -26,7 +26,7 @@ int main_layout(int argc, char **argv) {
     --argc;
 
     args::ArgumentParser parser(
-        "Establish 2D layouts of the graph using path-guided stochastic gradient descent (the graph must be sorted and id-compacted).");
+        "Establish 2D layouts of the graph using path-guided stochastic gradient descent. The graph must be sorted and id-compacted.");
     args::Group mandatory_opts(parser, "[ MANDATORY OPTIONS ]");
     args::ValueFlag<std::string> dg_in_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "idx"});
     args::Group files_io_opts(parser, "[ Files IO ]");
@@ -416,7 +416,7 @@ int main_layout(int argc, char **argv) {
     return 0;
 }
 
-static Subcommand odgi_layout("layout", "Establish 2D layouts of the graph using path-guided stochastic gradient descent (the graph must be sorted and id-compacted).",
+static Subcommand odgi_layout("layout", "Establish 2D layouts of the graph using path-guided stochastic gradient descent.",
                                PIPELINE, 3, main_layout);
 
 

--- a/src/subcommand/matrix_main.cpp
+++ b/src/subcommand/matrix_main.cpp
@@ -18,7 +18,7 @@ int main_matrix(int argc, char** argv) {
     argv[0] = (char*)prog_name.c_str();
     --argc;
     
-    args::ArgumentParser parser("Write the graph topology in sparse matrix formats.");
+    args::ArgumentParser parser("Write the graph topology in sparse matrix format.");
     args::Group mandatory_opts(parser, "[ MANDATORY OPTIONS ]");
     args::ValueFlag<std::string> dg_in_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "idx"});
     args::Group matrix_opts(parser, "[ Matrix Options ]");
@@ -72,7 +72,7 @@ int main_matrix(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_matrix("matrix", "Write the graph topology in sparse matrix formats.",
+static Subcommand odgi_matrix("matrix", "Write the graph topology in sparse matrix format.",
                               PIPELINE, 3, main_matrix);
 
 

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -360,7 +360,7 @@ int main_paths(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_paths("paths", "Interrogate the embedded paths of a graph. Does not print anything to stdout by default!",
+static Subcommand odgi_paths("paths", "Interrogate the embedded paths of a graph.",
                               PIPELINE, 3, main_paths);
 
 

--- a/src/subcommand/position_main.cpp
+++ b/src/subcommand/position_main.cpp
@@ -1021,7 +1021,7 @@ int main_position(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_position("position", "Find, translate, and liftover graph and path positions between graphs. Results are printed to stdout.",
+static Subcommand odgi_position("position", "Find, translate, and liftover graph and path positions between graphs.",
                                 PIPELINE, 3, main_position);
 
 

--- a/src/subcommand/server_main.cpp
+++ b/src/subcommand/server_main.cpp
@@ -157,7 +157,7 @@ namespace odgi {
     }
 
     static Subcommand odgi_server("server",
-                                  "Start a basic HTTP server with a given path index file to go from *path:position* to *pangenome:position* very efficiently.",
+                                  "Start a basic HTTP server to lift coordinates between path and pangenomic positions.",
                                   PIPELINE, 3, main_server);
 
 }

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -456,7 +456,7 @@ int main_sort(int argc, char** argv) {
     return 0;
 }
 
-static Subcommand odgi_sort("sort", "Apply different kind of sorting algorithms to a graph. The most prominent one is the PG-SGD sorting algorithm.",
+static Subcommand odgi_sort("sort", "Apply different kind of sorting algorithms to a graph.",
                               PIPELINE, 3, main_sort);
 
 

--- a/src/subcommand/tips_main.cpp
+++ b/src/subcommand/tips_main.cpp
@@ -236,7 +236,7 @@ namespace odgi {
 	}
 
 	static Subcommand odgi_tips("tips",
-									"Identifying break point positions relative to given query (reference) path(s) of all the tips in the graph or of tips of given path(s). Prints BED records to stdout.",
+									"Identifying break point positions relative to given references.",
 									PIPELINE, 3, main_tips);
 
 }

--- a/src/subcommand/untangle_main.cpp
+++ b/src/subcommand/untangle_main.cpp
@@ -189,6 +189,6 @@ int main_untangle(int argc, char **argv) {
     return 0;
 }
 
-static Subcommand odgi_untangle("untangle", "Project paths into reference-relative (optionally PAF), to decompose paralogy relationships.", PIPELINE, 3, main_untangle);
+static Subcommand odgi_untangle("untangle", "Project paths into reference-relative, to decompose paralogy relationships.", PIPELINE, 3, main_untangle);
 
 } // namespace odgi


### PR DESCRIPTION
This allows you to have (more easily) all tools and their descriptions in one line. The longer descriptions are still visible in the specific `odgi xxx` menu (and their documentation).

```
$ odgi

odgi: optimized dynamic genome/graph implementation, version v0.6.2-75-gc6570a3 "Auff"

usage: odgi <command> [options]

Overview of available commands:
  -- bin           Binning of pangenome sequence and path information in the graph.
  -- break         Break cycles in the graph and drop its paths.
  -- build         Construct a dynamic succinct variation graph in ODGI format from a GFAv1.
  -- chop          Divide nodes into smaller pieces preserving node topology and order.
  -- cover         Cover the graph with paths.
  -- crush         Crush runs of N.
  -- degree        Describe the graph in terms of node degree.
  -- depth         Find the depth of a graph as defined by query criteria.
  -- draw          Draw previously-determined 2D layouts of the graph with diverse annotations.
  -- explode       Breaks a graph into connected components storing each component in its own file.
  -- extract       Extract subgraphs or parts of a graph defined by query criteria.
  -- flatten       Generate linearizations of a graph.
  -- groom         Resolve spurious inverting links.
  -- kmers         Display and characterize the kmer space of a graph.
  -- layout        Establish 2D layouts of the graph using path-guided stochastic gradient descent.
  -- matrix        Write the graph topology in sparse matrix format.
  -- normalize     Compact unitigs and simplify redundant furcations.
  -- overlap       Find the paths touched by given input paths.
  -- panpos        Get the pangenome position of a given path and nucleotide position (1-based).
  -- pathindex     Create a path index for a given graph.
  -- paths         Interrogate the embedded paths of a graph.
  -- position      Find, translate, and liftover graph and path positions between graphs.
  -- prune         Remove complex parts of the graph.
  -- server        Start a basic HTTP server to lift coordinates between path and pangenomic positions.
  -- sort          Apply different kind of sorting algorithms to a graph.
  -- squeeze       Squeezes multiple graphs in ODGI format into the same file in ODGI format.
  -- stats         Metrics describing a variation graph and its path relationship.
  -- tips          Identifying break point positions relative to given references.
  -- unchop        Merge unitigs into a single node preserving the node order.
  -- unitig        Output unitigs of the graph.
  -- untangle      Project paths into reference-relative, to decompose paralogy relationships.
  -- validate      Validate a graph checking if the paths are consistent with the graph topology.
  -- version       Print the version of ODGI to stdout.
  -- view          Project a graph into other formats.
  -- viz           Visualize a variation graph in 1D.
```

Moreover, `odgi extract` does not show `[odgi::extract] fixed 0 edge(s)` anymore, if there are no edges that needed fixing (it seemed always a bad thing to show such a zero).