### PR TITLE
`odgi view`: optional node annotations in the GFA output format

### DIFF
--- a/docs/rst/commands/odgi_build.rst
+++ b/docs/rst/commands/odgi_build.rst
@@ -33,12 +33,6 @@ MANDATORY OPTIONS
 | Write the dynamic succinct variation graph to this *FILE*. A file ending
   with *.og* is recommended.
 
-Gaph Files IO
--------------
-
-| **-G, --to-gfa**
-| Write the graph to stdout in GFAv1 format.
-
 Graph Sorting
 -------------
 

--- a/docs/rst/commands/odgi_view.rst
+++ b/docs/rst/commands/odgi_view.rst
@@ -32,6 +32,9 @@ Output Options
 | **-g, --to-gfa**
 | Write the graph in GFAv1 format to standard output.
 
+| **-a, --node-annotation**
+| Emit node annotations for the graph in GFAv1 format.
+
 Summary Options
 ---------------
 

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -1537,14 +1537,18 @@ void graph_t::display() const {
 
 }
 
-void graph_t::to_gfa(std::ostream& out) const {
+void graph_t::to_gfa(std::ostream& out, const bool& emit_node_annotation) const {
     out << "H\tVN:Z:1.0" << std::endl;
     // for each node
-    for_each_handle([&out,this](const handle_t& h) {
-            out << "S\t" << get_id(h) << "\t"
-                << get_sequence(h) << "\t"
+    for_each_handle([&out,&emit_node_annotation, this](const handle_t& h) {
+            out << "S\t" << get_id(h) << "\t" << get_sequence(h);
+            if (emit_node_annotation) {
+                out << "\t"
                 << "DP:i:" << get_step_count(h) << "\t"
-                << "RC:i:" << get_step_count(h) * get_length(h) << std::endl;
+                << "RC:i:" << get_step_count(h) * get_length(h);
+            }
+            out << std::endl;
+
             {
                 // use this direct iteration to avoid double counting edges
                 // we only consider write the edges relative to their start

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -403,7 +403,7 @@ public:
     void display(void) const;
 
     /// Convert to GFA (for debugging)
-    void to_gfa(std::ostream& out) const;
+    void to_gfa(std::ostream& out, const bool& emit_node_annotation = false) const;
 
     /// Magic number header for serialization
     uint32_t get_magic_number(void) const;

--- a/src/subcommand/build_main.cpp
+++ b/src/subcommand/build_main.cpp
@@ -26,8 +26,6 @@ int main_build(int argc, char** argv) {
     args::ValueFlag<std::string> gfa_file(mandatory_opts, "FILE", "GFAv1 FILE containing the nodes, edges and "
                                                           "paths to build a dynamic succinct variation graph from.", {'g', "gfa"});
     args::ValueFlag<std::string> dg_out_file(mandatory_opts, "FILE", "Write the dynamic succinct variation graph to this *FILE*. A file ending with *.og* is recommended.", {'o', "out"});
-    args::Group graph_files_io(parser, "[ Graph Files IO ]");
-    args::Flag to_gfa(graph_files_io, "to_gfa", "Write the graph to stdout in GFAv1 format.", {'G', "to-gfa"});
     args::Group graph_sorting(parser, "[ Graph Sorting ]");
     args::Flag optimize(graph_sorting, "optimize", "Compact the graph id space into a dense integer range.", {'O', "optimize"});
     args::Flag toposort(graph_sorting, "sort", "Apply a general topological sort to the graph and order the node ids"
@@ -90,11 +88,8 @@ int main_build(int argc, char** argv) {
     if (args::get(debug)) {
         graph.display();
     }
-    if (args::get(to_gfa)) {
-        graph.to_gfa(std::cout);
-    }
-    std::string outfile = args::get(dg_out_file);
-    if (outfile.size()) {
+    const std::string outfile = args::get(dg_out_file);
+    if (!outfile.empty()) {
         if (outfile == "-") {
             graph.serialize(std::cout);
         } else {

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -246,7 +246,7 @@ namespace odgi {
                 // Save the component
                 ofstream f(filename);
                 if (to_gfa){
-                    subgraph.to_gfa(f);
+                    subgraph.to_gfa(f, false);
                 }else {
                     subgraph.serialize(f);
                 }

--- a/src/subcommand/view_main.cpp
+++ b/src/subcommand/view_main.cpp
@@ -22,6 +22,7 @@ int main_view(int argc, char** argv) {
     args::ValueFlag<std::string> dg_in_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "idx"});
     args::Group out_opts(parser, "[ Output Options ]");
     args::Flag to_gfa(out_opts, "to_gfa", "Write the graph in GFAv1 format to standard output.", {'g', "to-gfa"});
+    args::Flag emit_node_annotation(out_opts, "node_annotation", "Emit node annotations for the graph in GFAv1 format.", {'a', "node-annotation"});
     args::Flag display(out_opts, "display", "Show the internal structures of a graph. Print to stdout the maximum"
                                           " node identifier, the minimum node identifier, the nodes vector, the"
                                           " delete nodes bit vector and the path metadata, each in a separate"
@@ -57,19 +58,22 @@ int main_view(int argc, char** argv) {
 
     graph_t graph;
     assert(argc > 0);
-    std::string infile = args::get(dg_in_file);
-    if (infile.size()) {
-        if (infile == "-") {
-            graph.deserialize(std::cin);
-        } else {
-			utils::handle_gfa_odgi_input(infile, "view", args::get(progress), num_threads, graph);
+    {
+        const std::string infile = args::get(dg_in_file);
+        if (!infile.empty()) {
+            if (infile == "-") {
+                graph.deserialize(std::cin);
+            } else {
+                utils::handle_gfa_odgi_input(infile, "view", args::get(progress), num_threads, graph);
+            }
         }
     }
+
     if (args::get(display)) {
         graph.display();
     }
     if (args::get(to_gfa)) {
-        graph.to_gfa(std::cout);
+        graph.to_gfa(std::cout, args::get(emit_node_annotation));
     }
 
     return 0;


### PR DESCRIPTION
This allows generating of smaller GFA files.