### PR TITLE
`odgi extract` powerup: extract pangenomic ranges

### DIFF
--- a/docs/rst/commands/odgi_extract.rst
+++ b/docs/rst/commands/odgi_extract.rst
@@ -63,8 +63,11 @@ Extract Options
 | Find the node(s) in the specified path range TARGET=path[:pos1[-pos2]]
   (0-based coordinates).
 
-| **-r, --bed-file**\ =\ *FILE*
+| **-b, --bed-file**\ =\ *FILE*
 | Find the node(s) in the path range(s) specified in the given BED FILE
+
+| **-q, --pangenomic-range**\ =\ *FILE*
+|  Find the node(s) in the specified pangenomic range pos1-pos2 (0-based coordinates). The nucleotide positions refer to the pangenome’s sequence (i.e., the sequence obtained arranging all the graph’s node from left to right).
 
 | **-E, --full-range**
 | Collects all nodes in the sorted order of the graph in the min and max

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
 
     if (argc == 1) {
         odgi_help(argv);
-        return 1;
+        return 0;
     }
 
     const auto* subcommand = odgi::subcommand::Subcommand::get(argc, argv);

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -545,28 +545,23 @@ namespace odgi {
                             keep_bv.set(graph.get_id(handle) - shift);
                         });
                 }
+                if (_pangenomic_range) {
+                    uint64_t len = 0;
+                    graph.for_each_handle([&](const handle_t &h) {
+                        const uint64_t hl = graph.get_length(h);
+
+                        if (len <= pangenomic_range.second && pangenomic_range.first <= len + hl) {
+                            keep_bv.set(graph.get_id(h) - shift);
+                        }
+
+                        len += hl;
+                    });
+                }
                 for (auto id_shifted : keep_bv) {
                     const handle_t h = graph.get_handle(id_shifted + shift);
                     subgraph.create_handle(graph.get_sequence(h),
                                            id_shifted + shift);
                 }
-            }
-
-            // todo: to put in the parallel stuff or in the keep_bv stuff, to avoid checking has_node
-            if (_pangenomic_range) {
-                uint64_t len = 0;
-                graph.for_each_handle([&](const handle_t &h) {
-                    uint64_t hl = graph.get_length(h);
-
-                    if (len <= pangenomic_range.second && pangenomic_range.first <= len + hl) {
-                        nid_t hid = graph.get_id(h);
-                        if (!subgraph.has_node(hid)) {
-                            subgraph.create_handle(graph.get_sequence(h), hid);
-                        }
-                    }
-
-                    len += hl;
-                });
             }
 
             if (show_progress) {


### PR DESCRIPTION
This allows users to extract subgraphs by specifying pangenomic ranges, that is nucleotide ranges that refer to the pangenome’s sequence (i.e., the sequence obtained arranging all the graph’s node from left to right). This can be useful in specific cases.

**Example: extract sequences that do not align to the reference**
Given this rat chr1 pangenome as an example:

![image](https://user-images.githubusercontent.com/62253982/143481801-0ef6bf22-9112-4c49-9024-d923a337821a.png)

we can see sequences on the left/right that do not align with the reference (`REF`). A simple way to extract that region is to specify a pangenomic range from 0 to *something*.

`odgi extract -i chr1_mratnor1.pan+ref.fa.gz.f7b23b2.4030258.ab53614.smooth.og -q 0-145000000 -t 48 -P -o - | odgi viz -i - -o x.png -M sample.names`
![image](https://user-images.githubusercontent.com/62253982/143481975-9b5d8d35-d8c2-4a61-b768-3291aaaedf91.png)

In this case, we are extracting also a little piece of the reference. Part of these sequences presents uncalled bases:

![image](https://user-images.githubusercontent.com/62253982/143482224-2b8969d6-1aee-40c5-bb2b-fda5595f65ae.png)

Extracting and visualizing is a fast-enough workflow for searching a pangenomic range of interest, at least for not huge pangenomes, but we still need better ways to find such a range more easily and interactively.