### PR TITLE
a sampled step index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,10 @@ project(odgi)
 set(CMAKE_CXX_STANDARD 17)
 
 # Use all standard-compliant optimizations
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -O3 -g")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -O3 -g")
-#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
-#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
+#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -O3 -g")
+#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -O3 -g")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # assumes clang build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/unittest/pathindex.cpp
   ${CMAKE_SOURCE_DIR}/src/unittest/edge.cpp
   ${CMAKE_SOURCE_DIR}/src/unittest/extract.cpp
+  ${CMAKE_SOURCE_DIR}/src/unittest/stepindex.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/subcommand.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/build_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/test_main.cpp
@@ -392,6 +393,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/version_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/untangle_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/tips_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/stepindex_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,10 @@ project(odgi)
 set(CMAKE_CXX_STANDARD 17)
 
 # Use all standard-compliant optimizations
-#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -O3 -g")
-#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -O3 -g")
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -O3 -g")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -O3 -g")
+#set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O -g -fsanitize=address")
+#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O -g -fsanitize=address")
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   # assumes clang build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,13 @@ sys.path.insert(0, os.path.abspath('../lib/'))
 # -- Project information -----------------------------------------------------
 
 project = u'odgi'
-copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision v0.6.3-98fd121'
+copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision v0.6.3-75aa190'
 author = u'Andrea Guarracino, Simon Heumos, ... , Pjotr Prins, Erik Garrison'
 
 # The short X.Y version
 version = 'v0.6.3'
 # The full version, including alpha/beta/rc tags
-release = '98fd121'
+release = '75aa190'
 
 
 # -- General configuration ---------------------------------------------------
@@ -129,7 +129,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'odgi.tex', u'odgi documentation',
-     u'Andrea Guarracino, Simon Heumos, ... , Pjotr Prins, Erik Garrison', 'manual'),
+     u'Andrea Guarracino, Simon Heumos, Sven Nahnsen , Pjotr Prins, Erik Garrison', 'manual'),
 ]
 
 # -- Options for manual page output ------------------------------------------

--- a/docs/rst/commands.rst
+++ b/docs/rst/commands.rst
@@ -32,6 +32,7 @@ Commands
     commands/odgi_sort
     commands/odgi_squeeze
     commands/odgi_stats
+    commands/odgi_stepindex
     commands/odgi_test
     commands/odgi_tips
     commands/odgi_unchop

--- a/docs/rst/commands/odgi.rst
+++ b/docs/rst/commands/odgi.rst
@@ -73,6 +73,8 @@ input_graphs.txt -o graphs.og
 
 :ref:`odgi stats` -i graph.og -y
 
+:ref:`odgi stepindex` -i graph.og -o graph.og.stpidx
+
 :ref:`odgi test`
 
 :ref:`odgi tips` -i graph.og -q "query_name"
@@ -294,20 +296,12 @@ criteria.
    pseudo-random <http://www.cplusplus.com/reference/random/mt19937/>`__
    generated numbers.
 
--  A sparse matrix mondriaan sort: We can partition a hypergraph with
-   integer weights and uniform hyperedge costs using the
-   `Mondriaan <http://www.staff.science.uu.nl/~bisse101/Mondriaan/>`__
-   partitioner.
-
 -  A 1D linear SGD sort: ODGI implements a 1D linear, variation graph
    adjusted, multi-threaded version of the `Graph Drawing by Stochastic
    Gradient Descent <https://arxiv.org/abs/1710.04626>`__ algorithm. The
    force-directed graph drawing algorithm minimizes the graph’s energy
    function or stress level. It applies stochastic gradient descent
    (SGD) to move a single pair of nodes at a time.
-
--  An eades algorithmic sort: Use `Peter Eades’ heuristic for graph
-   drawing <http://www.it.usyd.edu.au/~pead6616/old_spring_paper.pdf>`__.
 
 Sorting the paths in a graph my refine the sorting process. For the
 users’ convenience, it is possible to specify a whole pipeline of sorts
@@ -322,6 +316,17 @@ multiple graphs into the same file.
   Among other metrics, it can calculate the #nodes, #edges, #paths and
   the total nucleotide length of the graph. It can also produce a YAML file that is perfectly curated for the input of
   `MultiQC's ODGI module <https://multiqc.info/docs/#odgi>`__.
+
+| **odgi stepindex** [**-i, --idx**\ =\ *FILE*] [**-o, --out**\ =\ *FILE*] [*OPTION*]…
+| The odgi stepindex command generates a step index from a given graph. Such an index allows us to efficiently retrieve the nucleotide position of a given graph step.
+In order to save memory, a sampled step index is implemented here. We solve memory issues by only indexing every node with node identifier fitting **mod(node_id, step-index-sample-rate) == 0** in the graph.
+From a given step, we can find its position by walking backwards until a node fitting our sampling criteria is found. We can retrieve this position easily, adding up the walked distance to retrieve the actual position of the step.
+Effectively, the sample rate is only allowed to be a number by the power of 2, because we can use bit shift operations to calculate the modulo in O(1)! (`https://www.geeksforgeeks.org/compute-modulus-division-by-a-power-of-2-number/ <https://www.geeksforgeeks.org/compute-modulus-division-by-a-power-of-2-number/>`_).
+As `evaluated <https://docs.google.com/presentation/d/1a8bOnulta6fYnQ2DFmdzt4es2vaRGmgIxO3kCe-HXR8/edit#slide=id.p>`_, the default sample rate is 8, which represents a good compromise between performance and memory usage. For ultra large graphs with hundreds of gigabytes in size, a sample rate of 16 might suite better.
+
+As a bonus, the step index includes all the lengths of the paths, too. This allows us to efficiently get the length in nucleotides of a path by a given path handle.
+
+Current ODGI tools that work with a step index are :ref:`odgi untangle` and :ref:`odgi tips`.
 
 | **odgi test** [<TEST NAME|PATTERN|TAGS> …] [*OPTION*]…
 | The odgi test command starts all unit tests that are implemented in

--- a/docs/rst/commands/odgi_build.rst
+++ b/docs/rst/commands/odgi_build.rst
@@ -9,8 +9,7 @@ Construct a dynamic succinct variation graph in ODGI format from a GFAv1
 SYNOPSIS
 ========
 
-**odgi build** [**-g, --gfa**\ =\ *FILE*] [**-o, --out**\ =\ *FILE*]
-[*OPTION*]…
+**odgi build** [**-g, --gfa**\ =\ *FILE*] [**-o, --out**\ =\ *FILE*] [*OPTION*]…
 
 DESCRIPTION
 ===========

--- a/docs/rst/commands/odgi_stepindex.rst
+++ b/docs/rst/commands/odgi_stepindex.rst
@@ -1,0 +1,78 @@
+.. _odgi stepindex:
+
+#########
+odgi stepindex
+#########
+
+Generate a step index from a given graph. If no output file is provided via **-o, --out**, the index will be directly written to **INPUT_GRAPH.stpidx**.
+
+SYNOPSIS
+========
+
+**odgi stepindex** [**-i, --idx**\ =\ *FILE*] [**-o, --out**\ =\ *FILE*] [*OPTION*]…
+
+DESCRIPTION
+===========
+
+The odgi stepindex command generates a step index from a given graph. Such an index allows us to efficiently retrieve the nucleotide position of a given graph step.
+In order to save memory, a sampled step index is implemented here. We solve memory issues by only indexing every node with node identifier fitting **mod(node_id, step-index-sample-rate) == 0** in the graph.
+From a given step, we can find its position by walking backwards until a node fitting our sampling criteria is found. We can retrieve this position easily, adding up the walked distance to retrieve the actual position of the step.
+Effectively, the sample rate is only allowed to be a number by the power of 2, because we can use bit shift operations to calculate the modulo in O(1)! (`https://www.geeksforgeeks.org/compute-modulus-division-by-a-power-of-2-number/ <https://www.geeksforgeeks.org/compute-modulus-division-by-a-power-of-2-number/>`_).
+As `evaluated <https://docs.google.com/presentation/d/1a8bOnulta6fYnQ2DFmdzt4es2vaRGmgIxO3kCe-HXR8/edit#slide=id.p>`_, the default sample rate is 8, which represents a good compromise between performance and memory usage. For ultra large graphs with hundreds of gigabytes in size, a sample rate of 16 might suite better.
+
+As a bonus, the step index includes all the lengths of the paths, too. This allows us to efficiently get the length in nucleotides of a path by a given path handle.
+
+Current ODGI tools that work with a step index are :ref:`odgi untangle` and :ref:`odgi tips`.
+
+OPTIONS
+=======
+
+MANDATORY OPTIONS
+-----------------
+
+| **-i, --idx**\ =\ *FILE*
+| Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!
+
+| **-o, --out**\ =\ *FILE*
+| Write the created step index to the specified file. A file ending with *.stpidx* is recommended. (default: *INPUT_GRAPH.stpidx*).
+
+Step Index Options
+-------------
+
+| **-a, --step-index-sample-rate**\ =\ *N*
+| The sample rate when building the step index. We index a node only if **mod(node_id, step-index-sample-rate) == 0**! Number must be dividable by 2. (default: 8).
+
+Threading
+---------
+
+| **-t, --threads**\ =\ *N*
+| Number of threads to use for parallel operations.
+
+Processing Information
+----------------------
+
+| **-P, --progress**
+| Print information about the operations and the progress to stderr.
+
+Program Information
+-------------------
+
+| **-h, --help**
+| Print a help message for **odgi tips**.
+
+..
+	EXIT STATUS
+	===========
+
+	| **0**
+	| Success.
+
+	| **1**
+	| Failure (syntax or usage error; parameter error; file processing
+		failure; unexpected error).
+..
+	BUGS
+	====
+
+	Refer to the **odgi** issue tracker at
+	https://github.com/pangenome/odgi/issues.

--- a/docs/rst/commands/odgi_tips.rst
+++ b/docs/rst/commands/odgi_tips.rst
@@ -61,7 +61,13 @@ Tips Options
 | Maximum walking distance in nucleotides for one orientation when finding the best target (reference) range for each query path (default: 10000). Note: If we walked 9999 base pairs and **w, --jaccard-context** is **10000**, we will also include the next node, even if we overflow the actual limit.
 
 | **-j, --jaccards**
-| If for a target (reference) path several matches are possible, also report the additional jacard indices (default: false). In the resulting BED, an '.' is added, if set to 'false'.
+| If for a target (reference) path several matches are possible, also report the additional jaccard indices (default: false). In the resulting BED, an '.' is added, if set to 'false'.
+
+Step Index Options
+------------------
+
+| **-a, --step-index**\ =\ *FILE*
+| Load the step index from this *FILE*. The file name usually ends with *.stpidx*. (default: build the step index from scratch with a sampling rate of 8).
 
 Threading
 ---------

--- a/docs/rst/commands/odgi_untangle.rst
+++ b/docs/rst/commands/odgi_untangle.rst
@@ -48,15 +48,26 @@ Untangling Options
 | **-n, --n-best**\ =\ *N*
 | Report up to the *N*th best target (reference) mapping for each query segment (default: *1*).
 
-
 | **-j, --min-jaccard**\ =\ *N*
-| Report target mappings >= the given jaccard threshold, with 0 <= *N* <= 1.0 (default: *0.0*):
+| Report target mappings >= the given jaccard threshold, with 0 <= *N* <= 1.0 (default: *0.0*).
+
+| **-e, --cut-every**\ =\ *N*
+| Cut every *N* base pairs of the sorted graph (default: *0/OFF*).
+
+| **-p, --paf-output**
+| Emit the output in PAF format.
 
 Debugging Options
 -----------------
 
 | **-s, --self-dotplot**
 | Render a table showing the positional dotplot of the query against itself.
+
+Step Index Options
+------------------
+
+| **-a, --step-index**\ =\ *FILE*
+| Load the step index from this *FILE*. The file name usually ends with *.stpidx*. (default: build the step index from scratch with a sampling rate of 8).
 
 Threading
 ---------

--- a/scripts/test_binary.sh
+++ b/scripts/test_binary.sh
@@ -36,3 +36,12 @@ else
     exit 1
 fi
 
+echo "[binary_tester] INFO: Running binary tests of odgi untangle."
+bash "$SC"/untangle.sh "$OG" "$TEST"
+ret=$?
+if [[ $ret -eq 0 ]]; then
+    echo "[binary_tester] SUCCESS: All binary tests for odgi untangle passed."
+else
+    echo "[binary_tester] FAILED: At least one binary test for odgi untangle failed."
+    exit 1
+fi

--- a/scripts/untangle.sh
+++ b/scripts/untangle.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# path to the ODGI executable
+OG=$1
+# path to the ODGI test folder
+TEST=$2
+
+echo " [binary_tester::untangle] INFO: Testing with default settings."
+diff -u "$TEST"/binary/untangle/default <("$OG" untangle -i "$TEST"/overlap.gfa)
+ret=$?
+if [[ $ret -eq 0 ]]; then
+    echo " [binary_tester::untangle] SUCCESS: Testing with default settings."
+else
+    echo " [binary_tester::untangle] FAILED: Testing with default settings."
+    exit 1
+fi

--- a/src/algorithms/path_jaccard.hpp
+++ b/src/algorithms/path_jaccard.hpp
@@ -3,7 +3,6 @@
 #include "utils.hpp"
 #include "algorithms/stepindex.hpp"
 #include "algorithms/tips_bed_writer_thread.hpp"
-#include "algorithms/path_jaccard.hpp"
 #include "odgi.hpp"
 #include <omp.h>
 #include "hash_map.hpp"

--- a/src/algorithms/path_jaccard.hpp
+++ b/src/algorithms/path_jaccard.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "utils.hpp"
 #include "algorithms/stepindex.hpp"
 #include "algorithms/tips_bed_writer_thread.hpp"
-#include "odgi.hpp"
 #include <omp.h>
 #include "hash_map.hpp"
 

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -192,6 +192,9 @@ void step_index_t::load_sdsl(std::istream &in) {
 		throw std::runtime_error("[odgi::algorithms::stepindex] error: SDSL step index file does not have 'STEP' in its magic value. The file must be malformed.");
 	}
 
+	delete[] step_buffer;
+	delete[] index_buffer;
+
 	try {
 		pos.load(in);
 		path_len.load(in);

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -164,12 +164,13 @@ void step_index_t::load_sdsl(std::istream &in) {
 
 	// We need to look for the magic value(s)
 	char buffer;
-	char * step_buffer = new char [5];
-	char * index_buffer = new char [5];
+	char * step_buffer = new char [4];
+	char * index_buffer = new char [4];
 	std::string sample_rate = "";
 	std::string index = "";
+
 	in.read(step_buffer, 4);
-	std::string step = std::string(step_buffer);
+	std::string step(step_buffer, 4);
 	if (step == "STEP"){
 		// now we need collect all the characters which will form our sample rate
 		while(buffer != 'I') {
@@ -179,13 +180,18 @@ void step_index_t::load_sdsl(std::istream &in) {
 		this->sample_rate = std::stoi(sample_rate);
 		index += buffer;
 		in.read(index_buffer, 4);
-		index += index_buffer;
+		std::string index_buffer_string(index_buffer, 4);
+		index += index_buffer_string;
 		if (index != "INDEX") {
 			throw std::runtime_error("[odgi::algorithms::stepindex] error: SDSL step index file does not have 'INDEX' in its magic value. The file must be malformed.");
 		}
 	} else  {
 		throw std::runtime_error("[odgi::algorithms::stepindex] error: SDSL step index file does not have 'STEP' in its magic value. The file must be malformed.");
 	}
+
+
+	delete[] step_buffer;
+	delete[] index_buffer;
 
 	try {
 		pos.load(in);

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -164,8 +164,8 @@ void step_index_t::load_sdsl(std::istream &in) {
 
 	// We need to look for the magic value(s)
 	char buffer;
-	char * step_buffer = new char [4];
-	char * index_buffer = new char [4];
+	char * step_buffer = new char [5];
+	char * index_buffer = new char [5];
 	std::string sample_rate = "";
 	std::string index = "";
 	in.read(step_buffer, 4);

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -1,5 +1,4 @@
 #include "stepindex.hpp"
-#include "progress.hpp"
 
 namespace odgi {
 namespace algorithms {
@@ -44,6 +43,25 @@ step_index_t::step_index_t(const PathHandleGraph& graph,
     ips4o::parallel::sort(steps.begin(), steps.end(), std::less<>(), nthreads);
     // build the hash function (quietly)
     step_mphf = new boophf_step_t(steps.size(), steps, nthreads, 2.0, false, false);
+	/*
+	steps.resize(1);
+	step_mphf = new boophf_step_t(steps.size(), steps, nthreads, 2.0, false, false);
+	std::ofstream outfile ("new.txt");
+	step_mphf->save(outfile);
+	outfile << std::endl;
+	step_mphf->save(outfile);
+	std::string line;
+	std::ifstream infile ("new.txt");
+	while (std::getline(infile, line)) {
+		std::cout << line << std::endl;
+	}
+	std::getline(infile, line);
+	std::istringstream is1(line);
+	step_mphf->load(is1);
+	std::getline(infile, line);
+	std::istringstream is2(line);
+	step_mphf->load(is2);
+*/
     // use the hash function to record the step positions
     pos.resize(steps.size());
 	std::unique_ptr<algorithms::progress_meter::ProgressMeter> building_progress_meter;

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -1,4 +1,5 @@
 #include "stepindex.hpp"
+#include "progress.hpp"
 
 namespace odgi {
 namespace algorithms {

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -8,6 +8,8 @@ step_index_t::step_index_t() {
 	step_mphf = new boophf_step_t();
 }
 
+
+
 step_index_t::step_index_t(const PathHandleGraph& graph,
                            const std::vector<path_handle_t>& paths,
                            const uint64_t& nthreads,
@@ -170,6 +172,7 @@ void step_index_t::load_sdsl(std::istream &in) {
 	std::string index = "";
 
 	in.read(step_buffer, 4);
+	// https://stackoverflow.com/questions/1195675/convert-a-char-to-stdstring/1195705#1195705
 	std::string step(step_buffer, 4);
 	if (step == "STEP"){
 		// now we need collect all the characters which will form our sample rate
@@ -188,10 +191,6 @@ void step_index_t::load_sdsl(std::istream &in) {
 	} else  {
 		throw std::runtime_error("[odgi::algorithms::stepindex] error: SDSL step index file does not have 'STEP' in its magic value. The file must be malformed.");
 	}
-
-
-	delete[] step_buffer;
-	delete[] index_buffer;
 
 	try {
 		pos.load(in);

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -115,19 +115,16 @@ const uint64_t step_index_t::get_path_len(const path_handle_t& path) const {
 	return path_len[as_integer(path) - 1];
 }
 
-void step_index_t::save(const std::string& prefix) const {
-	std::ofstream stpidx_mphf_out(prefix + "_stpidx.mphf");
-	step_mphf->save(stpidx_mphf_out);
-
-	std::ofstream sdsl_out(prefix + ".sdsl");
-	serialize_members(sdsl_out);
+void step_index_t::save(const std::string& name) const {
+	std::ofstream stpidx_out(name);
+	serialize_members(stpidx_out);
+	step_mphf->save(stpidx_out);
 }
 
-void step_index_t::load(const std::string& prefix) {
-	std::ifstream stpidx_mphf_in(prefix + "_stpidx.mphf");
-	step_mphf->load(stpidx_mphf_in);
-	std::ifstream sdsl_in(prefix + ".sdsl");
-	deserialize_members(sdsl_in);
+void step_index_t::load(const std::string& name) {
+	std::ifstream stpidx_in(name);
+	deserialize_members(stpidx_in);
+	step_mphf->load(stpidx_in);
 }
 
 void step_index_t::serialize_members(std::ostream &out) const {

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -54,11 +54,13 @@ struct step_index_t {
 				 const uint64_t& sample_rate);
     ~step_index_t(void);
     const uint64_t get_position(const step_handle_t& step, const PathHandleGraph& graph) const;
+	const uint64_t get_path_len(const path_handle_t& path) const;
 	void save(const std::string& prefix) const;
 	void load(const std::string& prefix);
     // map from step to position in its path
     boophf_step_t* step_mphf = nullptr;
 	sdsl::int_vector<64> pos;
+	sdsl::int_vector<64> path_len;
 	uint64_t sample_rate;
 private:
 	/// the assumptions is that the magic number will be STEPsampling_rateINDEX, where the sampling rate encodes the actual

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -55,8 +55,8 @@ struct step_index_t {
     ~step_index_t(void);
     const uint64_t get_position(const step_handle_t& step, const PathHandleGraph& graph) const;
 	const uint64_t get_path_len(const path_handle_t& path) const;
-	void save(const std::string& prefix) const;
-	void load(const std::string& prefix);
+	void save(const std::string& name) const;
+	void load(const std::string& name);
     // map from step to position in its path
     boophf_step_t* step_mphf = nullptr;
 	sdsl::int_vector<64> pos;

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+// FIXME including this breaks the compilation
+#include <sdsl/enc_vector.hpp>
+// FIXME including this breaks the compilation
+
 #include <iostream>
 #include <vector>
-#include <handlegraph/types.hpp>
-#include <handlegraph/util.hpp>
-#include <handlegraph/path_handle_graph.hpp>
 #include "ips4o.hpp"
 #include "BooPHF.h"
 #include "utils.hpp"
@@ -54,6 +55,7 @@ struct step_index_t {
     const uint64_t get_position(const step_handle_t& step, const PathHandleGraph& graph) const;
     // map from step to position in its path
     boophf_step_t* step_mphf = nullptr;
+	// sdsl::int_vector<> alternative_pos;
     std::vector<uint64_t> pos;
 	uint64_t sample_rate;
 };

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -49,9 +49,9 @@ struct step_index_t {
                  const std::vector<path_handle_t>& paths,
                  const uint64_t& nthreads,
                  const bool progress,
-				 const uint64_t sample_rate);
+				 const uint64_t& sample_rate);
     ~step_index_t(void);
-    const uint64_t& get_position(const step_handle_t& step, const PathHandleGraph& graph) const;
+    const uint64_t get_position(const step_handle_t& step, const PathHandleGraph& graph) const;
     // map from step to position in its path
     boophf_step_t* step_mphf = nullptr;
     std::vector<uint64_t> pos;

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -7,6 +7,7 @@
 #include <handlegraph/path_handle_graph.hpp>
 #include "ips4o.hpp"
 #include "BooPHF.h"
+#include "utils.hpp"
 
 namespace odgi {
 
@@ -47,12 +48,14 @@ struct step_index_t {
     step_index_t(const PathHandleGraph& graph,
                  const std::vector<path_handle_t>& paths,
                  const uint64_t& nthreads,
-                 const bool progress);
+                 const bool progress,
+				 const uint64_t sample_rate);
     ~step_index_t(void);
-    const uint64_t& get_position(const step_handle_t& step) const;
+    const uint64_t& get_position(const step_handle_t& step, const PathHandleGraph& graph) const;
     // map from step to position in its path
     boophf_step_t* step_mphf = nullptr;
     std::vector<uint64_t> pos;
+	uint64_t sample_rate;
 };
 
 // index of a single path's steps designed for efficient iteration

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -6,6 +6,9 @@
 
 #include <iostream>
 #include <vector>
+#include <handlegraph/types.hpp>
+#include <handlegraph/util.hpp>
+#include <handlegraph/path_handle_graph.hpp>
 #include "ips4o.hpp"
 #include "BooPHF.h"
 #include "utils.hpp"

--- a/src/algorithms/stepindex.hpp
+++ b/src/algorithms/stepindex.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-// FIXME including this breaks the compilation
 #include <sdsl/enc_vector.hpp>
-// FIXME including this breaks the compilation
-
 #include <iostream>
 #include <vector>
 #include <handlegraph/types.hpp>
@@ -49,6 +46,7 @@ typedef boomphf::mphf<step_handle_t, step_handle_hasher_t> boophf_step_t;
 typedef boomphf::mphf<uint64_t, boomphf::SingleHashFunctor<uint64_t>> boophf_uint64_t;
 
 struct step_index_t {
+	step_index_t();
     step_index_t(const PathHandleGraph& graph,
                  const std::vector<path_handle_t>& paths,
                  const uint64_t& nthreads,
@@ -56,11 +54,28 @@ struct step_index_t {
 				 const uint64_t& sample_rate);
     ~step_index_t(void);
     const uint64_t get_position(const step_handle_t& step, const PathHandleGraph& graph) const;
+	void save(const std::string& prefix) const;
+	void load(const std::string& prefix);
     // map from step to position in its path
     boophf_step_t* step_mphf = nullptr;
-	// sdsl::int_vector<> alternative_pos;
-    std::vector<uint64_t> pos;
+	sdsl::int_vector<64> pos;
 	uint64_t sample_rate;
+private:
+	/// the assumptions is that the magic number will be STEPsampling_rateINDEX, where the sampling rate encodes the actual
+	/// sampling rate of the index
+
+	/// Write the sdsl integer vectors of the step index to a stream.
+	size_t serialize_and_measure(std::ostream &out, sdsl::structure_tree_node *s = nullptr, std::string name = "") const;
+
+	/// Alias for serialize_and_measure().
+	void serialize_members(std::ostream &out) const;
+
+	/// Load the sdsl integer vectors of a step index from a stream. Throw an Error if the stream
+	/// does not produce a valid step index file.
+	void load_sdsl(std::istream &in);
+
+	/// Alias for load().
+	void deserialize_members(std::istream &in);
 };
 
 // index of a single path's steps designed for efficient iteration

--- a/src/algorithms/tips.cpp
+++ b/src/algorithms/tips.cpp
@@ -89,12 +89,12 @@ namespace odgi {
 							step_handle_t final_target_step = target_jaccard_index.step;
 							double final_target_jaccard = target_jaccard_index.jaccard;
 
-							uint64_t target_min_pos = step_index.get_position(final_target_step); // 0-based starting position in BED
-							uint64_t target_max_pos = step_index.get_position(final_target_step) + graph.get_length(graph.get_handle_of_step(final_target_step)); // 1-based ending position in BED
+							uint64_t target_min_pos = step_index.get_position(final_target_step, graph); // 0-based starting position in BED
+							uint64_t target_max_pos = target_min_pos + graph.get_length(graph.get_handle_of_step(final_target_step)); // 1-based ending position in BED
 
 							/// add BED record to queue of the BED writer
 							bed_writer_thread.append(target_path, target_min_pos, target_max_pos,
-													 query_path_name, step_index.get_position(cur_step),
+													 query_path_name, step_index.get_position(cur_step, graph),
 													 final_target_jaccard, walk_from_front, additional_jaccards_to_report);
 							i++;
 						}

--- a/src/algorithms/tips.hpp
+++ b/src/algorithms/tips.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "utils.hpp"
 #include "algorithms/stepindex.hpp"
 #include "algorithms/tips_bed_writer_thread.hpp"
 #include "algorithms/path_jaccard.hpp"

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -585,7 +585,8 @@ void untangle(
                 paths.end());
     //std::cerr << "[odgi::algorithms::untangle] building step index" << std::endl;
     //auto step_pos = make_step_index(graph, paths, num_threads);
-    step_index_t step_index(graph, paths, num_threads, progress);
+	// FIXME add the right number here later
+    step_index_t step_index(graph, paths, num_threads, progress, 8);
 
     // which nodes are traversed by our target paths?
     atomicbitvector::atomic_bv_t target_nodes(graph.get_node_count() + 1);

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -574,23 +574,12 @@ void untangle(
     const bool& paf_output,
     const size_t& num_threads,
     const bool& progress,
-	const uint64_t& step_index_sample_rate) {
+	const step_index_t& step_index,
+	const std::vector<path_handle_t>& paths) {
 
     if (progress) {
         std::cerr << "[odgi::algorithms::untangle] untangling " << queries.size() << " queries with " << targets.size() << " targets" << std::endl;
     }
-
-    std::vector<path_handle_t> paths;
-    paths.insert(paths.end(), queries.begin(), queries.end());
-    paths.insert(paths.end(), targets.begin(), targets.end());
-    std::sort(paths.begin(), paths.end());
-    paths.erase(std::unique(paths.begin(), paths.end()),
-                paths.end());
-    //std::cerr << "[odgi::algorithms::untangle] building step index" << std::endl;
-    //auto step_pos = make_step_index(graph, paths, num_threads);
-	// FIXME add the right number here later
-
-    step_index_t step_index(graph, paths, num_threads, progress, step_index_sample_rate);
 
     // which nodes are traversed by our target paths?
     atomicbitvector::atomic_bv_t target_nodes(graph.get_node_count() + 1);

--- a/src/algorithms/untangle.hpp
+++ b/src/algorithms/untangle.hpp
@@ -64,7 +64,8 @@ std::vector<step_handle_t> untangle_cuts(
 std::vector<step_handle_t> merge_cuts(
     const std::vector<step_handle_t>& cuts,
     const uint64_t& dist,
-    const step_index_t& step_index);
+    const step_index_t& step_index,
+	const PathHandleGraph& graph);
 
 void write_cuts(
     const PathHandleGraph& graph,
@@ -111,7 +112,8 @@ void untangle(
     const double& min_jaccard,
     const bool& paf_output,
     const size_t& num_threads,
-	const bool& progress);
+	const bool& progress,
+	const uint64_t& step_index_sample_rate);
 
 }
 }

--- a/src/algorithms/untangle.hpp
+++ b/src/algorithms/untangle.hpp
@@ -113,7 +113,8 @@ void untangle(
     const bool& paf_output,
     const size_t& num_threads,
 	const bool& progress,
-	const uint64_t& step_index_sample_rate);
+	const step_index_t& step_index,
+	const std::vector<path_handle_t>& paths);
 
 }
 }

--- a/src/subcommand/stepindex_main.cpp
+++ b/src/subcommand/stepindex_main.cpp
@@ -125,11 +125,15 @@ namespace odgi {
 			progress_meter = std::make_unique<algorithms::progress_meter::ProgressMeter>(paths.size()*iterations, "[odgi::stepindex::position_fetching] Progress:");
 		}
 
+		step_index.save("overlap_test_step_index");
+		algorithms::step_index_t step_index_1;
+		step_index_1.load("overlap_test_step_index");
+
 		for (int i = 0; i < iterations; i++) {
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
 			for (auto path: paths) {
 				graph.for_each_step_in_path(path, [&](const step_handle_t &step) {
-					std::cout << step_index.get_position(step, graph) << std::endl;
+					std::cout << step_index_1.get_position(step, graph) << std::endl;
 				});
 				if (progress) {
 					progress_meter->increment(1);

--- a/src/subcommand/stepindex_main.cpp
+++ b/src/subcommand/stepindex_main.cpp
@@ -20,15 +20,14 @@ namespace odgi {
 		--argc;
 
 		args::ArgumentParser parser(
-				"Generate a step index and access the position of each step of each path once. Prints the run time of each the index generation and the position fetching to stdout.");
+				"Generate a step index from a given graph. If no output file is provided via *-o, --out*, the index will be directly written to *INPUT_GRAPH.stpidx*.");
 		args::Group mandatory_opts(parser, "[ MANDATORY OPTIONS ]");
 		args::ValueFlag<std::string> og_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "input"});
 		args::Group step_index_opts(parser, "[ Step Index Options ]");
 		args::ValueFlag<uint64_t> _step_index_sample_rate(step_index_opts, "N", "The sample rate when building the step index. We index a node only if mod(node_id, step-index-sample-rate) == 0! Number must be dividable by 2. (default: 8).",
 														  {'a', "step-index-sample-rate"});
-		args::Flag naked_run(step_index_opts, "naked-run", "Only read in the given graph and then exit gracefully", {'n', "naked-run"});
-		args::ValueFlag<uint64_t> _iterations(step_index_opts, "N", "The number of position fetching rounds. For each path step a position is fetched N times. (default: 10).",
-														  {'b', "iterations"});
+		args::ValueFlag<std::string> dg_out_file(mandatory_opts, "FILE", "Write the created step index to the specified file. A file"
+																		 " ending with *.stpidx* is recommended. (default: *INPUT_GRAPH.stpidx*).", {'o', "out"});
 		args::Group threading(parser, "[ Threading ]");
 		args::ValueFlag<uint64_t> nthreads(threading, "N", "Number of threads to use for parallel operations.", {'t', "threads"});
 		args::Group processing_info_opts(parser, "[ Processing Information ]");
@@ -63,7 +62,7 @@ namespace odgi {
 			exit(1);
 		}
 
-		uint64_t iterations = args::get(_iterations) ? args::get(_iterations) : 10;
+		std::string step_index_out_file = dg_out_file ? args::get(dg_out_file) : (args::get(og_file) + ".stpidx");
 
 		const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
 
@@ -78,11 +77,8 @@ namespace odgi {
 			}
 		}
 
-		if (naked_run) {
-			exit(0);
-		}
-
 		omp_set_num_threads(num_threads);
+
 
 		std::vector<path_handle_t> paths;
 		paths.reserve(graph.get_path_count());
@@ -90,63 +86,8 @@ namespace odgi {
 			paths.push_back(path);
 		});
 
-		auto distribute_seconds = [&](int& days, int& hours, int& minutes, int& seconds, const double& input_seconds) {
-			const int cseconds_in_day = 86400;
-			const int cseconds_in_hour = 3600;
-			const int cseconds_in_minute = 60;
-			const int cseconds = 1;
-			days = std::floor(input_seconds / cseconds_in_day);
-			hours = std::floor(((int)input_seconds % cseconds_in_day) / cseconds_in_hour);
-			minutes = std::floor((((int)input_seconds % cseconds_in_day) % cseconds_in_hour) / cseconds_in_minute);
-			seconds = ((((int)input_seconds % cseconds_in_day) % cseconds_in_hour) % cseconds_in_minute) / cseconds;
-		};
-
-		auto print_time = [&](const double& _seconds) {
-			int days = 0, hours = 0, minutes = 0, seconds = 0;
-			distribute_seconds(days, hours, minutes, seconds, _seconds);
-			std::stringstream buffer;
-			buffer << std::setfill('0') << std::setw(2) << days << ":"
-				   << std::setfill('0') << std::setw(2) << hours << ":"
-				   << std::setfill('0') << std::setw(2) << minutes << ":"
-				   << std::setfill('0') << std::setw(2) << seconds;
-			return buffer.str();
-		};
-
-		std::chrono::time_point<std::chrono::steady_clock> start_time_index_building = std::chrono::steady_clock::now();
 		algorithms::step_index_t step_index(graph, paths, num_threads, progress, step_index_sample_rate);
-		auto cur_time_index_building = std::chrono::steady_clock::now();
-		std::chrono::duration<double> elapsed_seconds_index_building = cur_time_index_building-start_time_index_building;
-		std::cout << "[odgi::stepindex] info: Building step index elapsed time: " << print_time(elapsed_seconds_index_building.count()) << std::endl;
-
-		std::chrono::time_point<std::chrono::steady_clock> start_time_position_fetching = std::chrono::steady_clock::now();
-
-		std::unique_ptr<algorithms::progress_meter::ProgressMeter> progress_meter;
-		if (progress) {
-			progress_meter = std::make_unique<algorithms::progress_meter::ProgressMeter>(paths.size()*iterations, "[odgi::stepindex::position_fetching] Progress:");
-		}
-
-		step_index.save("overlap_test_step_index");
-		algorithms::step_index_t step_index_1;
-		step_index_1.load("overlap_test_step_index");
-
-		for (int i = 0; i < iterations; i++) {
-#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
-			for (auto path: paths) {
-				std::cout << graph.get_path_name(path) << ": " << step_index_1.get_path_len(path) << std::endl;
-				graph.for_each_step_in_path(path, [&](const step_handle_t &step) {
-					std::cout << step_index_1.get_position(step, graph) << std::endl;
-				});
-				if (progress) {
-					progress_meter->increment(1);
-				}
-			}
-		}
-		if (progress) {
-			progress_meter->finish();
-		}
-		auto cur_time_position_fetching = std::chrono::steady_clock::now();
-		std::chrono::duration<double> elapsed_seconds_position_fetching = cur_time_position_fetching-start_time_position_fetching;
-		std::cout << "[odgi::stepindex] info: Position fetching elapsed time: " << print_time(elapsed_seconds_position_fetching.count()) << std::endl;
+		step_index.save(step_index_out_file);
 
 		return 0;
 	}

--- a/src/subcommand/stepindex_main.cpp
+++ b/src/subcommand/stepindex_main.cpp
@@ -132,6 +132,7 @@ namespace odgi {
 		for (int i = 0; i < iterations; i++) {
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
 			for (auto path: paths) {
+				std::cout << graph.get_path_name(path) << ": " << step_index_1.get_path_len(path) << std::endl;
 				graph.for_each_step_in_path(path, [&](const step_handle_t &step) {
 					std::cout << step_index_1.get_position(step, graph) << std::endl;
 				});

--- a/src/subcommand/stepindex_main.cpp
+++ b/src/subcommand/stepindex_main.cpp
@@ -129,7 +129,7 @@ namespace odgi {
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
 			for (auto path: paths) {
 				graph.for_each_step_in_path(path, [&](const step_handle_t &step) {
-					step_index.get_position(step, graph);
+					std::cout << step_index.get_position(step, graph) << std::endl;
 				});
 				if (progress) {
 					progress_meter->increment(1);

--- a/src/subcommand/stepindex_main.cpp
+++ b/src/subcommand/stepindex_main.cpp
@@ -1,0 +1,149 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include <omp.h>
+#include "algorithms/stepindex.hpp"
+#include "algorithms/progress.hpp"
+
+namespace odgi {
+
+	using namespace odgi::subcommand;
+
+	int main_stepindex(int argc, char **argv) {
+
+		// trick argumentparser to do the right thing with the subcommand
+		for (uint64_t i = 1; i < argc - 1; ++i) {
+			argv[i] = argv[i + 1];
+		}
+		std::string prog_name = "odgi stepindex";
+		argv[0] = (char *) prog_name.c_str();
+		--argc;
+
+		args::ArgumentParser parser(
+				"Generate a step index and access the position of each step of each path once. Prints the run time of each the index generation and the position fetching to stdout.");
+		args::Group mandatory_opts(parser, "[ MANDATORY OPTIONS ]");
+		args::ValueFlag<std::string> og_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "input"});
+		args::Group step_index_opts(parser, "[ Step Index Options ]");
+		args::ValueFlag<uint64_t> _step_index_sample_rate(step_index_opts, "N", "The sample rate when building the step index. We index a node only if mod(node_id, step-index-sample-rate) == 0! Number must be dividable by 2. (default: 8).",
+														  {'a', "step-index-sample-rate"});
+		args::Flag naked_run(step_index_opts, "naked-run", "Only read in the given graph and then exit gracefully", {'n', "naked-run"});
+		args::Group threading(parser, "[ Threading ]");
+		args::ValueFlag<uint64_t> nthreads(threading, "N", "Number of threads to use for parallel operations.", {'t', "threads"});
+		args::Group processing_info_opts(parser, "[ Processing Information ]");
+		args::Flag progress(processing_info_opts, "progress", "Write the current progress to stderr.", {'P', "progress"});
+		args::Group program_information(parser, "[ Program Information ]");
+		args::HelpFlag help(program_information, "help", "Print a help message for odgi validate.", {'h', "help"});
+
+		try {
+			parser.ParseCLI(argc, argv);
+		} catch (args::Help) {
+			std::cout << parser;
+			return 0;
+		} catch (args::ParseError e) {
+			std::cerr << e.what() << std::endl;
+			std::cerr << parser;
+			return 1;
+		}
+		if (argc == 1) {
+			std::cout << parser;
+			return 1;
+		}
+
+		if (!og_file) {
+			std::cerr << "[odgi::stepindex] error: please specify a graph to index via -i=[FILE], --idx=[FILE]."
+					  << std::endl;
+			return 1;
+		}
+
+		uint64_t  step_index_sample_rate = args::get(_step_index_sample_rate) ? args::get(_step_index_sample_rate) : 8;
+		if (step_index_sample_rate % 2 != 0) {
+			std::cerr << "[odgi::stepindex] error: The given sample rate of " << step_index_sample_rate << " is not dividable by 2. Please provide a different sample rate." << std::endl;
+			exit(1);
+		}
+
+		const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+
+		odgi::graph_t graph;
+		assert(argc > 0);
+		std::string infile = args::get(og_file);
+		if (!infile.empty()) {
+			if (infile == "-") {
+				graph.deserialize(std::cin);
+			} else {
+				utils::handle_gfa_odgi_input(infile, "stepindex", args::get(progress), num_threads, graph);
+			}
+		}
+
+		if (naked_run) {
+			exit(0);
+		}
+
+		omp_set_num_threads(num_threads);
+
+		std::vector<path_handle_t> paths;
+		paths.reserve(graph.get_path_count());
+		graph.for_each_path_handle([&](const path_handle_t &path) {
+			paths.push_back(path);
+		});
+
+		auto distribute_seconds = [&](int& days, int& hours, int& minutes, int& seconds, const double& input_seconds) {
+			const int cseconds_in_day = 86400;
+			const int cseconds_in_hour = 3600;
+			const int cseconds_in_minute = 60;
+			const int cseconds = 1;
+			days = std::floor(input_seconds / cseconds_in_day);
+			hours = std::floor(((int)input_seconds % cseconds_in_day) / cseconds_in_hour);
+			minutes = std::floor((((int)input_seconds % cseconds_in_day) % cseconds_in_hour) / cseconds_in_minute);
+			seconds = ((((int)input_seconds % cseconds_in_day) % cseconds_in_hour) % cseconds_in_minute) / cseconds;
+		};
+
+		auto print_time = [&](const double& _seconds) {
+			int days = 0, hours = 0, minutes = 0, seconds = 0;
+			distribute_seconds(days, hours, minutes, seconds, _seconds);
+			std::stringstream buffer;
+			buffer << std::setfill('0') << std::setw(2) << days << ":"
+				   << std::setfill('0') << std::setw(2) << hours << ":"
+				   << std::setfill('0') << std::setw(2) << minutes << ":"
+				   << std::setfill('0') << std::setw(2) << seconds;
+			return buffer.str();
+		};
+
+		std::chrono::time_point<std::chrono::steady_clock> start_time_index_building = std::chrono::steady_clock::now();
+		algorithms::step_index_t step_index(graph, paths, num_threads, progress, step_index_sample_rate);
+		auto cur_time_index_building = std::chrono::steady_clock::now();
+		std::chrono::duration<double> elapsed_seconds_index_building = cur_time_index_building-start_time_index_building;
+		std::cout << "[odgi::stepindex] info: Building step index elapsed time: " << print_time(elapsed_seconds_index_building.count()) << std::endl;
+
+		std::chrono::time_point<std::chrono::steady_clock> start_time_position_fetching = std::chrono::steady_clock::now();
+
+		std::unique_ptr<algorithms::progress_meter::ProgressMeter> progress_meter;
+		if (progress) {
+			progress_meter = std::make_unique<algorithms::progress_meter::ProgressMeter>(paths.size()*10, "[odgi::stepindex::position_fetching] Progress:");
+		}
+
+		for (int i = 0; i < 10; i++) {
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
+			for (auto path: paths) {
+				graph.for_each_step_in_path(path, [&](const step_handle_t &step) {
+					step_index.get_position(step, graph);
+				});
+				if (progress) {
+					progress_meter->increment(1);
+				}
+			}
+		}
+		if (progress) {
+			progress_meter->finish();
+		}
+		auto cur_time_position_fetching = std::chrono::steady_clock::now();
+		std::chrono::duration<double> elapsed_seconds_position_fetching = cur_time_position_fetching-start_time_position_fetching;
+		std::cout << "[odgi::stepindex] info: Position fetching elapsed time: " << print_time(elapsed_seconds_position_fetching.count()) << std::endl;
+
+		return 0;
+	}
+
+	static Subcommand odgi_stepindex("stepindex",
+									"Generate a step index and access the position of each step of each path once. Prints the run time of each the index generation and the position fetching to stdout.",
+									PIPELINE, 3, main_stepindex);
+
+}

--- a/src/subcommand/tips_main.cpp
+++ b/src/subcommand/tips_main.cpp
@@ -165,7 +165,8 @@ namespace odgi {
 		graph.for_each_path_handle([&](const path_handle_t &path) {
 			paths.push_back(path);
 		});
-		algorithms::step_index_t step_index(graph, paths, num_threads, progress);
+		// FIXME add the right number here later
+		algorithms::step_index_t step_index(graph, paths, num_threads, progress, 2);
 		// open the bed writer thread
 		algorithms::tips_bed_writer bed_writer_thread;
 		bed_writer_thread.open_writer();

--- a/src/subcommand/tips_main.cpp
+++ b/src/subcommand/tips_main.cpp
@@ -2,7 +2,6 @@
 #include "odgi.hpp"
 #include "args.hxx"
 #include <omp.h>
-#include "utils.hpp"
 #include "algorithms/stepindex.hpp"
 #include "algorithms/tips.hpp"
 #include "algorithms/tips_bed_writer_thread.hpp"

--- a/src/subcommand/tips_main.cpp
+++ b/src/subcommand/tips_main.cpp
@@ -43,8 +43,8 @@ namespace odgi {
 												   {'w', "jaccard-context"});
 		args::Flag _report_additional_jaccards(tips_opts, "report_additional_jaccards", "If for a target (reference) path several matches are possible, also report the additional jaccard indices (default: false). In the resulting BED, an '.' is added, if set to 'false'.", {'j', "jaccards"});
 		args::Group step_index_opts(parser, "[ Step Index Options ]");
-		args::ValueFlag<uint64_t> _step_index_sample_rate(step_index_opts, "N", "The sample rate when building the step index. We index a node only if mod(node_id, step-index-sample-rate) == 0! Number must be dividable by 2. (default: 8).",
-												{'a', "step-index-sample-rate"});
+		args::ValueFlag<std::string> _step_index(step_index_opts, "FILE", "Load the step index from this *FILE*. The file name usually ends with *.stpidx*. (default: build the step index from scratch with a sampling rate of 8).",
+												{'a', "step-index"});
 		args::Group threading(parser, "[ Threading ]");
 		args::ValueFlag<uint64_t> nthreads(threading, "N", "Number of threads to use for parallel operations.", {'t', "threads"});
 		args::Group processing_info_opts(parser, "[ Processing Information ]");
@@ -74,12 +74,6 @@ namespace odgi {
 		}
 
 		const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
-		// if the sample rate is not dividable by 2, the algorithm will not work
-		uint64_t  step_index_sample_rate = args::get(_step_index_sample_rate) ? args::get(_step_index_sample_rate) : 8;
-		if (step_index_sample_rate % 2 != 0) {
-				std::cerr << "[odgi::tips] error: The given sample rate of " << step_index_sample_rate << " is not dividable by 2. Please provide a different sample rate." << std::endl;
-				exit(1);
-		}
 
 		odgi::graph_t graph;
 		assert(argc > 0);
@@ -173,8 +167,7 @@ namespace odgi {
 		graph.for_each_path_handle([&](const path_handle_t &path) {
 			paths.push_back(path);
 		});
-		// FIXME add the right number here later
-		algorithms::step_index_t step_index(graph, paths, num_threads, progress, step_index_sample_rate);
+
 		// open the bed writer thread
 		algorithms::tips_bed_writer bed_writer_thread;
 		bed_writer_thread.open_writer();
@@ -202,43 +195,97 @@ namespace odgi {
 			return graph.has_previous_step(step);
 		};
 
-		for (auto target_path_t : target_paths) {
-			// make bit vector across nodes to tell us if we have a hit
-			// this is a speed up compared to iterating through all steps of a potential node for each walked step
-			std::vector<bool> target_handles;
-			target_handles.resize(graph.get_node_count(), false);
-			graph.for_each_step_in_path(target_path_t, [&](const step_handle_t &step) {
-				handle_t h = graph.get_handle_of_step(step);
-				target_handles[number_bool_packing::unpack_number(h)] = true;
-			});
-			ska::flat_hash_set<std::string> not_visited_set;
-			/// walk from the front
-			algorithms::walk_tips(graph, query_paths, target_path_t, target_handles, step_index, num_threads, get_path_begin,
-								  get_next_step, has_next_step, bed_writer_thread, progress, true, not_visited_set,
-								  (_best_n_mappings ? args::get(_best_n_mappings) : 1),
-								  (_walking_dist ? args::get(_walking_dist) : 10000),
-								  (_report_additional_jaccards ? args::get(_report_additional_jaccards) : false));
-			std::vector<path_handle_t> visitable_query_paths;
-			for (auto query_path : query_paths) {
-				if (!not_visited_set.count(graph.get_path_name(query_path))) {
-					visitable_query_paths.push_back(query_path);
+		if (!_step_index) {
+			if (progress) {
+				std::cerr << "[odgi::tips] warning: no step index specified. Building one with a sample rate of 8. This may take additional time. "
+							 "A step index cstep_indexan be provided via -a, --step-index. A step index can be built using odgi stepindex." << std::endl;
+			}
+			algorithms::step_index_t step_index(graph, paths, num_threads, progress, 8);
+			for (auto target_path_t: target_paths) {
+				// make bit vector across nodes to tell us if we have a hit
+				// this is a speed up compared to iterating through all steps of a potential node for each walked step
+				std::vector<bool> target_handles;
+				target_handles.resize(graph.get_node_count(), false);
+				graph.for_each_step_in_path(target_path_t, [&](const step_handle_t &step) {
+					handle_t h = graph.get_handle_of_step(step);
+					target_handles[number_bool_packing::unpack_number(h)] = true;
+				});
+				ska::flat_hash_set<std::string> not_visited_set;
+				/// walk from the front
+				algorithms::walk_tips(graph, query_paths, target_path_t, target_handles, step_index, num_threads,
+									  get_path_begin,
+									  get_next_step, has_next_step, bed_writer_thread, progress, true, not_visited_set,
+									  (_best_n_mappings ? args::get(_best_n_mappings) : 1),
+									  (_walking_dist ? args::get(_walking_dist) : 10000),
+									  (_report_additional_jaccards ? args::get(_report_additional_jaccards) : false));
+				std::vector<path_handle_t> visitable_query_paths;
+				for (auto query_path: query_paths) {
+					if (!not_visited_set.count(graph.get_path_name(query_path))) {
+						visitable_query_paths.push_back(query_path);
+					}
+				}
+				/// walk from the back
+				algorithms::walk_tips(graph, visitable_query_paths, target_path_t, target_handles, step_index,
+									  num_threads, get_path_back,
+									  get_prev_step, has_previous_step, bed_writer_thread, progress, false,
+									  not_visited_set,
+									  (_best_n_mappings ? args::get(_best_n_mappings) : 1),
+									  (_walking_dist ? args::get(_walking_dist) : 10000),
+									  (_report_additional_jaccards ? args::get(_report_additional_jaccards) : false));
+				/// let's write our paths we did not visit
+				std::string query_path = graph.get_path_name(target_path_t);
+				for (auto not_visited_path: not_visited_set) {
+					not_visited_out << query_path << "\t" << not_visited_path << std::endl;
 				}
 			}
-			/// walk from the back
-			algorithms::walk_tips(graph, visitable_query_paths, target_path_t, target_handles, step_index, num_threads, get_path_back,
-								  get_prev_step, has_previous_step, bed_writer_thread, progress, false, not_visited_set,
-								  (_best_n_mappings ? args::get(_best_n_mappings) : 1),
-								  (_walking_dist ? args::get(_walking_dist) : 10000),
-								  (_report_additional_jaccards ? args::get(_report_additional_jaccards) : false));
-			/// let's write our paths we did not visit
-			std::string query_path = graph.get_path_name(target_path_t);
-			for (auto not_visited_path : not_visited_set) {
-				not_visited_out << query_path << "\t" << not_visited_path << std::endl;
+			bed_writer_thread.close_writer();
+			if (_not_visited_tsv) {
+				not_visited_out.close();
 			}
-		}
-		bed_writer_thread.close_writer();
-		if (_not_visited_tsv) {
-			not_visited_out.close();
+		} else {
+			algorithms::step_index_t step_index;
+			step_index.load(args::get(_step_index));
+			for (auto target_path_t: target_paths) {
+				// make bit vector across nodes to tell us if we have a hit
+				// this is a speed up compared to iterating through all steps of a potential node for each walked step
+				std::vector<bool> target_handles;
+				target_handles.resize(graph.get_node_count(), false);
+				graph.for_each_step_in_path(target_path_t, [&](const step_handle_t &step) {
+					handle_t h = graph.get_handle_of_step(step);
+					target_handles[number_bool_packing::unpack_number(h)] = true;
+				});
+				ska::flat_hash_set<std::string> not_visited_set;
+				/// walk from the front
+				algorithms::walk_tips(graph, query_paths, target_path_t, target_handles, step_index, num_threads,
+									  get_path_begin,
+									  get_next_step, has_next_step, bed_writer_thread, progress, true, not_visited_set,
+									  (_best_n_mappings ? args::get(_best_n_mappings) : 1),
+									  (_walking_dist ? args::get(_walking_dist) : 10000),
+									  (_report_additional_jaccards ? args::get(_report_additional_jaccards) : false));
+				std::vector<path_handle_t> visitable_query_paths;
+				for (auto query_path: query_paths) {
+					if (!not_visited_set.count(graph.get_path_name(query_path))) {
+						visitable_query_paths.push_back(query_path);
+					}
+				}
+				/// walk from the back
+				algorithms::walk_tips(graph, visitable_query_paths, target_path_t, target_handles, step_index,
+									  num_threads, get_path_back,
+									  get_prev_step, has_previous_step, bed_writer_thread, progress, false,
+									  not_visited_set,
+									  (_best_n_mappings ? args::get(_best_n_mappings) : 1),
+									  (_walking_dist ? args::get(_walking_dist) : 10000),
+									  (_report_additional_jaccards ? args::get(_report_additional_jaccards) : false));
+				/// let's write our paths we did not visit
+				std::string query_path = graph.get_path_name(target_path_t);
+				for (auto not_visited_path: not_visited_set) {
+					not_visited_out << query_path << "\t" << not_visited_path << std::endl;
+				}
+			}
+			bed_writer_thread.close_writer();
+			if (_not_visited_tsv) {
+				not_visited_out.close();
+			}
 		}
 
 		exit(0);

--- a/src/subcommand/untangle_main.cpp
+++ b/src/subcommand/untangle_main.cpp
@@ -50,8 +50,8 @@ int main_untangle(int argc, char **argv) {
     args::Flag make_self_dotplot(debugging_opts, "DOTPLOT", "Render a table showing the positional dotplot of the query against itself.",
                                  {'S', "self-dotplot"});
 	args::Group step_index_opts(parser, "[ Step Index Options ]");
-	args::ValueFlag<uint64_t> _step_index_sample_rate(step_index_opts, "N", "The sample rate when building the step index. We index a node only if mod(node_id, step-index-sample-rate) == 0! Number must be dividable by 2. (default: 8).",
-													  {'a', "step-index-sample-rate"});
+	args::ValueFlag<std::string> _step_index(step_index_opts, "FILE", "Load the step index from this *FILE*. The file name usually ends with *.stpidx*. (default: build the step index from scratch with a sampling rate of 8).",
+											 {'a', "step-index"});
     args::Group threading(parser, "[ Threading ]");
     args::ValueFlag<uint64_t> nthreads(
         threading, "N", "Number of threads to use for parallel operations.", {'t', "threads"});
@@ -85,12 +85,6 @@ int main_untangle(int argc, char **argv) {
     }
 
     const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
-	// if the sample rate is not dividable by 2, the algorithm will not work
-	uint64_t  step_index_sample_rate = args::get(_step_index_sample_rate) ? args::get(_step_index_sample_rate) : 8;
-	if (step_index_sample_rate % 2 != 0) {
-			std::cerr << "[odgi::untangle] error: The given sample rate of " << step_index_sample_rate << " is not dividable by 2. Please provide a different sample rate." << std::endl;
-			exit(1);
-	}
 
     graph_t graph;
     assert(argc > 0);
@@ -178,22 +172,53 @@ int main_untangle(int argc, char **argv) {
         });
     }
 
+	std::vector<path_handle_t> paths;
+	paths.insert(paths.end(), query_paths.begin(), query_paths.end());
+	paths.insert(paths.end(), target_paths.begin(), target_paths.end());
+	std::sort(paths.begin(), paths.end());
+	paths.erase(std::unique(paths.begin(), paths.end()),
+				paths.end());
+
     if (make_self_dotplot) {
         for (auto& query : query_paths) {
             algorithms::self_dotplot(graph, query);
         }
     } else {
-        algorithms::untangle(graph,
-                             query_paths,
-                             target_paths,
-                             args::get(merge_dist),
-                             (_max_self_coverage ? args::get(_max_self_coverage) : 0),
-                             (_best_n_mappings ? args::get(_best_n_mappings) : 1),
-                             (_jaccard_threshold ? args::get(_jaccard_threshold) : 0.0),
-                             args::get(paf_output),
-                             num_threads,
-                             progress,
-							 step_index_sample_rate);
+		if (!_step_index) {
+			if (progress) {
+				std::cerr
+						<< "[odgi::tips] warning: no step index specified. Building one with a sample rate of 8. This may take additional time. "
+						   "A step index cstep_indexan be provided via -a, --step-index. A step index can be built using odgi stepindex."
+						<< std::endl;
+			}
+			algorithms::step_index_t step_index(graph, paths, num_threads, progress, 8);
+			algorithms::untangle(graph,
+								 query_paths,
+								 target_paths,
+								 args::get(merge_dist),
+								 (_max_self_coverage ? args::get(_max_self_coverage) : 0),
+								 (_best_n_mappings ? args::get(_best_n_mappings) : 1),
+								 (_jaccard_threshold ? args::get(_jaccard_threshold) : 0.0),
+								 args::get(paf_output),
+								 num_threads,
+								 progress,
+								 step_index,
+								 paths);
+		} else {
+			algorithms::step_index_t step_index;
+			step_index.load(args::get(_step_index));
+			algorithms::untangle(graph,
+								 query_paths,
+								 target_paths,
+								 args::get(merge_dist),
+								 (_max_self_coverage ? args::get(_max_self_coverage) : 0),
+								 (_best_n_mappings ? args::get(_best_n_mappings) : 1),
+								 (_jaccard_threshold ? args::get(_jaccard_threshold) : 0.0),
+								 args::get(paf_output),
+								 num_threads,
+								 progress,
+								 step_index,paths);
+		}
     }
 
     return 0;

--- a/src/unittest/stepindex.cpp
+++ b/src/unittest/stepindex.cpp
@@ -1,0 +1,638 @@
+/**
+ * \file
+ * unittest/stepindex.cpp: test cases for the implementations of the step index.
+ */
+
+#include "catch.hpp"
+
+#include <handlegraph/util.hpp>
+#include "odgi.hpp"
+#include "stepindex.hpp"
+
+namespace odgi {
+	namespace unittest {
+
+		using namespace std;
+		using namespace handlegraph;
+		using namespace algorithms;
+
+		TEST_CASE("step index construction, and position retrieval.", "[stepindex]") {
+
+			graph_t graph;
+			handle_t n1 = graph.create_handle("CAA");
+			handle_t n2 = graph.create_handle("A");
+			handle_t n3 = graph.create_handle("G");
+			handle_t n4 = graph.create_handle("T");
+			handle_t n5 = graph.create_handle("C");
+			handle_t n6 = graph.create_handle("TTG");
+			handle_t n7 = graph.create_handle("A");
+			handle_t n8 = graph.create_handle("GAT");
+			handle_t n9 = graph.create_handle("GTC");
+			handle_t n10 = graph.create_handle("CATG");
+			graph.create_edge(n1, n2);
+			graph.create_edge(n1, n3);
+			graph.create_edge(n2, n4);
+			graph.create_edge(n2, n5);
+			graph.create_edge(n3, n5);
+			graph.create_edge(n4, n6);
+			graph.create_edge(n5, n6);
+			graph.create_edge(n6, n6);
+			graph.create_edge(n6, n7);
+			graph.create_edge(n6, n8);
+			graph.create_edge(n8, n9);
+
+			graph.create_path_handle("target", false);
+			path_handle_t target = graph.get_path_handle("target");
+			graph.append_step(target, n3);
+			graph.append_step(target, n5);
+			graph.append_step(target, n6);
+			graph.append_step(target, n6);
+			graph.append_step(target, n8);
+			graph.append_step(target, n9);
+
+			graph.create_path_handle("query1", false);
+			path_handle_t query1 = graph.get_path_handle("query1");
+			graph.append_step(query1, n2);
+			graph.append_step(query1, n4);
+			graph.append_step(query1, n6);
+			graph.append_step(query1, n7);
+
+			graph.create_path_handle("query2", false);
+			path_handle_t query2 = graph.get_path_handle("query2");
+			graph.append_step(query2, n10);
+
+			graph.create_path_handle("query3", false);
+			path_handle_t query3 = graph.get_path_handle("query3");
+			graph.append_step(query3, n1);
+			graph.append_step(query3, n2);
+			graph.append_step(query3, n5);
+			graph.append_step(query3, n6);
+			graph.append_step(query3, n8);
+			graph.append_step(query3, n9);
+
+			vector<path_handle_t> paths;
+			graph.for_each_path_handle([&](const path_handle_t path) {
+				paths.push_back(path);
+			});
+
+			SECTION("The index delivers the correct positions for a given step. Sample rate: 1.") {
+				step_index_t step_index_1(graph, paths, 1, false, 1);
+				graph.for_each_path_handle([&](const path_handle_t path) {
+					std::string cur_path = graph.get_path_name(path);
+					if (cur_path == "target") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_1.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_1.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_1.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_1.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_1.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_1.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query1") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_1.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_1.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_1.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_1.get_position(occ, graph) == 5);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query2") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_1.get_position(occ, graph) == 0);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query3") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_1.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_1.get_position(occ, graph) == 3);
+									break;
+								case 2:
+									REQUIRE(step_index_1.get_position(occ, graph) == 4);
+									break;
+								case 3:
+									REQUIRE(step_index_1.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_1.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_1.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+				});
+			}
+
+			SECTION("The index delivers the correct positions for a given step. Sample rate: 2.") {
+				step_index_t step_index_2(graph, paths, 1, false, 2);
+				graph.for_each_path_handle([&](const path_handle_t path) {
+					std::string cur_path = graph.get_path_name(path);
+					if (cur_path == "target") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_2.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_2.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_2.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_2.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_2.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_2.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query1") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_2.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_2.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_2.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_2.get_position(occ, graph) == 5);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query2") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_2.get_position(occ, graph) == 0);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query3") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_2.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_2.get_position(occ, graph) == 3);
+									break;
+								case 2:
+									REQUIRE(step_index_2.get_position(occ, graph) == 4);
+									break;
+								case 3:
+									REQUIRE(step_index_2.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_2.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_2.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+				});
+			}
+
+			SECTION("The index delivers the correct positions for a given step. Sample rate: 4.") {
+				step_index_t step_index_4(graph, paths, 1, false, 4);
+				graph.for_each_path_handle([&](const path_handle_t path) {
+					std::string cur_path = graph.get_path_name(path);
+					if (cur_path == "target") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_4.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_4.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_4.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_4.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_4.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query1") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_4.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_4.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_4.get_position(occ, graph) == 5);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query2") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query3") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_4.get_position(occ, graph) == 3);
+									break;
+								case 2:
+									REQUIRE(step_index_4.get_position(occ, graph) == 4);
+									break;
+								case 3:
+									REQUIRE(step_index_4.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_4.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_4.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+				});
+			}
+
+			SECTION("The index delivers the correct positions for a given step. Sample rate: 4.") {
+				step_index_t step_index_4(graph, paths, 1, false, 4);
+				graph.for_each_path_handle([&](const path_handle_t path) {
+					std::string cur_path = graph.get_path_name(path);
+					if (cur_path == "target") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_4.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_4.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_4.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_4.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_4.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query1") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_4.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_4.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_4.get_position(occ, graph) == 5);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query2") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query3") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_4.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_4.get_position(occ, graph) == 3);
+									break;
+								case 2:
+									REQUIRE(step_index_4.get_position(occ, graph) == 4);
+									break;
+								case 3:
+									REQUIRE(step_index_4.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_4.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_4.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+				});
+			}
+
+			SECTION("The index delivers the correct positions for a given step. Sample rate: 8.") {
+				step_index_t step_index_8(graph, paths, 1, false, 8);
+				graph.for_each_path_handle([&](const path_handle_t path) {
+					std::string cur_path = graph.get_path_name(path);
+					if (cur_path == "target") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_8.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_8.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_8.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_8.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_8.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_8.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query1") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_8.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_8.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_8.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_8.get_position(occ, graph) == 5);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query2") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_8.get_position(occ, graph) == 0);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query3") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_8.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_8.get_position(occ, graph) == 3);
+									break;
+								case 2:
+									REQUIRE(step_index_8.get_position(occ, graph) == 4);
+									break;
+								case 3:
+									REQUIRE(step_index_8.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_8.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_8.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+				});
+			}
+
+			SECTION("The index delivers the correct positions for a given step. Sample rate: 16.") {
+				step_index_t step_index_16(graph, paths, 1, false, 16);
+				graph.for_each_path_handle([&](const path_handle_t path) {
+					std::string cur_path = graph.get_path_name(path);
+					if (cur_path == "target") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_16.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_16.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_16.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_16.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_16.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_16.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query1") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_16.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_16.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_16.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_16.get_position(occ, graph) == 5);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query2") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_16.get_position(occ, graph) == 0);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query3") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_16.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_16.get_position(occ, graph) == 3);
+									break;
+								case 2:
+									REQUIRE(step_index_16.get_position(occ, graph) == 4);
+									break;
+								case 3:
+									REQUIRE(step_index_16.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_16.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_16.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+				});
+			}
+
+		}
+	}
+}

--- a/src/unittest/stepindex.cpp
+++ b/src/unittest/stepindex.cpp
@@ -9,6 +9,8 @@
 #include "odgi.hpp"
 #include "stepindex.hpp"
 
+#include "algorithms/xp.hpp"
+
 namespace odgi {
 	namespace unittest {
 
@@ -625,6 +627,106 @@ namespace odgi {
 									break;
 								case 5:
 									REQUIRE(step_index_16.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+				});
+			}
+
+			SECTION("The index can be saved and loaded. After loading, we can retrieve all the correct positions again.") {
+				step_index_t step_index_to_save(graph, paths, 1, false, 8);
+				// Write index to temporary file in preparation for the next tests.
+				std::string basename = xp::temp_file::create();
+				step_index_to_save.save(basename + "unittest.stpidx");
+
+				step_index_t step_index_loaded;
+				step_index_loaded.load(basename + "unittest.stpidx");
+
+				graph.for_each_path_handle([&](const path_handle_t path) {
+					std::string cur_path = graph.get_path_name(path);
+					if (cur_path == "target") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 11);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query1") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 1);
+									break;
+								case 2:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 2);
+									break;
+								case 3:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 5);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query2") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 0);
+									break;
+							}
+							cur_step_rank++;
+						});
+					}
+
+					if (cur_path == "query3") {
+						uint64_t cur_step_rank = 0;
+						graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+							switch(cur_step_rank) {
+								case 0:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 0);
+									break;
+								case 1:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 3);
+									break;
+								case 2:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 4);
+									break;
+								case 3:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 5);
+									break;
+								case 4:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 8);
+									break;
+								case 5:
+									REQUIRE(step_index_loaded.get_position(occ, graph) == 11);
 									break;
 							}
 							cur_step_rank++;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -81,4 +81,8 @@ namespace utils {
 		}
 		return 0;
     }
+
+	uint64_t modulo_two(const uint64_t n, const uint64_t d) {
+		return (n & (d - 1));
+	}
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -82,7 +82,7 @@ namespace utils {
 		return 0;
     }
 
-	uint64_t modulo_two(const uint64_t n, const uint64_t d) {
+	uint64_t modulo(const uint64_t n, const uint64_t d) {
 		return (n & (d - 1));
 	}
 }

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -17,7 +17,7 @@ namespace utils {
 							  const uint64_t num_threads, odgi::graph_t &graph);
 	/// this function will return n % d
 	/// it is assumed that d is one of 1, 2, 4, 8, 16, 32, ....
-	uint64_t modulo_two(const uint64_t n, const uint64_t d);
+	uint64_t modulo(const uint64_t n, const uint64_t d);
 }
 
 

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -15,6 +15,9 @@ namespace utils {
 	bool ends_with(const std::string &fullString, const std::string &ending);
 	int handle_gfa_odgi_input(const std::string infile, const std::string subcommmand_name, const bool progress,
 							  const uint64_t num_threads, odgi::graph_t &graph);
+	/// this function will return n % d
+	/// it is assumed that d is one of 1, 2, 4, 8, 16, 32, ....
+	uint64_t modulo_two(const uint64_t n, const uint64_t d);
 }
 
 

--- a/test/binary/untangle/default
+++ b/test/binary/untangle/default
@@ -1,0 +1,9 @@
+#query.name	query.start	query.end	ref.name	ref.start	ref.end	score	inv	self.cov	nth.best
+target	0	2	target	0	2	1	+	1	1
+target	2	5	query1	2	5	1	+	2	1
+target	5	11	query3	5	11	1	+	1.5	1
+query1	0	2	query1	0	2	1	+	1	1
+query1	2	5	query1	2	5	1	+	1	1
+query3	0	3	query3	0	3	1	+	1	1
+query3	3	5	query3	3	5	1	+	1	1
+query3	5	11	query3	5	11	1	+	1	1


### PR DESCRIPTION
The current step index implementation is very heavy when it comes to RAM usage. This PR attempts to solve that by only indexing every node with node identifier fitting  `mod(node_id, step-index-sample-rate) == 0` in the graph. 
From a given step, we can find its position by walking backwards until a node fitting our sampling criteria is found. We can retrieve this position easily, adding up the walked distance to retrieve the actual position of the step. 
Effectively, the sample rate is only allowed to be a number by the power of 2, because we can use bit shift operations to calculate the modulo in O(1)! (https://www.geeksforgeeks.org/compute-modulus-division-by-a-power-of-2-number/).

- [x] Basic implementation.
- [x] Can we add a pointer to a graph_t in the step_index_t so that we don't need a graph_t at hand for the `get_position(step, graph)` function? --> We will need the graph at all times anyhow, so it won't matter.
- [x] We need to figure out which value for the sampling rate delivers the best compromise of performance and memory usage. The current default in `odgi tips` and `odgi untangle` is 8.
- [X] Add unittests.
- [x] Add the length of each path to the index. This is a requirement to replace the XG in `smoothxg`. Might be tricky to serialize to disk, then. Not sure here.
- [x] Find a way to serialize and deserialize a step index to disk.
- [x] Update unittests.
- [x] Update the stepindex, tips, untangle, and position interfaces.
- [x] Binary tests for tips, untangle.
- [x] Update the Docs.