### PR TITLE
We can go from an end step to its previous step

### DIFF
--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -416,7 +416,8 @@ step_handle_t graph_t::get_previous_step(const step_handle_t& step_handle) const
     if (is_path_front_end(step_handle)) {
         return step_handle;
     } else if (is_path_end(step_handle)) {
-        curr_handle = get_handle_of_step(path_back(as_path_handle(as_integers(step_handle)[0])));
+        return path_back(as_path_handle(as_integers(step_handle)[0]));
+		// curr_handle = get_handle_of_step(path_back(as_path_handle(as_integers(step_handle)[0])));
     } else {
         curr_handle = get_handle_of_step(step_handle);
     }

--- a/src/unittest/stepindex.cpp
+++ b/src/unittest/stepindex.cpp
@@ -106,6 +106,10 @@ namespace odgi {
 							}
 							cur_step_rank++;
 						});
+						step_handle_t path_end = graph.path_end(path);
+						step_handle_t path_back_from_end = graph.get_previous_step(path_end);
+						REQUIRE(step_index_1.get_position(path_end, graph) == step_index_1.get_path_len(path));
+						REQUIRE(step_index_1.get_position(path_back_from_end, graph) == step_index_1.get_position(graph.path_back(path), graph));
 					}
 
 					if (cur_path == "query1") {
@@ -127,6 +131,10 @@ namespace odgi {
 							}
 							cur_step_rank++;
 						});
+						step_handle_t path_end = graph.path_end(path);
+						step_handle_t path_back_from_end = graph.get_previous_step(path_end);
+						REQUIRE(step_index_1.get_position(path_end, graph) == step_index_1.get_path_len(path));
+						REQUIRE(step_index_1.get_position(path_back_from_end, graph) == step_index_1.get_position(graph.path_back(path), graph));
 					}
 
 					if (cur_path == "query2") {
@@ -139,6 +147,10 @@ namespace odgi {
 							}
 							cur_step_rank++;
 						});
+						step_handle_t path_end = graph.path_end(path);
+						step_handle_t path_back_from_end = graph.get_previous_step(path_end);
+						REQUIRE(step_index_1.get_position(path_end, graph) == step_index_1.get_path_len(path));
+						REQUIRE(step_index_1.get_position(path_back_from_end, graph) == step_index_1.get_position(graph.path_back(path), graph));
 					}
 
 					if (cur_path == "query3") {
@@ -166,6 +178,10 @@ namespace odgi {
 							}
 							cur_step_rank++;
 						});
+						step_handle_t path_end = graph.path_end(path);
+						step_handle_t path_back_from_end = graph.get_previous_step(path_end);
+						REQUIRE(step_index_1.get_position(path_end, graph) == step_index_1.get_path_len(path));
+						REQUIRE(step_index_1.get_position(path_back_from_end, graph) == step_index_1.get_position(graph.path_back(path), graph));
 					}
 				});
 			}


### PR DESCRIPTION
This updates the ODGI API so that we can actually ask a previous step for an end step. An end step is a step past the last step of a path! This is important to have so we can ask the nucleotide position of such an end step from the step index. 
It also mimics the XG API in `smoothxg`. This update is a major step for implementing https://github.com/pangenome/smoothxg/pull/151.