### PR TITLE
Heaps law

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/untangle_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/tips_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/stepindex_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/heaps_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp
@@ -445,6 +446,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/stepindex.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/groom.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/crush_n.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/heaps.cpp
   ${CMAKE_SOURCE_DIR}/src/unittest/edge.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/tips.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/path_jaccard.cpp)

--- a/scripts/heaps_fit.R
+++ b/scripts/heaps_fit.R
@@ -1,0 +1,20 @@
+#!/usr/bin/env Rscript
+
+require(tidyverse)
+
+objectFun <- function(p, x, y){                                                                                                                      
+  y.hat <- p[1] * x^(p[2])
+  J <- sqrt(sum((y - y.hat)^2))/length(x)
+  return(J)
+}
+
+# ENABLE command line arguments
+args <- commandArgs(TRUE)
+x <- read.delim(args[1])
+
+fit <- with(x, optim(c(0,0), objectFun, gr = NULL, nth.genome, base.pairs/max(base.pairs), method = "L-BFGS-B", lower = c(-100, -100), upper = c(100, 100)))
+
+print(fit)
+
+ggplot(x, aes(x=nth.genome, y=base.pairs/max(base.pairs))) + geom_point() + stat_function(fun=function(x) fit$par[1] * x^fit$par[2])
+ggsave(args[2])

--- a/src/algorithms/heaps.cpp
+++ b/src/algorithms/heaps.cpp
@@ -1,0 +1,62 @@
+#include "heaps.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+void for_each_heap_permutation(const PathHandleGraph& graph,
+                               const std::vector<std::vector<path_handle_t>>& path_groups,
+                               uint64_t n_permutations,
+                               const std::function<void(const std::vector<uint64_t>&, uint64_t)>& func) {
+    //std::vector<std::vector<path_handle_t>>
+    auto get_permutation = [&](void) {
+        std::random_device rd;
+        std::default_random_engine rng(rd());
+        std::vector<uint64_t> order; order.reserve(path_groups.size());
+        for (uint64_t i = 0; i < path_groups.size(); ++i) {
+            order.push_back(i);
+        }
+        std::shuffle(order.begin(), order.end(), rng);
+        return order;
+    };
+
+    uint64_t graph_total_bp = 0;
+    uint64_t idx = 0;
+    graph.for_each_handle([&](const handle_t& h) {
+        graph_total_bp += graph.get_length(h);
+        if (graph.get_id(h) != ++idx) {
+            std::cerr << "[odgi::algorithms::heaps] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+            std::abort();
+        }
+    });
+
+#pragma omp parallel for
+    for (uint64_t i = 0; i < n_permutations; ++i) {
+        auto permutation = get_permutation();
+        // XXX the graph must be node-id compacted for this trick!
+        std::vector<bool> seen_nodes(graph.get_node_count(), 0);
+        uint64_t seen_bp = 0;
+        std::vector<uint64_t> vals;
+        for (auto& j : permutation) {
+            auto& paths = path_groups[j];
+            for (auto& path : paths) {
+                graph.for_each_step_in_path(
+                    path,
+                    [&](const step_handle_t& step) {
+                        auto h = graph.get_handle_of_step(step);
+                        uint64_t rank = graph.get_id(h)-1; // assumes compaction!
+                        if (!seen_nodes[rank]) {
+                            seen_nodes[rank] = 1;
+                            seen_bp += graph.get_length(h);
+                        }
+                    });
+            }
+            vals.push_back(seen_bp);
+        }
+        func(vals, i);
+    }
+}
+
+}
+
+}

--- a/src/algorithms/heaps.hpp
+++ b/src/algorithms/heaps.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include <map>
+#include <algorithm>
+#include <random>
+#include <omp.h>
+#include "hash_map.hpp"
+#include "position.hpp"
+#include <handlegraph/types.hpp>
+#include <handlegraph/iteratee.hpp>
+#include <handlegraph/util.hpp>
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/path_handle_graph.hpp>
+
+namespace odgi {
+
+using namespace handlegraph;
+
+namespace algorithms {
+
+/// For each permutation of the path groups
+/// we call func with a vector that is the fraction of the pangenome covered when we've considered N groups in the permutation
+void for_each_heap_permutation(const PathHandleGraph& graph,
+                               const std::vector<std::vector<path_handle_t>>& path_groups,
+                               uint64_t n_permutations,
+                               const std::function<void(const std::vector<uint64_t>&, uint64_t)>& func);
+
+}
+
+}

--- a/src/subcommand/heaps_main.cpp
+++ b/src/subcommand/heaps_main.cpp
@@ -1,0 +1,127 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include <omp.h>
+#include "algorithms/heaps.hpp"
+#include "utils.hpp"
+#include "split.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_heaps(int argc, char **argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc - 1; ++i) {
+        argv[i] = argv[i + 1];
+    }
+    const std::string prog_name = "odgi heaps";
+    argv[0] = (char *) prog_name.c_str();
+    --argc
+;
+    args::ArgumentParser parser("Extract matrix of path pangenome coverage permutations for power law regression.");
+    args::Group mandatory_opts(parser, "[ MANDATORY ARGUMENTS ]");
+    args::ValueFlag<std::string> og_in_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "idx"});
+    args::Group heaps_opts(parser, "[ Heaps Options ]");
+    args::ValueFlag<std::string> _path_groups(heaps_opts, "FILE", "Group paths as described in two-column FILE, with columns path.name and group.name.",
+                                              {'p', "path-groups"});
+    args::ValueFlag<uint64_t> _n_permutations(heaps_opts, "N", "Number of permutations to run.",
+                                             {'n', "n-permutations"});
+    args::Group threading_opts(parser, "[ Threading ]");
+    args::ValueFlag<uint64_t> nthreads(threading_opts, "N", "Number of threads to use for parallel operations.",
+                                       {'t', "threads"});
+    args::Group processing_info_opts(parser, "[ Processing Information ]");
+    args::Flag debug(processing_info_opts, "debug", "Print information about the process to stderr.", {'d', "debug"});
+    args::Flag progress(processing_info_opts, "progress", "Write the current progress to stderr.", {'P', "progress"});
+    args::Group program_info_opts(parser, "[ Program Information ]");
+    args::HelpFlag help(program_info_opts, "help", "Print a help message for odgi heaps.", {'h', "help"});
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc == 1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    if (!og_in_file) {
+        std::cerr
+            << "[odgi::heaps] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+            << std::endl;
+        return 1;
+    }
+
+    const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+    omp_set_num_threads(num_threads);
+
+    const uint64_t n_permutations = args::get(_n_permutations) ? args::get(_n_permutations) : 1;
+
+    graph_t graph;
+    assert(argc > 0);
+    {
+        const std::string infile = args::get(og_in_file);
+        if (!infile.empty()) {
+            if (infile == "-") {
+                graph.deserialize(std::cin);
+            } else {
+                utils::handle_gfa_odgi_input(infile, "heaps", args::get(progress), num_threads, graph);
+            }
+        }
+    }
+
+    std::vector<std::vector<path_handle_t>> path_groups;
+    if (_path_groups) {
+        std::unordered_map<std::string, std::vector<path_handle_t>> path_groups_map;
+        std::ifstream refs(args::get(_path_groups).c_str());
+        std::string line;
+        while (std::getline(refs, line)) {
+            if (!line.empty()) {
+                auto vals = split(line, '\t');
+                if (vals.size() != 2) {
+                    std::cerr << "[odgi::heaps] line does not have a path.name and path.group value:"
+                              << std::endl << line << std::endl;
+                    return 1;
+                }
+                auto& path_name = vals.front();
+                auto& group = vals.back();
+                if (!graph.has_path(vals.front())) {
+                    std::cerr << "[odgi::heaps] no path '" << path_name << "'" << std::endl;
+                    return 1;
+                }
+                path_groups_map[group].push_back(graph.get_path_handle(path_name));
+            }
+        }
+        path_groups.reserve(path_groups_map.size());
+        for (auto& g : path_groups_map) {
+            path_groups.push_back(g.second);
+        }
+    }
+
+    
+    graph.set_number_of_threads(num_threads);
+
+    std::cout << "permutation\tnth.genome\tbase.pairs" << std::endl;
+    auto handle_output = [&](const std::vector<uint64_t>& vals, uint64_t perm_id) {
+        int i = 0;
+#pragma omp critical (cout)
+        for (auto& v : vals) {
+            std::cout << perm_id << "\t" << ++i << "\t" << v << std::endl;
+        }
+    };
+    algorithms::for_each_heap_permutation(graph, path_groups, n_permutations, handle_output);
+
+    return 0;
+}
+
+static Subcommand odgi_heaps("heaps", "Path pangenome coverage permutations.",
+                             PIPELINE, 3, main_heaps);
+
+
+}


### PR DESCRIPTION
Compute the openness of a pangenome using Heaps' law. Includes a subcommand to generate the nth genome pangenome coverage permutations, plus an R script to make the fit and a plot.