### PR TITLE
Improved guix support with guix.scm

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ gcc --version
 g++ --version
 ```
 
-`odgi` pulls in a host of source repositories as dependencies. It may be necessary to install several system-level 
-libraries to build `odgi`. On `Ubuntu 20.04`, these can be installed using `apt`:
-
+`odgi` pulls in a host of source repositories as dependencies. It may be necessary to install several system-level libraries to build `odgi`. On `Ubuntu 20.04`, these can be installed using `apt`:
 ```
 sudo apt install build-essential cmake python3-distutils python3-dev libjemalloc-dev
 ```
@@ -61,11 +59,14 @@ On `Arch Linux`, the `jemalloc` dependency can be installed with:
 sudo pacman -S jemalloc     # arch linux
 ```
 
-An alternative way to manage `odgi`'s dependencies is to use `GUIX`. After `sudo apt install guix`, start a GNU Guix
-build container with:
+An alternative way to manage `odgi`'s dependencies is to use `GUIX`. After `sudo apt install guix`, start a GNU Guix build container with:
 
 ```bash
+git submodule update --init --recursive
 source ./.guix-build
+cd build
+cmake ..
+make
 ```
 
 ### Bioconda
@@ -157,8 +158,7 @@ with a new release version and codename. [version.cpp](./src/version.cpp) is upd
 
 ## presentations
 
-[@AndreaGuarracino](https://github.com/andreaguarracino) and [@subwaystation](https://github.com/subwaystation) 
-presented `odgi` at the German Bioinformatics Conference 2021: [ODGI - scalable tools for pangenome graphs](https://docs.google.com/presentation/d/1d52kaiOqeH4db4LyMHn7YNjv-mBKvhY2t2zQMNvzgno/edit#slide=id.p).
+[@AndreaGuarracino](https://github.com/andreaguarracino) and [@subwaystation](https://github.com/subwaystation) presented `odgi` at the German Bioinformatics Conference 2021: [ODGI - scalable tools for pangenome graphs](https://docs.google.com/presentation/d/1d52kaiOqeH4db4LyMHn7YNjv-mBKvhY2t2zQMNvzgno/edit#slide=id.p).
 
 ## name
 

--- a/README.md
+++ b/README.md
@@ -59,14 +59,29 @@ On `Arch Linux`, the `jemalloc` dependency can be installed with:
 sudo pacman -S jemalloc     # arch linux
 ```
 
-An alternative way to manage `odgi`'s dependencies is to use `GUIX`. After `sudo apt install guix`, start a GNU Guix build container with:
+An alternative way to manage `odgi`'s dependencies is to use `GUIX`. After installing and updating guix, load the current profile with:
+
+```sh
+sudo apt install guix
+guix pull
+source ~/.config/guix/current/etc/profile
+```
+
+With the latest guix in the path start a GNU Guix build container with:
 
 ```bash
-git submodule update --init --recursive
+git clone --recursive https://github.com/pangenome/odgi.git
+cd odgi
 source ./.guix-build
 cd build
 cmake ..
 make
+```
+
+The alternative way of building odgi is with guix.scm:
+
+```sh
+guix build -f guix.scm
 ```
 
 ### Bioconda

--- a/guix.scm
+++ b/guix.scm
@@ -1,0 +1,85 @@
+;; To use this file to build HEAD of odgi:
+;;
+;;   guix build -f guix.scm
+;;
+;; To get a development container (emacs shell will work)
+;;
+;;   guix shell -C -f guix.scm
+;;
+;; For the tests you may need /usr/bin/env. In a container create it with
+;;
+;;   mkdir -p /usr/bin ; ln -s $GUIX_ENVIRONMENT/bin/env /usr/bin/env
+
+(use-modules
+  ((guix licenses) #:prefix license:)
+  (guix gexp)
+  (guix packages)
+  (guix git-download)
+  (guix build-system cmake)
+  (guix utils)
+  (gnu packages algebra)
+  (gnu packages base)
+  (gnu packages compression)
+  (gnu packages bioinformatics)
+  (gnu packages build-tools)
+  (gnu packages curl)
+  (gnu packages gcc)
+  (gnu packages jemalloc)
+  (gnu packages llvm)
+  (gnu packages python)
+  (gnu packages python-xyz)
+  (gnu packages parallel)
+  (gnu packages perl)
+  (gnu packages perl6)
+  (gnu packages pkg-config)
+  (gnu packages tls)
+  (gnu packages version-control)
+  (srfi srfi-1)
+  (ice-9 popen)
+  (ice-9 rdelim))
+
+(define %source-dir (dirname (current-filename)))
+
+(define %git-commit
+    (read-string (open-pipe "git show HEAD | head -1 | cut -d ' ' -f 2" OPEN_READ)))
+
+(define-public odgi-git
+  (package
+    (name "odgi-git")
+    (version (git-version "0.6.3" "HEAD" %git-commit))
+    (source (local-file %source-dir #:recursive? #t))
+    (build-system cmake-build-system)
+    (inputs
+     `(
+       ; ("pybind11" ,pybind11)
+       ("jemalloc" ,jemalloc)
+                                        ; ("openssl" ,openssl)
+       ("gcc" ,gcc-11)
+       ("git" ,git)
+       ("python" ,python)))
+    (native-inputs
+     `(("pkg-config" ,pkg-config)
+       ))
+    (arguments
+      `(#:phases
+        (modify-phases
+         %standard-phases
+         ;; This stashes our build version in the executable
+         (add-after 'unpack 'set-version
+           (lambda _
+             (mkdir "include")
+             (with-output-to-file "include/odgi_git_version.hpp"
+               (lambda ()
+                 (format #t "#define ODGI_GIT_VERSION \"~a\"~%" version)))
+             #t))
+         (delete 'check))
+        #:make-flags (list ,(string-append "CC=" (cc-for-target)))))
+     (synopsis "odgi optimized dynamic sequence graph implementation")
+     (description
+"odgi provides an efficient, succinct dynamic DNA sequence graph model, as well
+as a host of algorithms that allow the use of such graphs in bioinformatic
+analyses.")
+     (home-page "https://github.com/vgteam/odgi")
+     (license license:expat)))
+
+odgi-git


### PR DESCRIPTION
Updated README and added guix.scm. It can build odgi on top of a recursive git checkout. 

This is the starting point for getting dependencies sorted in Guix itself.