### PR TITLE
Added `odgi pav` to quantify presence/absence variants (PAVs)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,6 +410,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/tips_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/stepindex_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/heaps_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/pav_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,13 @@ sys.path.insert(0, os.path.abspath('../lib/'))
 # -- Project information -----------------------------------------------------
 
 project = u'odgi'
-copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision v0.6.3-7b866a5'
+copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision v0.6.3-f6d86c3'
 author = u'Andrea Guarracino, Simon Heumos, ... , Pjotr Prins, Erik Garrison'
 
 # The short X.Y version
 version = 'v0.6.3'
 # The full version, including alpha/beta/rc tags
-release = '7b866a5'
+release = 'f6d86c3'
 
 
 # -- General configuration ---------------------------------------------------
@@ -152,6 +152,8 @@ man_pages = [
     ('man/odgi_chop', 'odgi_chop', u'Divide nodes into smaller pieces preserving node topology and order.',
      [EG, AG], 1),
     ('man/odgi_cover', 'odgi_cover', u'Cover the graph with paths.',
+     [AG], 1),
+    ('man/odgi_pav', 'odgi_pav', u'Presence/absence variants (PAVs).',
      [AG], 1),
     ('man/odgi_degree', 'odgi_degree', u'Describe the graph in terms of node degree.',
      [EG], 1),

--- a/docs/rst/commands.rst
+++ b/docs/rst/commands.rst
@@ -25,6 +25,7 @@ Commands
     commands/odgi_overlap
     commands/odgi_panpos
     commands/odgi_pathindex
+    commands/odgi_pav
     commands/odgi_paths
     commands/odgi_position
     commands/odgi_prune

--- a/docs/rst/commands/odgi_pav.rst
+++ b/docs/rst/commands/odgi_pav.rst
@@ -1,0 +1,75 @@
+.. _odgi pav:
+
+#########
+odgi pav
+#########
+
+Presence/absence variants (PAVs).
+It prints to stdout a matrix with the PAVs ratios.
+
+SYNOPSIS
+========
+
+**odgi pav** [**-i, --idx**\ =\ *FILE*] [**-b,
+–bed-file**\ =\ *FILE*] [*OPTION*]…
+
+DESCRIPTION
+===========
+
+The odgi pav command prints to stdout a matrix with the Presence/absence variants (PAVs) ratios.
+
+OPTIONS
+=======
+
+MANDATORY OPTIONS
+--------------
+
+| **-i, --idx**\ =\ *FILE*
+| Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!
+
+| **-b, --bed-file**\ =\ *FILE*
+| Find PAVs in the path range(s) specified in the given BED FILE
+
+Pav Options
+---------------
+
+| **-p, --path-groups**\ =\ *FILE*
+| Group paths as described in two-column *FILE*, with columns `path.name` and `group.name`.
+
+| **-B, --binary-matrix**\ =\ *THRESHOLD*
+| Emit a binary matrix, with 1 if the PAV ratio is greater than or equal to the specified THRESHOLD, else 0.
+
+Threading
+---------
+
+| **-t, --threads**\ =\ *N*
+| Number of threads to use for parallel operations.
+
+Processing Information
+----------------------
+
+| **-P, --progress**
+| Print information about the components and the progress to stderr.
+
+Program Information
+-------------------
+
+| **-h, --help**
+| Print a help message for **odgi pav**.
+
+..
+	EXIT STATUS
+	===========
+	
+	| **0**
+	| Success.
+	
+	| **1**
+	| Failure (syntax or usage error; parameter error; file processing
+	  failure; unexpected error).
+	
+	BUGS
+	====
+	
+	Refer to the **odgi** issue tracker at
+	https://github.com/pangenome/odgi/issues.

--- a/docs/rst/tutorials.rst
+++ b/docs/rst/tutorials.rst
@@ -8,6 +8,7 @@ Tutorials
     tutorials/exploratory_analysis
     tutorials/detect_complex_regions
     tutorials/extract_selected_loci
+    tutorials/presence_absence_variants
     tutorials/untangling_the_pangenome
     tutorials/sort_layout
     tutorials/navigating_and_annotating_graphs

--- a/docs/rst/tutorials/presence_absence_variants.rst
+++ b/docs/rst/tutorials/presence_absence_variants.rst
@@ -1,0 +1,136 @@
+.. _presence_absence_variants:
+
+####################################
+Identify presence/absence variants
+####################################
+
+========
+Synopsis
+========
+
+The term presence/absence variation (PAV) is used to describe sequences that are present in one genome, but
+entirely missing in another genome, and is an important source of genetic divergence and diversity.
+
+-----------------------------
+Build the Lipoprotein A graph
+-----------------------------
+
+Assuming that your current working directory is the root of the ``odgi`` project, to construct an ``odgi`` file from the
+``LPA`` dataset in ``GFA`` format, execute:
+
+.. code-block:: bash
+
+    odgi build -g test/LPA.gfa -o LPA.og
+
+The command creates a file called ``LPA.og``, which contains the input graph in ``odgi`` format. This graph contains
+13 contigs from 7 haploid human genome assemblies from 6 individuals plus the chm13 cell line. The contigs cover the
+`Lipoprotein A (LPA) <https://www.ensembl.org/Homo_sapiens/Gene/Summary?g=ENSG00000198670>`_ locus, which encodes the
+Apo(a) protein.
+
+-----------------------
+Presence/absence variants (PAVs)
+-----------------------
+
+Any path in the graph can be used as a reference to identify PAVs. In this example, we have chosen the ``chm13__LPA__tig00000001``
+path. To obtain contains 1000 bp interval windows across the chosen reference, execute:
+
+.. code-block:: bash
+
+    odgi paths -i LPA.og -f | grep 'chm13__LPA__tig00000001' -A 1 > reference.fa
+    samtools faidx reference.fa
+    bedtools makewindows -g <(cut -f 1,2 reference.fa.fai) -w 1000 > LPA.w1kbp.bed
+
+To identify the PAVs, execute:
+
+.. code-block:: bash
+
+    odgi pav -i LPA.og -b LPA.w1kbp.bed > LPA.w1kbp.pavs.txt
+
+By default, ``odgi pav`` prints to stdout a matrix with the PAVs ratios.
+To take a look at the first rows and columns of the matrix in the ``LPA.w1kbp.pavs.txt`` file, execute:
+
+.. code-block:: bash
+
+    head LPA.w1kbp.pavs.txt | cut -f 1-8 | column -t
+
+.. code-block:: none
+
+    chrom                    start  end   name  chm13__LPA__tig00000001  HG002__LPA__tig00000001  HG002__LPA__tig00000005  HG00733__LPA__tig00000001
+    chm13__LPA__tig00000001  0      1000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  1000   2000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  2000   3000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  3000   4000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  4000   5000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  5000   6000  .     1                        0.4156                   0.91101                  0.00091743
+    chm13__LPA__tig00000001  6000   7000  .     1                        1                        1                        0.80339
+    chm13__LPA__tig00000001  7000   8000  .     1                        0.99811                  0.99906                  0.98491
+    chm13__LPA__tig00000001  8000   9000  .     1                        1                        1                        0.99466
+
+
+The ``chrom``, ``start``, ``end``, and ``name`` columns are filled with the values in the corresponding columns in the
+input ``BED`` format file. In this example, the region ``chm13__LPA__tig00000001:5000-6000`` is covered at ``41.56%`` in the
+``HG002__LPA__tig00000001`` contig and it is almost absent in ``HG00733__LPA__tig00000001``.
+
+To emit a binary PAV matrix, execute:
+
+.. code-block:: bash
+
+    odgi pav -i LPA.og -b LPA.w1kbp.bed -B 0.5 > LPA.w1kbp.pavs.binary.txt
+    head LPA.w1kbp.pavs.binary.txt | cut -f 1-8 | column -t
+
+.. code-block:: none
+
+    chrom                    start  end   name  chm13__LPA__tig00000001  HG002__LPA__tig00000001  HG002__LPA__tig00000005  HG00733__LPA__tig00000001
+    chm13__LPA__tig00000001  0      1000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  1000   2000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  2000   3000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  3000   4000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  4000   5000  .     1                        0                        0                        0
+    chm13__LPA__tig00000001  5000   6000  .     1                        0                        1                        0
+    chm13__LPA__tig00000001  6000   7000  .     1                        1                        1                        1
+    chm13__LPA__tig00000001  7000   8000  .     1                        1                        1                        1
+    chm13__LPA__tig00000001  8000   9000  .     1                        1                        1                        1
+
+With ``B`` is specified to emit a binary matrix, with 1 if the PAV ratio is greater than or equal to the specified
+threshold (``0.5`` in the example), else 0.
+
+If needed, it is possible to group paths. For this, we need to prepare a file that specifies for each path the group it
+belongs to. In the ``LPA`` pangenome graph, the first part of each path name indicates the sample name. Therefore, to
+prepare such a file, execute:
+
+.. code-block:: bash
+
+    odgi paths -i LPA.og -L > LPA.paths.txt
+    cut -f 1 -d '_' LPA.paths.txt > LPA.samples.txt
+    paste LPA.paths.txt LPA.samples.txt > LPA.path_and_sample.txt
+
+    head LPA.path_and_sample.txt -n 5 | column -t
+
+.. code-block:: none
+
+    chm13__LPA__tig00000001    chm13
+    HG002__LPA__tig00000001    HG002
+    HG002__LPA__tig00000005    HG002
+    HG00733__LPA__tig00000001  HG00733
+    HG00733__LPA__tig00000008  HG00733
+
+Then, to group the PAVs by sample, execute:
+
+.. code-block:: bash
+
+    odgi pav -i LPA.og -b LPA.w1kbp.bed -B 0.5 -p LPA.path_and_sample.txt > LPA.w1kbp.pavs.binary.grouped_by_sample.txt
+
+    head LPA.w1kbp.pavs.binary.grouped_by_sample.txt | column -t
+
+.. code-block:: none
+
+    chrom                    start  end   name  HG002  HG00733  HG01358  HG02572  NA19239  NA19240  chm13
+    chm13__LPA__tig00000001  0      1000  .     0      0        0        1        0        0        1
+    chm13__LPA__tig00000001  1000   2000  .     0      0        0        1        0        0        1
+    chm13__LPA__tig00000001  2000   3000  .     0      0        0        1        0        0        1
+    chm13__LPA__tig00000001  3000   4000  .     0      0        0        1        0        0        1
+    chm13__LPA__tig00000001  4000   5000  .     0      0        0        1        0        0        1
+    chm13__LPA__tig00000001  5000   6000  .     1      0        0        1        0        0        1
+    chm13__LPA__tig00000001  6000   7000  .     1      1        1        1        0        0        1
+    chm13__LPA__tig00000001  7000   8000  .     1      1        1        1        1        0        1
+    chm13__LPA__tig00000001  8000   9000  .     1      1        1        1        1        0        1

--- a/docs/rst/tutorials/untangling_the_pangenome.rst
+++ b/docs/rst/tutorials/untangling_the_pangenome.rst
@@ -1,3 +1,5 @@
+.. _untangling_the_pangenome:
+
 ######################
 Untangling the pangenome
 ######################

--- a/src/algorithms/subgraph/region.cpp
+++ b/src/algorithms/subgraph/region.cpp
@@ -115,7 +115,7 @@ namespace odgi {
                                 end,
                                 false
                             },
-                            (vals.size() > 3 && vals[3] == "-"),
+                            (vals.size() > 5 && vals[5] == "-"),
                             buffer
                         });
             }

--- a/src/algorithms/subgraph/region.cpp
+++ b/src/algorithms/subgraph/region.cpp
@@ -1,7 +1,10 @@
 #include <iostream>
 #include <fstream>
 #include <cassert>
+#include <odgi.hpp>
+#include <position.hpp>
 #include "region.hpp"
+#include "split.hpp"
 
 namespace odgi {
 
@@ -67,5 +70,56 @@ namespace odgi {
         }
     }
 
+    void add_bed_range(std::vector<odgi::path_range_t>& path_ranges,
+                       const odgi::graph_t &graph,
+                       const std::string &buffer) {
+        if (!buffer.empty() && buffer[0] != '#') {
+            const auto vals = split(buffer, '\t');
+            /*
+            if (vals.size() != 3) {
+                std::cerr << "[odgi::add_bed_range] error: path position record is incomplete" << std::endl;
+                std::cerr << "[odgi::add_bed_range] error: got '" << buffer << "'" << std::endl;
+                exit(1);
+            }
+            */
+            const auto &path_name = vals[0];
+            if (!graph.has_path(path_name)) {
+                std::cerr << "[odgi::add_bed_range] error: path " << path_name << " not found in graph" << std::endl;
+                exit(1);
+            } else {
+                const uint64_t start = vals.size() > 1 ? (uint64_t) std::stoi(vals[1]) : 0;
+                uint64_t end = 0;
+                if (vals.size() > 2) {
+                    end = (uint64_t) std::stoi(vals[2]);
+                } else {
+                    // In the BED format, the end is non-inclusive, unlike start
+                    graph.for_each_step_in_path(graph.get_path_handle(path_name), [&](const step_handle_t &s) {
+                        end += graph.get_length(graph.get_handle_of_step(s));
+                    });
+                }
+
+                if (start > end) {
+                    std::cerr << "[odgi::add_bed_range] error: wrong input coordinates in row: " << buffer << std::endl;
+                    exit(1);
+                }
+
+                path_ranges.push_back(
+                        {
+                            {
+                                graph.get_path_handle(path_name),
+                                start,
+                                false
+                            },
+                            {
+                                graph.get_path_handle(path_name),
+                                end,
+                                false
+                            },
+                            (vals.size() > 3 && vals[3] == "-"),
+                            buffer
+                        });
+            }
+        }
+    };
 
 }

--- a/src/algorithms/subgraph/region.cpp
+++ b/src/algorithms/subgraph/region.cpp
@@ -116,6 +116,7 @@ namespace odgi {
                                 false
                             },
                             (vals.size() > 5 && vals[5] == "-"),
+                            vals.size() > 3 ? vals[3] : ".",
                             buffer
                         });
             }

--- a/src/algorithms/subgraph/region.hpp
+++ b/src/algorithms/subgraph/region.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include "position.hpp"
 
 namespace odgi {
 
@@ -36,6 +37,9 @@ namespace odgi {
             std::vector<Region> &out_regions,
             std::vector<std::string> *out_names = nullptr);
 
+    void add_bed_range(std::vector<odgi::path_range_t>& path_ranges,
+                       const odgi::graph_t &graph,
+                       const std::string &buffer);
 }
 
 #endif //ODGI_REGION_H

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -84,6 +84,7 @@ struct path_range_t {
     path_pos_t begin;
     path_pos_t end;
     bool is_rev;
+    std::string name;
     std::string data;
 };
 

--- a/src/subcommand/degree_main.cpp
+++ b/src/subcommand/degree_main.cpp
@@ -2,6 +2,7 @@
 #include "odgi.hpp"
 #include "args.hxx"
 #include "split.hpp"
+#include "subgraph/region.hpp"
 #include <omp.h>
 #include "algorithms/degree.hpp"
 
@@ -216,50 +217,7 @@ int main_degree(int argc, char** argv) {
 		}
 	};
 
-	// TODO refactor this into a file, we are using this in odgi depth, odgi position, ....
-	auto add_bed_range = [&path_ranges](const odgi::graph_t &graph,
-										const std::string &buffer) {
-		if (!buffer.empty() && buffer[0] != '#') {
-			auto vals = split(buffer, '\t');
-			auto &path_name = vals[0];
-			if (!graph.has_path(path_name)) {
-				std::cerr << "[odgi::degree] error: path " << path_name << " not found in graph" << std::endl;
-				exit(1);
-			} else {
-				uint64_t start = vals.size() > 1 ? (uint64_t) std::stoi(vals[1]) : 0;
-				uint64_t end = 0;
-				if (vals.size() > 2) {
-					end = (uint64_t) std::stoi(vals[2]);
-				} else {
-					// In the BED format, the end is non-inclusive, unlike start
-					graph.for_each_step_in_path(graph.get_path_handle(path_name), [&](const step_handle_t &s) {
-						end += graph.get_length(graph.get_handle_of_step(s));
-					});
-				}
 
-				if (start > end) {
-					std::cerr << "[odgi::degree] error: wrong input coordinates in row: " << buffer << std::endl;
-					exit(1);
-				}
-
-				path_ranges.push_back(
-						{
-								{
-										graph.get_path_handle(path_name),
-										start,
-										false
-								},
-								{
-										graph.get_path_handle(path_name),
-										end,
-										false
-								},
-								(vals.size() > 3 && vals[3] == "-"),
-								buffer
-						});
-			}
-		}
-	};
 
 	if (summarize_degree) {
 		// we do nothing here, we iterate over the handles in the graph later, spitting out the information by default
@@ -378,21 +336,21 @@ int main_degree(int argc, char** argv) {
 		std::ifstream bed_in(args::get(bed_input));
 		std::string buffer;
 		while (std::getline(bed_in, buffer)) {
-			add_bed_range(graph, buffer);
+		    add_bed_range(path_ranges, graph, buffer);
 		}
 	} else if (path_name) {
-		add_bed_range(graph, args::get(path_name));
+	    add_bed_range(path_ranges, graph, args::get(path_name));
 	} else if (path_file) {
 		// for thing in things
 		std::ifstream refs(args::get(path_file));
 		std::string line;
 		while (std::getline(refs, line)) {
-			add_bed_range(graph, line);
+		    add_bed_range(path_ranges, graph, line);
 		}
 	} else if (!_windows_in && !_windows_out) {
 		// using all the paths in the graph
 		graph.for_each_path_handle(
-				[&](const path_handle_t &path) { add_bed_range(graph, graph.get_path_name(path)); });
+		        [&](const path_handle_t &path) { add_bed_range(path_ranges, graph, graph.get_path_name(path)); });
 	}
 
 	auto get_graph_pos = [](const odgi::graph_t &graph,

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -229,8 +229,6 @@ namespace odgi {
 
         std::vector<odgi::path_range_t> path_ranges;
 
-
-
         // handle targets from BED
         if (_path_bed_file && !args::get(_path_bed_file).empty()) {
             std::ifstream bed_in(args::get(_path_bed_file));

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -229,63 +229,14 @@ namespace odgi {
 
         std::vector<odgi::path_range_t> path_ranges;
 
-        auto add_bed_range = [&path_ranges](const odgi::graph_t &graph,
-                                            const std::string &buffer) {
-            if (!buffer.empty() && buffer[0] != '#') {
-                const auto vals = split(buffer, '\t');
-                /*
-                if (vals.size() != 3) {
-                    std::cerr << "[odgi::extract] error: path position record is incomplete" << std::endl;
-                    std::cerr << "[odgi::extract] error: got '" << buffer << "'" << std::endl;
-                    exit(1); // bail
-                }
-                */
-                const auto &path_name = vals[0];
-                if (!graph.has_path(path_name)) {
-                    std::cerr << "[odgi::extract] error: path " << path_name << " not found in graph" << std::endl;
-                    exit(1);
-                } else {
-                    uint64_t start = vals.size() > 1 ? (uint64_t) std::stoi(vals[1]) : 0;
-                    uint64_t end = 0;
-                    if (vals.size() > 2) {
-                        end = (uint64_t) std::stoi(vals[2]);
-                    } else {
-                        // In the BED format, the end is non-inclusive, unlike start
-                        graph.for_each_step_in_path(graph.get_path_handle(path_name), [&](const step_handle_t &s) {
-                            end += graph.get_length(graph.get_handle_of_step(s));
-                        });
-                    }
 
-                    if (start > end) {
-                        std::cerr << "[odgi::extract] error: wrong input coordinates in row: " << buffer << std::endl;
-                        exit(1);
-                    }
-
-                    path_ranges.push_back(
-                            {
-                                    {
-                                            graph.get_path_handle(path_name),
-                                            start,
-                                            false
-                                    },
-                                    {
-                                            graph.get_path_handle(path_name),
-                                            end,
-                                            false
-                                    },
-                                    (vals.size() > 3 && vals[3] == "-"),
-                                    buffer
-                            });
-                }
-            }
-        };
 
         // handle targets from BED
         if (_path_bed_file && !args::get(_path_bed_file).empty()) {
             std::ifstream bed_in(args::get(_path_bed_file));
             std::string line;
             while (std::getline(bed_in, line)) {
-                add_bed_range(graph, line);
+                add_bed_range(path_ranges, graph, line);
             }
         }
 
@@ -303,9 +254,9 @@ namespace odgi {
 
             // no coordinates given, we do whole thing (0,-1)
             if (region.start < 0 && region.end < 0) {
-                add_bed_range(graph, region.seq);
+                add_bed_range(path_ranges, graph, region.seq);
             } else {
-                add_bed_range(graph, region.seq + "\t" + std::to_string(region.start) + "\t" + std::to_string(region.end));
+                add_bed_range(path_ranges, graph, region.seq + "\t" + std::to_string(region.start) + "\t" + std::to_string(region.end));
             }
         }
 

--- a/src/subcommand/heaps_main.cpp
+++ b/src/subcommand/heaps_main.cpp
@@ -91,13 +91,14 @@ int main_heaps(int argc, char **argv) {
                 }
                 auto& path_name = vals.front();
                 auto& group = vals.back();
-                if (!graph.has_path(vals.front())) {
+                if (!graph.has_path(path_name)) {
                     std::cerr << "[odgi::heaps] no path '" << path_name << "'" << std::endl;
                     return 1;
                 }
                 path_groups_map[group].push_back(graph.get_path_handle(path_name));
             }
         }
+        refs.close();
         path_groups.reserve(path_groups_map.size());
         for (auto& g : path_groups_map) {
             path_groups.push_back(g.second);

--- a/src/subcommand/pav_main.cpp
+++ b/src/subcommand/pav_main.cpp
@@ -118,6 +118,13 @@ int main_pav(int argc, char **argv) {
         }
         refs.close();
 
+        if (group_2_index.empty()) {
+            std::cerr
+                << "[odgi::pav] error: 0 path groups were read. Please specify at least one path group via -p/--path-groups."
+                << std::endl;
+            return 1;
+        }
+
         uint64_t group_index = 0;
         for (auto& x : group_2_index) {
             x.second = group_index++;
@@ -243,10 +250,13 @@ int main_pav(int argc, char **argv) {
             unordered_set<uint64_t> group_ranks_on_node_handle;
             graph.for_each_step_on_handle(handle, [&](const step_handle_t &source_step) {
                 const auto& path_handle = graph.get_path_handle_of_step(source_step);
-                const uint64_t group_rank = _path_groups ?
-                        group_2_index[path_2_group[path_handle]] :
-                        as_integer(path_handle) - 1;
-                group_ranks_on_node_handle.insert(group_rank);
+                // Check if the paths are grouped and there are paths that do not belong to any group
+                if (!_path_groups || path_2_group.find(path_handle) != path_2_group.end()) {
+                    const uint64_t group_rank = _path_groups ?
+                            group_2_index[path_2_group[path_handle]] :
+                            as_integer(path_handle) - 1;
+                    group_ranks_on_node_handle.insert(group_rank);
+                }
             });
 
             const uint64_t len_handle = graph.get_length(handle);

--- a/src/subcommand/pav_main.cpp
+++ b/src/subcommand/pav_main.cpp
@@ -1,0 +1,191 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include <omp.h>
+#include <position.hpp>
+#include <subgraph/extract.hpp>
+#include "utils.hpp"
+#include "split.hpp"
+#include "subgraph/region.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_pav(int argc, char **argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc - 1; ++i) {
+        argv[i] = argv[i + 1];
+    }
+    const std::string prog_name = "odgi pav";
+    argv[0] = (char *) prog_name.c_str();
+    --argc
+;
+    args::ArgumentParser parser("Presence/absence variants (PAVs).");
+    args::Group mandatory_opts(parser, "[ MANDATORY ARGUMENTS ]");
+    args::ValueFlag<std::string> og_in_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "idx"});
+    args::Group pav_opts(parser, "[ Pav Options ]");
+    args::ValueFlag<std::string> _path_bed_file(pav_opts, "FILE",
+                                                "Find PAVs in the path range(s) specified in the given BED FILE.",
+                                                {'b', "bed-file"});
+    args::ValueFlag<std::string> _path_groups(pav_opts, "FILE", "Group paths as described in two-column FILE, with columns path.name and group.name.",
+                                              {'p', "path-groups"});
+    args::Group threading_opts(parser, "[ Threading ]");
+    args::ValueFlag<uint64_t> nthreads(threading_opts, "N", "Number of threads to use for parallel operations.",
+                                       {'t', "threads"});
+    args::Group processing_info_opts(parser, "[ Processing Information ]");
+    args::Flag debug(processing_info_opts, "debug", "Print information about the process to stderr.", {'d', "debug"});
+    args::Flag _progress(processing_info_opts, "progress", "Write the current progress to stderr.", {'P', "progress"});
+    args::Group program_info_opts(parser, "[ Program Information ]");
+    args::HelpFlag help(program_info_opts, "help", "Print a help message for odgi pav.", {'h', "help"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc == 1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    if (!og_in_file) {
+        std::cerr
+        << "[odgi::pav] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+            << std::endl;
+        return 1;
+    }
+
+    const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+    omp_set_num_threads(num_threads);
+
+    const bool show_progress = args::get(_progress);
+
+    graph_t graph;
+    assert(argc > 0);
+    {
+        const std::string infile = args::get(og_in_file);
+        if (!infile.empty()) {
+            if (infile == "-") {
+                graph.deserialize(std::cin);
+            } else {
+                utils::handle_gfa_odgi_input(infile, "pav", show_progress, num_threads, graph);
+            }
+        }
+    }
+    graph.set_number_of_threads(num_threads);
+
+    std::vector<odgi::path_range_t> path_ranges;
+
+    // handle targets from BED
+    if (_path_bed_file && !args::get(_path_bed_file).empty()) {
+        std::ifstream bed_in(args::get(_path_bed_file));
+        std::string line;
+        while (std::getline(bed_in, line)) {
+            add_bed_range(path_ranges, graph, line);
+        }
+    }
+
+    std::vector<unordered_set<handle_t>> path_range_node_handles;
+    path_range_node_handles.resize(path_ranges.size());
+
+    if (!path_ranges.empty()) {
+        std::unique_ptr<algorithms::progress_meter::ProgressMeter> progress;
+        if (show_progress) {
+            progress = std::make_unique<algorithms::progress_meter::ProgressMeter>(
+                    path_ranges.size(), "[odgi::pav] collect node handles for the path range");
+        }
+        #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
+        for (uint64_t i = 0; i < path_ranges.size(); ++i) {
+            auto &path_range = path_ranges[i];
+
+            algorithms::for_handle_in_path_range(
+                    graph, path_range.begin.path, path_range.begin.offset, path_range.end.offset,
+                    [&](const handle_t& cur_handle) {
+                        path_range_node_handles[i].insert(cur_handle);
+                    });
+            if (show_progress) {
+                progress->increment(1);
+            }
+        }
+        if (show_progress) {
+            progress->finish();
+        }
+    }
+
+    // Prepare all paths for parallelize the next step
+    // todo to support subsets?
+//    std::vector<path_handle_t> paths;
+//    paths.reserve(graph.get_path_count());
+//    graph.for_each_path_handle([&](const path_handle_t path) {
+//        paths.push_back(path);
+//    });
+
+    //todo we are not managing the strandness... should we?
+    //todo we are still managing entire nodes, not chunks
+    std::cout << "chrom" << "\t"
+              << "start" << "\t"
+              << "end";
+    graph.for_each_path_handle([&](const path_handle_t path_handle) {
+        std::cout << graph.get_path_name(path_handle) << "\t";
+    });
+    std::cout << std::endl;
+
+#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
+    for (uint64_t i = 0; i < path_ranges.size(); ++i) {
+        auto &path_range = path_ranges[i];
+
+        uint64_t len_unique_nodes_in_range = 0;
+        std::vector<uint64_t> len_unique_nodes_in_range_each_path(graph.get_path_count(), 0);
+
+        // For each node in the range
+        for (const auto& handle : path_range_node_handles[i]) {
+            // Get paths that cross the node
+            unordered_set<uint64_t> path_handles_on_handle;
+            graph.for_each_step_on_handle(handle, [&](const step_handle_t &source_step) {
+                const auto& path_handle = graph.get_path_handle_of_step(source_step);
+                const uint64_t path_rank = as_integer(path_handle) - 1;
+                path_handles_on_handle.insert(path_rank);
+            });
+
+            const uint64_t len_handle = graph.get_length(handle);
+            for (const auto& path_rank: path_handles_on_handle) {
+                len_unique_nodes_in_range_each_path[path_rank] += len_handle;
+            }
+
+            len_unique_nodes_in_range += len_handle;
+        }
+
+#pragma omp critical (cout)
+        {
+            std::cout << std::setprecision(5)
+                      << graph.get_path_name(path_range.begin.path) << "\t"
+                      << path_range.begin.offset << "\t"
+                      << path_range.end.offset;
+            for (auto& x: len_unique_nodes_in_range_each_path) {
+                std::cout << "\t" << (double) x / (double) len_unique_nodes_in_range;
+            }
+            std::cout << std::endl;
+        }
+
+//        if (path_handle == path_range.begin.path) {
+//            continue; // Skip itself
+//        }
+//#pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
+//        for (uint64_t path_rank = 0; path_rank < paths.size(); ++path_rank) {
+    }
+
+    return 0;
+}
+
+static Subcommand odgi_pav("pav", "Presence/absence variants (PAVs).",
+                             PIPELINE, 3, main_pav);
+
+
+}

--- a/src/subcommand/pav_main.cpp
+++ b/src/subcommand/pav_main.cpp
@@ -204,7 +204,8 @@ int main_pav(int argc, char **argv) {
     //todo we are not managing the strandness... should we?
     std::cout << "chrom" << "\t"
               << "start" << "\t"
-              << "end";
+              << "end" << "\t"
+              << "name";
     if (_path_groups) {
         for (auto& x : group_2_index) {
             std::cout << "\t" << x.first;
@@ -261,7 +262,8 @@ int main_pav(int argc, char **argv) {
                 std::cout << std::setprecision(5)
                 << graph.get_path_name(path_range.begin.path) << "\t"
                 << path_range.begin.offset << "\t"
-                << path_range.end.offset;
+                << path_range.end.offset << "\t"
+                << path_range.name;
                 for (auto& x: len_unique_nodes_in_range_for_each_group) {
                     const double pav_ratio = (double) x / (double) len_unique_nodes_in_range;
                     std::cout << "\t" << (emit_binary_matrix ? pav_ratio >= binary_threshold : pav_ratio);

--- a/src/subcommand/position_main.cpp
+++ b/src/subcommand/position_main.cpp
@@ -3,6 +3,7 @@
 #include "position.hpp"
 #include "args.hxx"
 #include "split.hpp"
+#include "subgraph/region.hpp"
 #include "algorithms/bfs.hpp"
 #include "algorithms/path_jaccard.hpp"
 #include <omp.h>
@@ -298,58 +299,6 @@ int main_position(int argc, char** argv) {
             }
         };
 
-    auto add_bed_range =
-        [&path_ranges](const odgi::graph_t& graph,
-                       const std::string& buffer) {
-            if (!buffer.empty() && buffer[0] != '#') {
-                auto vals = split(buffer, '\t');
-                /*
-                if (vals.size() != 3) {
-                    std::cerr << "[odgi::position] error: path position record is incomplete" << std::endl;
-                    std::cerr << "[odgi::position] error: got '" << buffer << "'" << std::endl;
-                    exit(1); // bail
-                }
-                */
-                auto& path_name = vals[0];
-                if (!graph.has_path(path_name)) {
-                    std::cerr << "[odgi::position] error: ref path " << path_name << " not found in graph" << std::endl;
-                    exit(1);
-                } else {
-                    uint64_t start = vals.size() > 1 ? (uint64_t) std::stoi(vals[1]) : 0;
-                    uint64_t end = 0;
-                    if (vals.size() > 2) {
-                        end = (uint64_t) std::stoi(vals[2]);
-                    } else {
-                        // In the BED format, the end is non-inclusive, unlike start
-                        graph.for_each_step_in_path(graph.get_path_handle(path_name), [&](const step_handle_t &s) {
-                            end += graph.get_length(graph.get_handle_of_step(s));
-                        });
-                    }
-
-                    if (start > end) {
-                        std::cerr << "[odgi::position] error: wrong input coordinates in row: " << buffer << std::endl;
-                        exit(1);
-                    }
-
-                    path_ranges.push_back(
-                            {
-                                    {
-                                            graph.get_path_handle(path_name),
-                                            start,
-                                            false
-                                    },
-                                    {
-                                            graph.get_path_handle(path_name),
-                                            end,
-                                            false
-                                    },
-                                    (vals.size() > 3 && vals[3] == "-"),
-                                    buffer
-                            });
-                }
-            }
-        };
-
 	auto add_gff_range =
 			[&path_ranges](const odgi::graph_t& graph,
 						   const std::string& buffer,
@@ -479,9 +428,9 @@ int main_position(int argc, char** argv) {
 			std::string buffer;
 			while (std::getline(bed_in, buffer)) {
 				if (lifting) {
-					add_bed_range(source_graph, buffer);
+				    add_bed_range(path_ranges, source_graph, buffer);
 				} else {
-					add_bed_range(target_graph, buffer);
+				    add_bed_range(path_ranges, target_graph, buffer);
 				}
 			}
 		}

--- a/src/subcommand/position_main.cpp
+++ b/src/subcommand/position_main.cpp
@@ -378,7 +378,7 @@ int main_position(int argc, char** argv) {
 												end,
 												false
 										},
-										(vals.size() > 5 && vals[6] == "-"),
+										(vals.size() > 6 && vals[6] == "-"),
 										vals[8]
 								});
 					}

--- a/src/subcommand/position_main.cpp
+++ b/src/subcommand/position_main.cpp
@@ -379,6 +379,7 @@ int main_position(int argc, char** argv) {
 												false
 										},
 										(vals.size() > 6 && vals[6] == "-"),
+										vals[8],
 										vals[8]
 								});
 					}

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -44,7 +44,7 @@ int main_stats(int argc, char** argv) {
     //args::Flag path_setcov_count(parser, "setcountcov", "provide a histogram of coverage over counts of unique paths", {'Q', "set-count-coverage"});
     //args::Flag path_multicov(parser, "multicov", "provide a histogram of coverage over unique multisets of paths", {'M', "multi-coverage"});
     //args::Flag path_multicov_count(parser, "multicountcov", "provide a histogram of coverage over counts of paths", {'L', "multi-count-coverage"});
-    //args::ValueFlag<std::string> path_bedmulticov(parser, "BED", "for each BED entry, provide a table of path coverage over unique multisets of paths in the graph. Each unique multiset of paths overlapping a given BED interval is described in terms of its length relative to the total interval, the number of path traversals, and unique paths involved in these traversals.", {'B', "bed-multicov"});
+    args::ValueFlag<std::string> path_bedmulticov(parser, "BED", "for each BED entry, provide a table of path coverage over unique multisets of paths in the graph. Each unique multiset of paths overlapping a given BED interval is described in terms of its length relative to the total interval, the number of path traversals, and unique paths involved in these traversals.", {'B', "bed-multicov"});
     args::ValueFlag<std::string> path_delim(summary_opts, "STRING", "The part of each path name before this delimiter is a group identifier, which when specified will ensure that odgi stats collects the summary information per group and not per path.", {'D', "delim"});
 	args::Flag _file_size(summary_opts, "file-size", "Show the file size in bytes.", {'f', "file-size"});
 	args::ValueFlag<std::string> _pangenome_sequence_class_counts(summary_opts, "DELIM,POS", "Show counted pangenome sequence class counts of all samples. Classes are Private (only one sample visiting the node), Core (all samples visiting the node), and Shell (not Core or Private). The given String determines how to find the sample name in the path names: DELIM,POS. Split the whole path name by DELIM and access the actual sample name at POS of the split result. If the full path name is the sample name, select a DELIM that is not in the path names and set POS to 0. If -m,--multiqc was set, this OPTION has to be set implicitly.", {'a', "pangenome-sequence-class-counts"});
@@ -896,103 +896,103 @@ for (auto& p : multisetcov_count) {
               << p.first << std::endl;
 }
 }
-
+*/
 
 if (!args::get(path_bedmulticov).empty()) {
-std::string line;
-typedef std::map<std::vector<uint64_t>, uint64_t> setcov_t;
-typedef IntervalTree<uint64_t, std::pair<std::string, setcov_t*> > itree_t;
-map<std::string, itree_t::interval_vector> intervals;
-auto& x = args::get(path_bedmulticov);
-std::ifstream bed_in(x);
-while (std::getline(bed_in, line)) {
-    // BED is base-numbered, 0-origin, half-open.  This parse turns that
-    // into base-numbered, 0-origin, fully-closed for internal use.  All
-    // coordinates used internally should be in the latter, and coordinates
-    // from the user in the former should be converted immediately to the
-    // internal format.
-    std::vector<string> fields = split(line, '\t');
-    intervals[fields[0]].push_back(
-        itree_t::interval(
-            std::stoul(fields[1]),
-            std::stoul(fields[2]),
-            make_pair(fields[3], new setcov_t())));
-}
+    std::string line;
+    typedef std::map<std::vector<uint64_t>, uint64_t> setcov_t;
+    typedef IntervalTree<uint64_t, std::pair<std::string, setcov_t*> > itree_t;
+    map<std::string, itree_t::interval_vector> intervals;
+    auto& x = args::get(path_bedmulticov);
+    std::ifstream bed_in(x);
+    while (std::getline(bed_in, line)) {
+        // BED is base-numbered, 0-origin, half-open.  This parse turns that
+        // into base-numbered, 0-origin, fully-closed for internal use.  All
+        // coordinates used internally should be in the latter, and coordinates
+        // from the user in the former should be converted immediately to the
+        // internal format.
+        std::vector<string> fields = split(line, '\t');
+        intervals[fields[0]].push_back(
+            itree_t::interval(
+                std::stoul(fields[1]),
+                std::stoul(fields[2]),
+                make_pair(fields[3], new setcov_t())));
+    }
 
-std::vector<std::string> path_names;
-path_names.reserve(intervals.size());
-for(auto const& i : intervals) {
-    path_names.push_back(i.first);
-}
+    std::vector<std::string> path_names;
+    path_names.reserve(intervals.size());
+    for(auto const& i : intervals) {
+        path_names.push_back(i.first);
+    }
 
-// the header
-std::cout << "path.name" << "\t"
-          << "bed.name" << "\t"
-          << "bed.start" << "\t"
-          << "bed.stop" << "\t"
-          << "bed.len" << "\t"
-          << "path.set.state.len" << "\t"
-          << "path.set.frac" << "\t"
-          << "path.traversals" << "\t"
-          << "uniq.paths.in.state" << "\t"
-          << "path.multiset" << std::endl;
+    // the header
+    std::cout << "path.name" << "\t"
+              << "bed.name" << "\t"
+              << "bed.start" << "\t"
+              << "bed.stop" << "\t"
+              << "bed.len" << "\t"
+              << "path.set.state.len" << "\t"
+              << "path.set.frac" << "\t"
+              << "path.traversals" << "\t"
+              << "uniq.paths.in.state" << "\t"
+              << "path.multiset" << std::endl;
 
-#pragma omp parallel for
-for (uint64_t k = 0; k < path_names.size(); ++k) {
-    auto& path_name = path_names.at(k);
-    auto& path_ivals = intervals[path_name];
-    path_handle_t path = graph.get_path_handle(path_name);
-    // build the intervals for each path we'll query
-    itree_t itree(std::move(path_ivals)); //, 16, 1);
-    uint64_t pos = 0;
-    graph.for_each_step_in_path(graph.get_path_handle(x), [&](const step_handle_t& occ) {
-            std::vector<uint64_t> paths_here;
-            handle_t h = graph.get_handle_of_step(occ);
-            graph.for_each_step_on_handle(
-                h,
-                [&](const step_handle_t& occ) {
-                    paths_here.push_back(get_path_id(graph.get_path(occ)));
-                });
-            uint64_t len = graph.get_length(h);
-            // check each position in the node
-            auto hits = itree.findOverlapping(pos, pos+len);
-            if (hits.size()) {
-                for (auto& h : hits) {
-                    auto& q = *h.value.second;
-                    // adjust length for overlap length
-                    uint64_t ovlp = len - (h.start > pos ? h.start - pos : 0) - (h.stop < pos+len ? pos+len - h.stop : 0);
-                    q[paths_here] += ovlp;
-                }
-            }
-            pos += len;
-        });
-    itree.visit_all([&](const itree_t::interval& ival) {
-            auto& name = ival.value.first;
-            auto& setcov = *ival.value.second;
-            for (auto& p : setcov) {
-                std::set<uint64_t> u(p.first.begin(), p.first.end());
-#pragma omp critical (cout)
-                {
-                    std::cout << path_name << "\t" << name << "\t" << ival.start << "\t" << ival.stop << "\t"
-                              << ival.stop - ival.start << "\t"
-                              << p.second << "\t"
-                              << (float)p.second/(ival.stop-ival.start) << "\t"
-                              << p.first.size() << "\t"
-                              << u.size() << "\t";
-                    bool first = true;
-                    for (auto& i : p.first) {
-                        std::cout << (first ? (first=false, "") :",") << get_path_name(i);
+    #pragma omp parallel for
+    for (uint64_t k = 0; k < path_names.size(); ++k) {
+        auto& path_name = path_names.at(k);
+        auto& path_ivals = intervals[path_name];
+        path_handle_t path = graph.get_path_handle(path_name);
+        // build the intervals for each path we'll query
+        itree_t itree(std::move(path_ivals)); //, 16, 1);
+        uint64_t pos = 0;
+        graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+                std::vector<uint64_t> paths_here;
+                handle_t h = graph.get_handle_of_step(occ);
+                graph.for_each_step_on_handle(
+                    h,
+                    [&](const step_handle_t& occ) {
+                        paths_here.push_back(get_path_id(graph.get_path(occ)));
+                    });
+                uint64_t len = graph.get_length(h);
+                // check each position in the node
+                auto hits = itree.findOverlapping(pos, pos+len);
+                if (hits.size()) {
+                    for (auto& h : hits) {
+                        auto& q = *h.value.second;
+                        // adjust length for overlap length
+                        uint64_t ovlp = len - (h.start > pos ? h.start - pos : 0) - (h.stop < pos+len ? pos+len - h.stop : 0);
+                        q[paths_here] += ovlp;
                     }
-                    std::cout << std::endl;
                 }
-            }
-    });
-    for (auto& ival : path_ivals) {
-        delete ival.value.second;
+                pos += len;
+            });
+        itree.visit_all([&](const itree_t::interval& ival) {
+                auto& name = ival.value.first;
+                auto& setcov = *ival.value.second;
+                for (auto& p : setcov) {
+                    std::set<uint64_t> u(p.first.begin(), p.first.end());
+    #pragma omp critical (cout)
+                    {
+                        std::cout << path_name << "\t" << name << "\t" << ival.start << "\t" << ival.stop << "\t"
+                                  << ival.stop - ival.start << "\t"
+                                  << p.second << "\t"
+                                  << (float)p.second/(ival.stop-ival.start) << "\t"
+                                  << p.first.size() << "\t"
+                                  << u.size() << "\t";
+                        bool first = true;
+                        for (auto& i : p.first) {
+                            std::cout << (first ? (first=false, "") :",") << get_path_name(i);
+                        }
+                        std::cout << std::endl;
+                    }
+                }
+        });
+        for (auto& ival : path_ivals) {
+            delete ival.value.second;
+        }
     }
 }
-}
-*/
+
 
     return 0;
 }


### PR DESCRIPTION
Given the target regions in the input BED file, for each BED range and each path in the graph, the command currently returns the ratio `#bases covered by the path in the range / #bases covered by the target path in the range`.

It takes ~6.23GB and ~9 seconds on a ~5.4 ODGI graph (HPRC chr6 pangenome) to query 10449 BED ranges (all with respect to the `grch38#chr6` path).

```
odgi pav -i chr6.pan.fa.a2fb268.4030258.6a1ecc2.smooth.og -b hg38.chr6.bed -t 1 | head | cut -f 1-10 |  column -t

chrom        start   end     chm13#chr6  grch38#chr6  HG00438#2#JAHBCA010000010.1  HG00438#2#JAHBCA010000042.1  HG00438#2#JAHBCA010000061.1  HG00438#2#JAHBCA010000090.1  HG00438#2#JAHBCA010000098.1
grch38#chr6  292540  292560  1           1            0                            1                            0                            0                            0
grch38#chr6  304628  304661  1           1            0                            1                            0                            0                            0
grch38#chr6  311880  311962  1           1            0                            1                            0                            0                            0
grch38#chr6  324775  326826  0.99854     1            0                            0.98018                      0                            0                            0
grch38#chr6  335114  335163  1           1            0                            1                            0                            0                            0
grch38#chr6  338074  338081  1           1            0                            1                            0                            0                            0
grch38#chr6  345854  345928  1           1            0                            1                            0                            0                            0
grch38#chr6  348103  348274  1           1            0                            1                            0                            0                            0
grch38#chr6  348769  348948  1           1            0                            1                            0                            0                            0
```