### PR TITLE
Interval Heaps' law

### DIFF
--- a/scripts/heaps_fit.R
+++ b/scripts/heaps_fit.R
@@ -2,10 +2,11 @@
 
 require(tidyverse)
 
-objectFun <- function(p, x, y){                                                                                                                      
-  y.hat <- p[1] * x^(p[2])
-  J <- sqrt(sum((y - y.hat)^2))/length(x)
-  return(J)
+objectFun <- function(p, x, y){
+    y.hat <- p[1] * x^(p[2])
+    #J <- sqrt(sum((y - y.hat)^2))/length(x)
+    J <- sum((y - y.hat)^2) # sum of squared error
+    return(J)
 }
 
 # ENABLE command line arguments

--- a/src/algorithms/heaps.cpp
+++ b/src/algorithms/heaps.cpp
@@ -6,8 +6,10 @@ namespace algorithms {
 
 void for_each_heap_permutation(const PathHandleGraph& graph,
                                const std::vector<std::vector<path_handle_t>>& path_groups,
+                               const ska::flat_hash_map<path_handle_t, std::vector<interval_t>>& path_intervals,
                                uint64_t n_permutations,
                                const std::function<void(const std::vector<uint64_t>&, uint64_t)>& func) {
+    //const std::function<bool(const path_handle_t&, _t)>& in_range) {
     //std::vector<std::vector<path_handle_t>>
     auto get_permutation = [&](void) {
         std::random_device rd;
@@ -30,6 +32,47 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
         }
     });
 
+    // which nodes are traversed by our target paths?
+    atomicbitvector::atomic_bv_t target_nodes(graph.get_node_count() + 1);
+
+    if (path_intervals.size() == 0) {
+        // keep everything if we aren't given intervals to guide subset
+        for (uint64_t i = 0; i < graph.get_node_count(); ++i) {
+            target_nodes.set(i, false);
+        }
+    } else {
+        std::vector<path_handle_t> paths;
+        graph.for_each_path_handle([&](const path_handle_t& path) {
+            paths.push_back(path);
+        });
+#pragma omp parallel for
+        for (auto& path : paths) {
+            if (path_intervals.find(path) != path_intervals.end()) {
+                auto& intervals = path_intervals.find(path)->second;
+                auto ival = intervals.begin();
+                std::set<uint64_t> interval_ends;
+                uint64_t pos = 0;
+                graph.for_each_step_in_path(
+                    path,
+                    [&](const step_handle_t& step) {
+                        while (interval_ends.size()
+                               && *interval_ends.begin() < pos) {
+                            interval_ends.erase(interval_ends.begin());
+                        }
+                        while (ival->first >= pos) {
+                            interval_ends.insert(ival->second);
+                        }
+                        auto h = graph.get_handle_of_step(step);
+                        uint64_t rank = graph.get_id(h)-1; // assumes compaction!
+                        if (interval_ends.size()) {
+                            target_nodes.set(rank, true);
+                        }
+                        pos += graph.get_length(h);
+                    });
+            }
+        }
+    }
+
 #pragma omp parallel for
     for (uint64_t i = 0; i < n_permutations; ++i) {
         auto permutation = get_permutation();
@@ -40,21 +83,24 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
         for (auto& j : permutation) {
             auto& paths = path_groups[j];
             for (auto& path : paths) {
+                uint64_t pos = 0;
                 graph.for_each_step_in_path(
                     path,
                     [&](const step_handle_t& step) {
                         auto h = graph.get_handle_of_step(step);
                         uint64_t rank = graph.get_id(h)-1; // assumes compaction!
-                        if (!seen_nodes[rank]) {
+                        if (target_nodes[rank] && !seen_nodes[rank]) {
                             seen_nodes[rank] = 1;
                             seen_bp += graph.get_length(h);
                         }
+                        pos += graph.get_length(h);
                     });
             }
             vals.push_back(seen_bp);
         }
         func(vals, i);
     }
+
 }
 
 }

--- a/src/algorithms/heaps.hpp
+++ b/src/algorithms/heaps.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <vector>
 #include <map>
+#include <set>
 #include <algorithm>
 #include <random>
 #include <omp.h>
@@ -13,6 +14,7 @@
 #include <handlegraph/util.hpp>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
+#include <atomic_bitvector.hpp>
 
 namespace odgi {
 
@@ -20,10 +22,13 @@ using namespace handlegraph;
 
 namespace algorithms {
 
+typedef std::pair<uint64_t, uint64_t> interval_t;
+
 /// For each permutation of the path groups
 /// we call func with a vector that is the fraction of the pangenome covered when we've considered N groups in the permutation
 void for_each_heap_permutation(const PathHandleGraph& graph,
                                const std::vector<std::vector<path_handle_t>>& path_groups,
+                               const ska::flat_hash_map<path_handle_t, std::vector<interval_t>>& path_intervals,
                                uint64_t n_permutations,
                                const std::function<void(const std::vector<uint64_t>&, uint64_t)>& func);
 

--- a/src/subcommand/heaps_main.cpp
+++ b/src/subcommand/heaps_main.cpp
@@ -115,7 +115,9 @@ int main_heaps(int argc, char **argv) {
             std::cout << perm_id << "\t" << ++i << "\t" << v << std::endl;
         }
     };
-    algorithms::for_each_heap_permutation(graph, path_groups, n_permutations, handle_output);
+    ska::flat_hash_map<path_handle_t, std::vector<algorithms::interval_t>> x;
+    
+    algorithms::for_each_heap_permutation(graph, path_groups, x, n_permutations, handle_output);
 
     return 0;
 }


### PR DESCRIPTION
Compute cumulative coverage of the pangenome with permutations. These can be used to make a fit for an exponential distribution, the exponent of which describes pangenome diversity. The ultimate fit and parameter estimates are done with the script `heaps_fit.R`.