### PR TITLE
`odgi sort`: optimize the graph ASAP + tweaks + documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The edges and path steps are recorded as deltas between the current node id and 
 Graphs built from biological data sets tend to have local partial order and, when sorted, the deltas be small.
 This allows them to be compressed with a variable length integer representation, resulting in a small in-memory footprint at the cost of packing and unpacking.
 
-The RAM and computational savings are substantial.  In partially ordered regions of the graph, most deltas will require only a single byte.
+The RAM and computational savings are substantial. In partially ordered regions of the graph, most deltas will require only a single byte.
 
 ## installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,13 @@ sys.path.insert(0, os.path.abspath('../lib/'))
 # -- Project information -----------------------------------------------------
 
 project = u'odgi'
-copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision v0.6.3-838d607'
-author = u'Andrea Guarracino, Simon Heumos, ... , Pjotr Prins, Erik Garrison'
+copyright = '2021, Guarracino A., Heumos S., Nahnsen S., Prins P., Garrison E. Revision v0.6.3-305f069'
+author = u'Andrea Guarracino, Simon Heumos, Sven Nahnsen , Pjotr Prins, Erik Garrison'
 
 # The short X.Y version
 version = 'v0.6.3'
 # The full version, including alpha/beta/rc tags
-release = '838d607'
+release = '305f069'
 
 
 # -- General configuration ---------------------------------------------------
@@ -156,6 +156,8 @@ man_pages = [
     ('man/odgi_pav', 'odgi_pav', u'Presence/absence variants (PAVs).',
      [AG], 1),
     ('man/odgi_degree', 'odgi_degree', u'Describe the graph in terms of node degree.',
+     [EG], 1),
+    ('man/odgi_heaps', 'odgi_heaps', u'Path pangenome coverage permutations.',
      [EG], 1),
     ('man/odgi_depth', 'odgi_depth', u'Find the depth of a graph as defined by query criteria. Without specifying any '
                                      u'non-mandatory options, it prints in a tab-delimited format path, start, end, '

--- a/docs/rst/commands.rst
+++ b/docs/rst/commands.rst
@@ -18,6 +18,7 @@ Commands
     commands/odgi_extract
     commands/odgi_flatten
     commands/odgi_groom
+    commands/odgi_heaps
     commands/odgi_kmers
     commands/odgi_layout
     commands/odgi_matrix

--- a/docs/rst/commands/odgi.rst
+++ b/docs/rst/commands/odgi.rst
@@ -33,8 +33,9 @@ coords.lay -p .png -x 1920 -y 1080 -R -t 28
 
 :ref:`odgi flatten` -i graph.og -f FASTA.fa -b BED.tsv
 
-:ref:`odgi groom` -i graph.og -o
-graph.groomed.og
+:ref:`odgi groom` -i graph.og -o graph.groomed.og
+
+:ref:`odgi heaps` -i graph.og
 
 :ref:`odgi kmers` -i graph.og -c -k 23
 -e 34 -D 50
@@ -55,6 +56,8 @@ Chr1 -n 4
 :ref:`odgi pathindex` -i graph.og -o graph.xp
 
 :ref:`odgi paths` -i graph.og -f
+
+:ref:`odgi pav` -i graph.og -b bed.bed
 
 :ref:`odgi position` -i
 target_graph.og -g
@@ -400,7 +403,7 @@ AUTHORS
 Erik Garrison from the University of Tennessee wrote the
 whole **odgi** tool suite.
 
-Andrea Guarracino from the Human Technopole wrote **odgi viz**, **odgi extract**, **odgi explode**, **odgi squeeze**,
+Andrea Guarracino from the Human Technopole wrote **odgi viz**, **odgi extract**, **odgi pav**, **odgi explode**, **odgi squeeze**,
 **odgi untangle**, **odgi position**, **odgi cover**, **odgi sort**, **odgi groom**, **odgi layout**, **odgi chop**,
 **odgi unchop**, **odgi depth**, **odgi degree**, **odgi stats**, **odgi overlap**, **odgi validate**, **odgi test**,
 and this documentation.

--- a/docs/rst/commands/odgi_heaps.rst
+++ b/docs/rst/commands/odgi_heaps.rst
@@ -1,0 +1,79 @@
+.. _odgi heaps:
+
+#########
+odgi heaps
+#########
+
+Path pangenome coverage permutations.
+
+SYNOPSIS
+========
+
+**odgi heaps** [**-i, --idx**\ =\ *FILE*] [*OPTION*]…
+
+DESCRIPTION
+===========
+
+Extract matrix of path pangenome coverage permutations for power law regression.
+
+OPTIONS
+=======
+
+MANDATORY OPTIONS
+--------------
+
+| **-i, --idx**\ =\ *FILE*
+| Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!
+
+Pav Options
+---------------
+
+| **-p, --path-groups**\ =\ *FILE*
+| Group paths as described in two-column *FILE*, with columns `path.name` and `group.name`.
+
+| **-S, --group-by-sample**
+| Following `PanSN <https://github.com/pangenome/PanSN-spec>`_ naming (`sample#hap#ctg`), group by sample (1st field).
+
+| **-H, --group-by-haplotype**
+| Following `PanSN <https://github.com/pangenome/PanSN-spec>`_ naming (`sample#hap#ctg`), group by haplotype (2nd field).
+
+| **-b, --bed-targets**\ =\ *FILE*
+| BED file over path space of the graph, describing a subset of the graph to consider.
+
+| **-n, --n-permutations**\ =\ *N*
+| Number of permutations to run.
+
+Threading
+---------
+
+| **-t, --threads**\ =\ *N*
+| Number of threads to use for parallel operations.
+
+Processing Information
+----------------------
+
+| **-P, --progress**
+| Print information about the components and the progress to stderr.
+
+Program Information
+-------------------
+
+| **-h, --help**
+| Print a help message for **odgi pav**.
+
+..
+	EXIT STATUS
+	===========
+	
+	| **0**
+	| Success.
+	
+	| **1**
+	| Failure (syntax or usage error; parameter error; file processing
+	  failure; unexpected error).
+	
+	BUGS
+	====
+	
+	Refer to the **odgi** issue tracker at
+	https://github.com/pangenome/odgi/issues.

--- a/docs/scripts/gen_copy-right_version_release.sh
+++ b/docs/scripts/gen_copy-right_version_release.sh
@@ -9,4 +9,4 @@ COMMIT=$(git describe --always)
 
 sed -i ""$VERSION_LINE_NMBR"s/.*/version = '"$TAG"'/" conf.py
 sed -i ""$RELEASE_LINE_NMBR"s/.*/release = '"$COMMIT"'/" conf.py
-sed -i ""$COPYRIGHT_LINE_NMBR"s/.*/copyright = '2021, Simon Heumos, Andrea Guarracino, Erik Garrison. Revision "$TAG"-"$COMMIT"'/" conf.py
+sed -i ""$COPYRIGHT_LINE_NMBR"s/.*/copyright = '2021, Guarracino A., Heumos S., Nahnsen S., Prins P., Garrison E. Revision "$TAG"-"$COMMIT"'/" conf.py

--- a/src/subcommand/heaps_main.cpp
+++ b/src/subcommand/heaps_main.cpp
@@ -36,7 +36,7 @@ int main_heaps(int argc, char **argv) {
     args::ValueFlag<uint64_t> nthreads(threading_opts, "N", "Number of threads to use for parallel operations.",
                                        {'t', "threads"});
     args::Group processing_info_opts(parser, "[ Processing Information ]");
-    args::Flag debug(processing_info_opts, "debug", "Print information about the process to stderr.", {'d', "debug"});
+    //args::Flag debug(processing_info_opts, "debug", "Print information about the process to stderr.", {'d', "debug"});
     args::Flag progress(processing_info_opts, "progress", "Write the current progress to stderr.", {'P', "progress"});
     args::Group program_info_opts(parser, "[ Program Information ]");
     args::HelpFlag help(program_info_opts, "help", "Print a help message for odgi heaps.", {'h', "help"});

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -310,164 +310,158 @@ int main_sort(int argc, char** argv) {
         path_sgd_max_eta = args::get(p_sgd_eta_max) ? args::get(p_sgd_eta_max) : max_path_step_count * max_path_step_count;
     }
 
-    // helper, TODO: move into its own file
-
     // did we groom the graph?
-    const std::string outfile = args::get(dg_out_file);
-    if (!outfile.empty()) {
-        if (args::get(two)) {
-            graph.apply_ordering(algorithms::two_way_topological_order(&graph), true);
-        } else if (args::get(optimize)) {
-            graph.optimize();
-        } else if (!args::get(sort_order_in).empty()) {
-            std::vector<handle_t> given_order;
-            std::string buf;
-            std::ifstream in_order(args::get(sort_order_in).c_str());
-            while (std::getline(in_order, buf)) {
-                given_order.push_back(graph.get_handle(std::stol(buf)));
+    if (!args::get(pipeline).empty()) {
+        // for each sort type, apply it to the graph
+        std::vector<handle_t> order;
+        for (auto c : args::get(pipeline)) {
+            switch (c) {
+                case 's':
+                    order = algorithms::topological_order(&graph, true, false, args::get(progress));
+                    break;
+                case 'n':
+                    order = algorithms::topological_order(&graph, false, false, args::get(progress));
+                    break;
+                case 'd': {
+                    graph_t split, into;
+                    order = algorithms::dagify_sort(graph, split, into);
+                }
+                    break;
+                case 'c':
+                    order = algorithms::cycle_breaking_sort(graph);
+                    break;
+                case 'b':
+                    order = algorithms::breadth_first_topological_order(graph, bf_chunk_size);
+                    break;
+                case 'z':
+                    order = algorithms::depth_first_topological_order(graph, df_chunk_size);
+                    break;
+                case 'w':
+                    order = algorithms::two_way_topological_order(&graph);
+                    break;
+                case 'r':
+                    order = algorithms::random_order(graph);
+                    break;
+                case 'Y': {
+                    if (!fresh_path_index) {
+                        path_index.clean();
+                        path_index.from_handle_graph(graph, num_threads);
+                    }
+                    order = algorithms::path_linear_sgd_order(graph,
+                                                              path_index,
+                                                              path_sgd_use_paths,
+                                                              path_sgd_iter_max,
+                                                              path_sgd_iter_max_learning_rate,
+                                                              path_sgd_min_term_updates,
+                                                              path_sgd_delta,
+                                                              path_sgd_eps,
+                                                              path_sgd_max_eta,
+                                                              path_sgd_zipf_theta,
+                                                              path_sgd_zipf_space,
+                                                              path_sgd_zipf_space_max,
+                                                              path_sgd_zipf_space_quantization_step,
+                                                              path_sgd_cooling,
+                                                              num_threads,
+                                                              progress,
+                                                              path_sgd_seed,
+                                                              snapshot,
+                                                              snapshot_prefix);
+                    break;
+                }
+                case 'f':
+                    order.clear();
+                    graph.for_each_handle([&order](const handle_t &handle) {
+                        order.push_back(handle);
+                    });
+                    std::reverse(order.begin(), order.end());
+                    break;
+                case 'g': {
+                    order = algorithms::groom(graph, progress);
+                    break;
+                }
+                default:
+                    break;
             }
-            graph.apply_ordering(given_order, true);
-        } else if (args::get(dagify)) {
-            graph_t split, into;
-            graph.apply_ordering(algorithms::dagify_sort(graph, split, into), true);
-        } else if (args::get(cycle_breaking)) {
-            graph.apply_ordering(algorithms::cycle_breaking_sort(graph), true);
-        } else if (args::get(no_seeds)) {
-            graph.apply_ordering(algorithms::topological_order(&graph, false, false, args::get(progress)), true);
-        } else if (args::get(p_sgd)) {
-            std::vector<handle_t> order =
-                    algorithms::path_linear_sgd_order(graph,
-                                                      path_index,
-                                                      path_sgd_use_paths,
-                                                      path_sgd_iter_max,
-                                                      path_sgd_iter_max_learning_rate,
-                                                      path_sgd_min_term_updates,
-                                                      path_sgd_delta,
-                                                      path_sgd_eps,
-                                                      path_sgd_max_eta,
-                                                      path_sgd_zipf_theta,
-                                                      path_sgd_zipf_space,
-                                                      path_sgd_zipf_space_max,
-                                                      path_sgd_zipf_space_quantization_step,
-                                                      path_sgd_cooling,
-                                                      num_threads,
-                                                      progress,
-                                                      path_sgd_seed,
-                                                      snapshot,
-                                                      snapshot_prefix);
+            if (order.size() != graph.get_node_count()) {
+                std::cerr << "[odgi::sort] error: expected " << graph.get_node_count()
+                          << " handles in the order "
+                          << "but got " << order.size() << std::endl;
+                assert(false);
+            }
             graph.apply_ordering(order, true);
-        } else if (args::get(breadth_first)) {
-            graph.apply_ordering(algorithms::breadth_first_topological_order(graph, bf_chunk_size), true);
-        } else if (args::get(depth_first)) {
-            graph.apply_ordering(algorithms::depth_first_topological_order(graph, df_chunk_size), true);
-        } else if (args::get(randomize)) {
-            graph.apply_ordering(algorithms::random_order(graph), true);
-        } else if (!args::get(pipeline).empty()) {
-            // for each sort type, apply it to the graph
-            std::vector<handle_t> order;
-            for (auto c : args::get(pipeline)) {
-                switch (c) {
-                    case 's':
-                        order = algorithms::topological_order(&graph, true, false, args::get(progress));
-                        break;
-                    case 'n':
-                        order = algorithms::topological_order(&graph, false, false, args::get(progress));
-                        break;
-                    case 'd': {
-                        graph_t split, into;
-                        order = algorithms::dagify_sort(graph, split, into);
-                    }
-                        break;
-                    case 'c':
-                        order = algorithms::cycle_breaking_sort(graph);
-                        break;
-                    case 'b':
-                        order = algorithms::breadth_first_topological_order(graph, bf_chunk_size);
-                        break;
-                    case 'z':
-                        order = algorithms::depth_first_topological_order(graph, df_chunk_size);
-                        break;
-                    case 'w':
-                        order = algorithms::two_way_topological_order(&graph);
-                        break;
-                    case 'r':
-                        order = algorithms::random_order(graph);
-                        break;
-                    case 'Y': {
-                        if (!fresh_path_index) {
-                            path_index.clean();
-                            path_index.from_handle_graph(graph, num_threads);
-                        }
-                        order = algorithms::path_linear_sgd_order(graph,
-                                                                  path_index,
-                                                                  path_sgd_use_paths,
-                                                                  path_sgd_iter_max,
-                                                                  path_sgd_iter_max_learning_rate,
-                                                                  path_sgd_min_term_updates,
-                                                                  path_sgd_delta,
-                                                                  path_sgd_eps,
-                                                                  path_sgd_max_eta,
-                                                                  path_sgd_zipf_theta,
-                                                                  path_sgd_zipf_space,
-                                                                  path_sgd_zipf_space_max,
-                                                                  path_sgd_zipf_space_quantization_step,
-                                                                  path_sgd_cooling,
-                                                                  num_threads,
-                                                                  progress,
-                                                                  path_sgd_seed,
-                                                                  snapshot,
-                                                                  snapshot_prefix);
-                        break;
-                    }
-                    case 'f':
-                        order.clear();
-                        graph.for_each_handle([&order](const handle_t &handle) {
-                            order.push_back(handle);
-                        });
-                        std::reverse(order.begin(), order.end());
-                        break;
-                    case 'g': {
-                        order = algorithms::groom(graph, progress);
-                        break;
-                    }
-                    default:
-                        break;
-                }
-                if (order.size() != graph.get_node_count()) {
-                    std::cerr << "[odgi::sort] error: expected " << graph.get_node_count()
-                              << " handles in the order "
-                              << "but got " << order.size() << std::endl;
-                    assert(false);
-                }
-                graph.apply_ordering(order, true);
-                fresh_path_index = false;
-            }
-        } else {
-            graph.apply_ordering(algorithms::topological_order(&graph, true, false, args::get(progress)), true);
+            fresh_path_index = false;
         }
-        if (args::get(paths_by_min_node_id)) {
-            graph.apply_path_ordering(
-                    algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), false, false));
+    } else if (args::get(two)) {
+        graph.apply_ordering(algorithms::two_way_topological_order(&graph), true);
+    } else if (!args::get(sort_order_in).empty()) {
+        std::vector<handle_t> given_order;
+        std::string buf;
+        std::ifstream in_order(args::get(sort_order_in).c_str());
+        while (std::getline(in_order, buf)) {
+            given_order.push_back(graph.get_handle(std::stol(buf)));
         }
-        if (args::get(paths_by_max_node_id)) {
-            graph.apply_path_ordering(
-                    algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), false, true));
-        }
-        if (args::get(paths_by_avg_node_id)) {
-            graph.apply_path_ordering(
-                    algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), true, false));
-        }
-        if (args::get(paths_by_avg_node_id_rev)) {
-            graph.apply_path_ordering(
-                    algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), true, true));
-        }
-        if (outfile == "-") {
-            graph.serialize(std::cout);
-        } else {
-            ofstream f(outfile.c_str());
-            graph.serialize(f);
-            f.close();
-        }
+        graph.apply_ordering(given_order, true);
+    } else if (args::get(dagify)) {
+        graph_t split, into;
+        graph.apply_ordering(algorithms::dagify_sort(graph, split, into), true);
+    } else if (args::get(cycle_breaking)) {
+        graph.apply_ordering(algorithms::cycle_breaking_sort(graph), true);
+    } else if (args::get(no_seeds)) {
+        graph.apply_ordering(algorithms::topological_order(&graph, false, false, args::get(progress)), true);
+    } else if (args::get(p_sgd)) {
+        std::vector<handle_t> order =
+                algorithms::path_linear_sgd_order(graph,
+                                                  path_index,
+                                                  path_sgd_use_paths,
+                                                  path_sgd_iter_max,
+                                                  path_sgd_iter_max_learning_rate,
+                                                  path_sgd_min_term_updates,
+                                                  path_sgd_delta,
+                                                  path_sgd_eps,
+                                                  path_sgd_max_eta,
+                                                  path_sgd_zipf_theta,
+                                                  path_sgd_zipf_space,
+                                                  path_sgd_zipf_space_max,
+                                                  path_sgd_zipf_space_quantization_step,
+                                                  path_sgd_cooling,
+                                                  num_threads,
+                                                  progress,
+                                                  path_sgd_seed,
+                                                  snapshot,
+                                                  snapshot_prefix);
+        graph.apply_ordering(order, true);
+    } else if (args::get(breadth_first)) {
+        graph.apply_ordering(algorithms::breadth_first_topological_order(graph, bf_chunk_size), true);
+    } else if (args::get(depth_first)) {
+        graph.apply_ordering(algorithms::depth_first_topological_order(graph, df_chunk_size), true);
+    } else if (args::get(randomize)) {
+        graph.apply_ordering(algorithms::random_order(graph), true);
+    } else {
+        graph.apply_ordering(algorithms::topological_order(&graph, true, false, args::get(progress)), true);
+    }
+    if (args::get(paths_by_min_node_id)) {
+        graph.apply_path_ordering(
+                algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), false, false));
+    }
+    if (args::get(paths_by_max_node_id)) {
+        graph.apply_path_ordering(
+                algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), false, true));
+    }
+    if (args::get(paths_by_avg_node_id)) {
+        graph.apply_path_ordering(
+                algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), true, false));
+    }
+    if (args::get(paths_by_avg_node_id_rev)) {
+        graph.apply_path_ordering(
+                algorithms::prefix_and_id_ordered_paths(graph, args::get(path_delim), true, true));
+    }
+    const std::string outfile = args::get(dg_out_file);
+    if (outfile == "-") {
+        graph.serialize(std::cout);
+    } else {
+        ofstream f(outfile.c_str());
+        graph.serialize(f);
+        f.close();
     }
     return 0;
 }

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -133,7 +133,7 @@ int main_sort(int argc, char** argv) {
         return 1;
     }
 
-    if (!dg_out_file) {
+    if (!dg_out_file || args::get(dg_out_file).empty()) {
         std::cerr << "[odgi::sort] error: please specify an output file to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
@@ -210,6 +210,12 @@ int main_sort(int argc, char** argv) {
                      "Please either use -G=[N], path-sgd-min-term-updates-paths=[N] or -U=[N], path-sgd-min-term-updates-nodes=[N]." << std::endl;
         return 1;
     }
+
+    // If required, first of all, optimize the graph so that it is optimized for subsequent algorithms (if required)
+    if (args::get(optimize)) {
+        graph.optimize();
+    }
+
     uint64_t path_sgd_iter_max = args::get(p_sgd_iter_max) ? args::get(p_sgd_iter_max) : 100;
     uint64_t path_sgd_iter_max_learning_rate = args::get(p_sgd_iter_with_max_learning_rate) ? args::get(p_sgd_iter_with_max_learning_rate) : 0;
     double path_sgd_zipf_theta = args::get(p_sgd_zipf_theta) ? args::get(p_sgd_zipf_theta) : 0.99;


### PR DESCRIPTION
This avoids having to optimize the graph in an `odgi` call and sort in another.

`odgi sort -i - -o - -O -p Ygs` instead of `odgi sort -i - -o - -O | odgi sort -i - -o - -p Ygs`