### PR TITLE
Heaps depth min

### DIFF
--- a/docs/rst/commands/odgi_heaps.rst
+++ b/docs/rst/commands/odgi_heaps.rst
@@ -43,6 +43,9 @@ Heaps Options
 | **-n, --n-permutations**\ =\ *N*
 | Number of permutations to run.
 
+| **-d, --min-node-depth**\ =\ *N*
+| Exclude nodes with less than this path depth (default: 0).
+
 Threading
 ---------
 
@@ -64,16 +67,16 @@ Program Information
 ..
 	EXIT STATUS
 	===========
-	
+
 	| **0**
 	| Success.
-	
+
 	| **1**
 	| Failure (syntax or usage error; parameter error; file processing
 	  failure; unexpected error).
-	
+
 	BUGS
 	====
-	
+
 	Refer to the **odgi** issue tracker at
 	https://github.com/pangenome/odgi/issues.

--- a/src/algorithms/heaps.cpp
+++ b/src/algorithms/heaps.cpp
@@ -8,6 +8,7 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
                                const std::vector<std::vector<path_handle_t>>& path_groups,
                                const ska::flat_hash_map<path_handle_t, std::vector<interval_t>>& path_intervals,
                                uint64_t n_permutations,
+                               uint64_t min_node_depth,
                                const std::function<void(const std::vector<uint64_t>&, uint64_t)>& func) {
     //const std::function<bool(const path_handle_t&, _t)>& in_range) {
     //std::vector<std::vector<path_handle_t>>
@@ -38,7 +39,11 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
     if (path_intervals.size() == 0) {
         // keep everything if we aren't given intervals to guide subset
         for (uint64_t i = 0; i < graph.get_node_count(); ++i) {
-            target_nodes.set(i, true);
+            if (min_node_depth == 0
+                || (graph.get_step_count(graph.get_handle(i+1))
+                    >= min_node_depth)) {
+                target_nodes.set(i, true);
+            }
         }
     } else {
         std::vector<path_handle_t> paths;
@@ -70,7 +75,9 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
                             ++ival;
                         }
                         uint64_t rank = graph.get_id(h)-1; // assumes compaction!
-                        if (interval_ends.size()) {
+                        if (interval_ends.size()
+                            && (min_node_depth == 0
+                                || graph.get_step_count(h) >= min_node_depth)) {
                             target_nodes.set(rank, true);
                         }
                         pos += len;

--- a/src/algorithms/heaps.hpp
+++ b/src/algorithms/heaps.hpp
@@ -28,6 +28,7 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
                                const std::vector<std::vector<path_handle_t>>& path_groups,
                                const ska::flat_hash_map<path_handle_t, std::vector<interval_t>>& path_intervals,
                                uint64_t n_permutations,
+                               uint64_t min_node_depth,
                                const std::function<void(const std::vector<uint64_t>&, uint64_t)>& func);
 
 }

--- a/src/subcommand/heaps_main.cpp
+++ b/src/subcommand/heaps_main.cpp
@@ -32,6 +32,8 @@ int main_heaps(int argc, char **argv) {
                                               {'b', "bed-targets"});
     args::ValueFlag<uint64_t> _n_permutations(heaps_opts, "N", "Number of permutations to run.",
                                              {'n', "n-permutations"});
+    args::ValueFlag<uint64_t> _min_node_depth(heaps_opts, "N", "Exclude nodes with less than this path depth (default: 0).",
+                                         {'d', "min-node-depth"});
     args::Group threading_opts(parser, "[ Threading ]");
     args::ValueFlag<uint64_t> nthreads(threading_opts, "N", "Number of threads to use for parallel operations.",
                                        {'t', "threads"});
@@ -66,6 +68,8 @@ int main_heaps(int argc, char **argv) {
     omp_set_num_threads(num_threads);
 
     const uint64_t n_permutations = args::get(_n_permutations) ? args::get(_n_permutations) : 1;
+
+    const uint64_t min_node_depth = args::get(_min_node_depth) ? args::get(_min_node_depth) : 0;
 
     graph_t graph;
     assert(argc > 0);
@@ -177,7 +181,7 @@ int main_heaps(int argc, char **argv) {
         }
     };
 
-    algorithms::for_each_heap_permutation(graph, path_groups, intervals, n_permutations, handle_output);
+    algorithms::for_each_heap_permutation(graph, path_groups, intervals, n_permutations, min_node_depth, handle_output);
 
     return 0;
 }


### PR DESCRIPTION
This lets us set a minimum depth on nodes to be used in the Heaps' power law permutations.

The idea is that this acts as a noise filter, to remove misassemblies and under-aligned parts of graphs.