### PR TITLE
with rPG-SGD we have to count term updates even when we don't move reference nodes

### DIFF
--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -301,6 +301,8 @@ namespace odgi {
 										}
 									}
 									if (!update_term_j && !update_term_i) {
+										// we also have to update the number of terms here, because else we will over sample and the sorting will take much longer
+										term_updates++; // atomic
 										continue;
 									}
 


### PR DESCRIPTION
@joehagmann This should fix the additional run time issue you observed. Thanks for bringing this up.