### PR TITLE
Procrustes BED adjustment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,6 +549,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/stepindex_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/heaps_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/inject_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/procbed_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/flip_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/pav_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
@@ -603,6 +604,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/crush_n.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/heaps.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/inject.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/procbed.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/flip.cpp
   ${CMAKE_SOURCE_DIR}/src/unittest/edge.cpp
   ${CMAKE_SOURCE_DIR}/src/unittest/inject.cpp

--- a/docs/rst/commands.rst
+++ b/docs/rst/commands.rst
@@ -33,6 +33,7 @@ Commands
     commands/odgi_paths
     commands/odgi_position
     commands/odgi_prune
+    commands/odgi_procbed
     commands/odgi_server
     commands/odgi_sort
     commands/odgi_squeeze

--- a/docs/rst/commands/odgi_procbed.rst
+++ b/docs/rst/commands/odgi_procbed.rst
@@ -1,0 +1,75 @@
+.. _odgi procbed:
+
+#########
+odgi procbed
+#########
+
+ProcBED, or "procrustes-BED", cuts and adjusts BED intervals to fit inside a subgraph.
+Coordinates of subgraph paths are taken from their names using `PanSN sequence naming format <https://github.com/pangenome/PanSN-spec>`_.
+Graphs with this naming format are extracted with **odgi extract**.
+**odgi procbed** can be used to map BED annotations against full reference paths to BED records against the sub-ranges of reference paths in a subgraph.
+This is useful to produce input to **odgi inject**.
+
+SYNOPSIS
+========
+
+**odgi procbed** [**-i, --input**\ =\ *FILE*] [**-b, --bed-targets**\ =\ *FILE*] [*OPTION*]…
+
+DESCRIPTION
+===========
+
+The odgi procbed command converts BED records against graph paths into new paths labeled by the BED record name.
+Procbedion allows us to import genome annotations as paths, and is useful to produce input to odgi untangle.
+
+OPTIONS
+=======
+
+MANDATORY OPTIONS
+--------------
+
+| **-i, --input**\ =\ *FILE*
+| Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!
+
+| **-o, --out**\ =\ *FILE*
+| Write the graph with procbeded paths to *.og*.
+
+Procbedion Options
+----------------
+
+| **-b, --bed-targets**\ =\ *FILE*
+| BED file over path space of the full graph from the input subgraph was generated. Where they fully overlap, records will be adjusted to fit in the subgraph coordinate space.
+
+Threading
+---------
+
+| **-t, --threads**\ =\ *N*
+| Number of threads to use for parallel operations.
+
+Processing Information
+----------------------
+
+| **-P, --progress**
+| Print information about the operations and the progress to stderr.
+
+Program Information
+-------------------
+
+| **-h, --help**
+| Print a help message for **odgi procbed**.
+
+..
+	EXIT STATUS
+	===========
+
+	| **0**
+	| Success.
+
+	| **1**
+	| Failure (syntax or usage error; parameter error; file processing
+	  failure; unexpected error).
+
+	BUGS
+	====
+
+	Refer to the **odgi** issue tracker at
+	https://github.com/pangenome/odgi/issues.

--- a/docs/rst/tutorials/injecting_gene_arrows.rst
+++ b/docs/rst/tutorials/injecting_gene_arrows.rst
@@ -70,11 +70,21 @@ However, the C4 locus graph ``chr6.c4.gfa`` is over the reference range ``grch38
    # grch38#chr6:31972046-32055647
 
 We must adjust the annotations to match the subgraph to ensure that path names and coordinates exactly correspond between the BED and GFA.
-We subtract ``31972046`` from both coordinates and adjust the path name to match that in the subgraph, yielding:
+We do so using **odgi procbed**, which like `Procrustes of Greek mythology <https://en.wikipedia.org/wiki/Procrustes>`_ cuts BED records to fit within a given subgraph.
 
 .. code-block:: bash
 
-   <chr6.C4.bed awk '{ i=31972046; j=32055647; print $1":"i"-"j, $2-i, $3-i, $4 }' | tr ' ' '\t' | sort -n >chr6.C4.adj.bed
+   odgi procbed -i chr6.C4.gfa -b chr6.C4.bed >chr6.C4.adj.bed
+
+The coordinate space now matches that of the C4A/B subgraph.
+
+.. code-block:: none
+
+   # chr6.C4.adj.bed
+   grch38#chr6:31972046-32055647   10011   30635   C4A
+   grch38#chr6:31972046-32055647   13055   19012   C4A_HERV-K
+   grch38#chr6:31972046-32055647   42749   63372   C4B
+   grch38#chr6:31972046-32055647   45793   51750   C4B_HERV-K
 
 Now, we can inject these into the graph:
 

--- a/src/algorithms/procbed.cpp
+++ b/src/algorithms/procbed.cpp
@@ -1,0 +1,123 @@
+#include "procbed.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+void adjust_ranges(const PathHandleGraph& graph, const std::string& bed_targets) {
+
+    // collect the subgraph path map
+    ska::flat_hash_map<std::string, std::vector<interval_t>> subpaths;
+    // iterate over paths
+    graph.for_each_path_handle(
+        [&subpaths,&graph](const path_handle_t& path) {
+            // check if the path is named following pansn
+            auto name = graph.get_path_name(path);
+            std::string base;
+            uint64_t start = 0;
+            uint64_t end = 0;
+            auto c = name.find(':');
+            auto d = name.find('-', c);
+            if (c != std::string::npos && d != std::string::npos) {
+                // PanSN
+                // if so, collect its name and length and try to put it into our subpath
+                base = name.substr(0,c);
+                start = std::stoul(name.substr(c+1,d));
+                end = std::stoul(name.substr(d+1));
+            } else {
+                // if not, measure its length and use [0, length) as our interval
+                base = name;
+                uint64_t len = 0;
+                graph.for_each_step_in_path(
+                    path,
+                    [&graph,&len](const step_handle_t& step) {
+                        len += graph.get_length(graph.get_handle_of_step(step));
+                    });
+                start = 0;
+                end = len;
+            }
+            subpaths[base].push_back(interval_t(start, end));
+        });
+    // sort the intervals
+    for (auto& p : subpaths) {
+        std::sort(p.second.begin(), p.second.end());
+    }
+
+    ska::flat_hash_map<std::string, std::vector<std::pair<interval_t, std::string>>> bed_intervals;
+    std::ifstream bed(bed_targets.c_str());
+    std::string line;
+    while (std::getline(bed, line)) {
+        if (!line.empty()) {
+            auto vals = split(line, '\t');
+            if (vals.size() < 3) {
+                std::cerr << "[odgi::algorithms::adjust_ranges]"
+                          << "BED line does not have enough fields to define an interval"
+                          << std::endl << line << std::endl;
+                std::abort();
+            }
+            auto& path_name = vals[0];
+            uint64_t start = std::stoul(vals[1]);
+            uint64_t end = std::stoul(vals[2]);
+            const std::string& name = vals[3];
+            bed_intervals[path_name].push_back(make_pair(interval_t(start, end), name));
+        }
+    }
+    // sort the intervals
+    for (auto& p : bed_intervals) {
+        std::sort(p.second.begin(), p.second.end());
+    }
+
+    // now we match BED ranges to graph intervals
+    // using a two-list sweep to find ranges that fit into our graph
+    // we can either emit warnings for those that are intersected
+    // or we can cut them
+    for (auto& b : bed_intervals) {
+        auto& ref = b.first;
+        auto& bedivals = b.second;
+        auto f = subpaths.find(ref);
+        if (f != subpaths.end()) {
+            auto& refivals = f->second;
+            // map from range end to starting positions
+            std::map<uint64_t, std::vector<uint64_t>> ref_range_ends;
+            auto r = refivals.begin();
+            auto b = bedivals.begin();
+            while (b != bedivals.end() && (r != refivals.end() || !ref_range_ends.empty())) {
+                auto& b_start = b->first.first;
+                auto& b_end = b->first.second;
+                auto& b_key = b->second;
+                while (ref_range_ends.size()
+                       && ref_range_ends.begin()->first < b_start) {
+                    ref_range_ends.erase(ref_range_ends.begin());
+                }
+                while (r != refivals.end() && r->second < b_start) {
+                    // non-overlapping
+                    ++r;
+                }
+                while (r != refivals.end() && r->first < b_end) {
+                    ref_range_ends[r->second].push_back(r->first);
+                    ++r;
+                }
+                // now we check if b is in the open ranges
+                // and for each one we'll do a mapping
+                for (auto& f : ref_range_ends) {
+                    auto& ref_end = f.first;
+                    if (ref_end > b_end) {
+                        // find the ranges that can contain this interval
+                        for (auto& ref_start : f.second) {
+                            std::cout << ref << ":" << ref_start << "-" << ref_end << "\t"
+                                      << b_start - ref_start << "\t" << b_end - ref_start << "\t"
+                                      << b_key << std::endl;
+                        }
+                    }
+                }
+                ++b;
+            }
+        }
+    }
+}
+
+}
+
+}

--- a/src/algorithms/procbed.hpp
+++ b/src/algorithms/procbed.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include <map>
+#include <set>
+#include <algorithm>
+#include <random>
+#include <fstream>
+#include <omp.h>
+#include "hash_map.hpp"
+#include "progress.hpp"
+#include "position.hpp"
+#include "split.hpp"
+#include "IITree.h"
+#include <handlegraph/types.hpp>
+#include <handlegraph/iteratee.hpp>
+#include <handlegraph/util.hpp>
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/path_handle_graph.hpp>
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+/// Subset and adjust the BED file to match the reference sub-ranges in the graph
+void adjust_ranges(const PathHandleGraph& graph, const std::string& bed_targets);
+
+}
+
+}

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -261,6 +261,10 @@ path_step_index_t::path_step_index_t(const PathHandleGraph& graph,
                                                         step));
                 offset += graph.get_length(graph.get_handle_of_step(step));
             });
+        if (offset == 0) {
+            std::cerr << "[odgi::algorithms::stepindex] unable to index empty path " << graph.get_path_name(path) << std::endl;
+            std::abort();
+        }
 
         node_offset.resize(node_count+1);
         step_offset.resize(step_count+1);

--- a/src/subcommand/procbed_main.cpp
+++ b/src/subcommand/procbed_main.cpp
@@ -1,0 +1,96 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include <omp.h>
+#include "algorithms/procbed.hpp"
+#include "utils.hpp"
+#include "split.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_procbed(int argc, char **argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc - 1; ++i) {
+        argv[i] = argv[i + 1];
+    }
+    const std::string prog_name = "odgi procbed";
+    argv[0] = (char *) prog_name.c_str();
+    --argc
+;
+    args::ArgumentParser parser("Pprocrustes-BED: Intersect and adjust BED interval into PanSN-defined path subranges. Lift BED files into graphs produced by odgi extract. Uses path range information in the path names.");
+    args::Group mandatory_opts(parser, "[ MANDATORY ARGUMENTS ]");
+    args::ValueFlag<std::string> og_in_file(mandatory_opts, "FILE", "Load the succinct variation graph in ODGI format from this *FILE*. The file name usually ends with *.og*. It also accepts GFAv1, but the on-the-fly conversion to the ODGI format requires additional time!", {'i', "idx"});
+    args::Group procbed_opts(parser, "[ Procbed Options ]");
+    args::ValueFlag<std::string> _bed_targets(procbed_opts, "FILE", "BED file over path space of the full graph from which this subgraph was obtained. Using path range information in the path names, overlapping records will be rewritten to fit into the coordinate space of the subgraph.",
+                                              {'b', "bed-targets"});
+    args::Group threading_opts(parser, "[ Threading ]");
+    args::ValueFlag<uint64_t> nthreads(threading_opts, "N", "Number of threads to use for parallel operations.",
+                                       {'t', "threads"});
+    args::Group processing_info_opts(parser, "[ Processing Information ]");
+    //args::Flag debug(processing_info_opts, "debug", "Print information about the process to stderr.", {'d', "debug"});
+    args::Flag progress(processing_info_opts, "progress", "Write the current progress to stderr.", {'P', "progress"});
+    args::Group program_info_opts(parser, "[ Program Information ]");
+    args::HelpFlag help(program_info_opts, "help", "Print a help message for odgi procbed.", {'h', "help"});
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc == 1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    if (!og_in_file) {
+        std::cerr
+            << "[odgi::procbed] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+            << std::endl;
+        return 1;
+    }
+
+    std::string bed_targets;
+    if (_bed_targets) {
+        bed_targets = args::get(_bed_targets);
+    } else {
+        std::cerr
+            << "[odgi::procbed] error: please specify an input BED file to adjust -b=[FILE], --bed-targets=[FILE]."
+            << std::endl;
+        return 1;
+    }
+
+    const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+    omp_set_num_threads(num_threads);
+
+    graph_t graph;
+    assert(argc > 0);
+    {
+        const std::string infile = args::get(og_in_file);
+        if (!infile.empty()) {
+            if (infile == "-") {
+                graph.deserialize(std::cin);
+            } else {
+                utils::handle_gfa_odgi_input(infile, "procbed", args::get(progress), num_threads, graph);
+            }
+        }
+    }
+
+    graph.set_number_of_threads(num_threads);
+
+    algorithms::adjust_ranges(graph, bed_targets);
+
+    return 0;
+}
+
+static Subcommand odgi_procbed("procbed", "Procrustes-BED: adjust BED to match subpaths in graph.",
+                              PIPELINE, 3, main_procbed);
+
+
+}


### PR DESCRIPTION
When we make subgraphs with `odgi extract` they come out with paths named using [PanSN](https://github.com/pangenome/PanSN-spec) sequence naming format. Specifically, they are suffixed with a range specification that says what coordinates in the original path they correspond to.

`odgi procbed` uses this information to adjust BED annotations relative to the full paths. In effect, the subgraph has a set of reference ranges. We intersect these with a BED file and adjust the BED records so their reference, start, and end fall within those of the subgraph.

This is a very specific operation, so it made sense to introduce a new tool so as to avoid confusion. The name is a reference to Greek mythology: [Procrustes](https://en.wikipedia.org/wiki/Procrustes) was infamous for shaping his guests to fit a BED. It's a little different here (we shape a BED to match a variation graph), but the idea is similar :grin: 