### PR TITLE
Correct default value for `path-sgd-iter-max` flag of layout subcommand

### DIFF
--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -60,7 +60,7 @@ int main_layout(int argc, char **argv) {
                                              "The theta value N for the Zipfian distribution which is used as the sampling method for the second node of one term in the path guided 2D SGD model (default: 0.99).",
                                              {'a', "path-sgd-zipf-theta"});
     args::ValueFlag<uint64_t> p_sgd_iter_max(pg_sgd_opts, "N",
-                                             "The maximum number of iterations N for the path guided 2D SGD model (default: 100).",
+                                             "The maximum number of iterations N for the path guided 2D SGD model (default: 30).",
                                              {'x', "path-sgd-iter-max"});
     args::ValueFlag<double> p_sgd_cooling(pg_sgd_opts, "N",
                                           "Use this fraction of the iterations for layout annealing (default: 0.5).",

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -145,7 +145,6 @@ int main_layout(int argc, char **argv) {
 		exit(1);
     }
 
-    const uint64_t t_max = !p_sgd_iter_max ? 100 : args::get(p_sgd_iter_max);
     const double eps = !p_sgd_eps ? 0.01 : args::get(p_sgd_eps);
     const double sgd_delta = p_sgd_delta ? args::get(p_sgd_delta) : 0;
     const bool show_progress = progress ? args::get(progress) : false;


### PR DESCRIPTION
Just a tiny change; this MR corrects the description of the `path-sgd-iter-max` flag: Default value is 30 and not 100.

**Explanation**
The description of the `path-sgd-iter-max` flag states that the default value for the maximum number of iterations is 100:
https://github.com/pangenome/odgi/blob/b623928a9e2778c6d4c00770a75bc647e8c52507/src/subcommand/layout_main.cpp#L62-L64

This seems to be wrong, since it is set to 30 (stored as variable `path_sgd_iter_max`)
https://github.com/pangenome/odgi/blob/b623928a9e2778c6d4c00770a75bc647e8c52507/src/subcommand/layout_main.cpp#L194

`path_sgd_iter_max` is used as an argument for the SGD procedure here:
https://github.com/pangenome/odgi/blob/b623928a9e2778c6d4c00770a75bc647e8c52507/src/subcommand/layout_main.cpp#L330-L351

The default value of `t_max` is 100, but `t_max` is not used as an argument for the SGD procedure. Actually, it is never used.
https://github.com/pangenome/odgi/blob/b623928a9e2778c6d4c00770a75bc647e8c52507/src/subcommand/layout_main.cpp#L148

