### PR TITLE
`odgi draw`: avoid too big images that would require too much memory

### DIFF
--- a/src/algorithms/draw.cpp
+++ b/src/algorithms/draw.cpp
@@ -188,7 +188,8 @@ std::vector<uint8_t> rasterize(const std::vector<double> &X,
 
     // determine height and width based on the width, if width = 0
     if (width == 0) {
-        width = std::ceil(height * (source_width / source_height));
+        // Avoid too big images that would require too much memory
+        width = std::min(100000.0, std::ceil(height * (source_width / source_height)));
     }
     //std::cerr << "source " << source_width << "×" << source_height << std::endl;
     //std::cerr << "raster " << width << "×" << height << std::endl;

--- a/src/subcommand/draw_main.cpp
+++ b/src/subcommand/draw_main.cpp
@@ -89,12 +89,14 @@ int main_draw(int argc, char **argv) {
 
 	graph_t graph;
     assert(argc > 0);
-    std::string infile = args::get(dg_in_file);
-    if (!infile.empty()) {
-        if (infile == "-") {
-            graph.deserialize(std::cin);
-        } else {
-			utils::handle_gfa_odgi_input(infile, "draw", args::get(progress), num_threads, graph);
+    {
+        const std::string infile = args::get(dg_in_file);
+        if (!infile.empty()) {
+            if (infile == "-") {
+                graph.deserialize(std::cin);
+            } else {
+                utils::handle_gfa_odgi_input(infile, "draw", args::get(progress), num_threads, graph);
+            }
         }
     }
 


### PR DESCRIPTION
This helps with overly simple graphs (from simulations, for example).