### PR TITLE
`odgi draw`: color by BED annotation

### DIFF
--- a/src/algorithms/atomic_image.hpp
+++ b/src/algorithms/atomic_image.hpp
@@ -93,6 +93,7 @@ color_t layer(const color_t& a, const color_t& b, const double& f);
 color_t mix(const color_t& a, const color_t& b, const double& f);
 
 const color_t COLOR_BLACK = { 0xff000000 };
+const color_t COLOR_LIGHTGRAY = { 0xffD3D3D3 };
 const color_t COLOR_WHITE = { 0xffffffff };
 
 # define COLOR_MAX  255

--- a/src/algorithms/draw.cpp
+++ b/src/algorithms/draw.cpp
@@ -164,7 +164,8 @@ std::vector<uint8_t> rasterize(const std::vector<double> &X,
                                uint64_t& height,
                                const double& line_width,
                                const double& path_line_spacing,
-                               bool color_paths) {
+                               bool color_paths,
+                               std::vector<algorithms::color_t>& node_id_to_color) {
 
     std::vector<std::vector<handle_t>> weak_components;
     coord_range_2d_t rendered_range;
@@ -242,7 +243,9 @@ std::vector<uint8_t> rasterize(const std::vector<double> &X,
                        image,
                        line_width);
                 */
-                wu_calc_wide_line(xy0, xy1, COLOR_BLACK, image, line_width);
+                const algorithms::color_t node_color = !node_id_to_color.empty() ? node_id_to_color[graph.get_id(handle)] : COLOR_BLACK;
+
+                wu_calc_wide_line(xy0, xy1, node_color, image, line_width);
             }
         }
     }
@@ -262,7 +265,8 @@ void draw_png(const std::string& filename,
               uint64_t height,
               const double& line_width,
               const double& path_line_spacing,
-              bool color_paths) {
+              bool color_paths,
+              std::vector<algorithms::color_t>& node_id_to_color) {
     auto bytes = rasterize(X, Y,
                            graph,
                            scale,
@@ -271,7 +275,8 @@ void draw_png(const std::string& filename,
                            height,
                            line_width,
                            path_line_spacing,
-                           color_paths);
+                           color_paths,
+                           node_id_to_color);
     png::encodeOneStep(filename.c_str(), bytes, width, height);
 }
 

--- a/src/algorithms/draw.hpp
+++ b/src/algorithms/draw.hpp
@@ -80,7 +80,8 @@ std::vector<uint8_t> rasterize(const std::vector<double> &X,
                                uint64_t& height,
                                const double& line_width,
                                const double& path_line_spacing,
-                               bool color_paths);
+                               bool color_paths,
+                               std::vector<algorithms::color_t>& node_id_to_color);
 
 void draw_png(const std::string& filename,
               const std::vector<double> &X,
@@ -92,7 +93,8 @@ void draw_png(const std::string& filename,
               uint64_t height,
               const double& line_width,
               const double& path_line_spacing,
-              bool color_paths);
+              bool color_paths,
+              std::vector<algorithms::color_t>& node_id_to_color);
 
 
 


### PR DESCRIPTION
This power-up allows `odgi draw` to color paths with the colors specified in the input annotation file in BED format.

As an example, we can see that in the human C4 region, the haplotype `HG01952#1#JAHAME010000044.1` doesn't have the HERV sequence (grey nested bubble in the layout):

```
cat anno.bed
HG01952#1#JAHAME010000044.1:28380191-28451052   1       70861   C4LOCUS#00FF00

odgi draw -i test/chr6.C4.gfa -c x.lay -p x.png -t 1 -b anno.bed -P -w 300 -B 
```

![x](https://user-images.githubusercontent.com/62253982/178327117-888fb9c2-44bb-4259-b25c-70705f645fc4.png)
