### PR TITLE
`odgi extract`: better management of input path/pangenomic ranges to avoid subpath fragmentation

### DIFF
--- a/docs/rst/commands/odgi_extract.rst
+++ b/docs/rst/commands/odgi_extract.rst
@@ -77,6 +77,8 @@ Extract Options
 | **-p, --paths-to-extract**\ =\ *FILE*
 | List of paths to keep in the extracted graph. The *FILE* must contain one
   path name per line and a subset of all paths can be specified.
+ Paths specified in the input path ranges (with ``-r/--path-range`` and/or ``-b/--bed-file``)
+ will be keep in any case.
 
 | **-R, --lace-paths**\ =\ *FILE*
 | List of paths to fully retain in the extracted graph. Must contain one

--- a/docs/rst/commands/odgi_extract.rst
+++ b/docs/rst/commands/odgi_extract.rst
@@ -75,7 +75,7 @@ Extract Options
   very complex graphs.
 
 | **-p, --paths-to-extract**\ =\ *FILE*
-| List of paths to consider in the extraction. The *FILE* must contain one
+| List of paths to keep in the extracted graph. The *FILE* must contain one
   path name per line and a subset of all paths can be specified.
 
 | **-R, --lace-paths**\ =\ *FILE*

--- a/docs/rst/commands/odgi_extract.rst
+++ b/docs/rst/commands/odgi_extract.rst
@@ -54,10 +54,10 @@ Extract Options
 
 | **-c, --context-steps**\ =\ *N*
 | The number of steps (nodes) *N* away from our initial subgraph that we should
-  collect.
+  collect [default: 0 (disabled)].
 
 | **-L, --context-bases**
-| The number of bases *N* away from our initial subgraph that we should collect.
+| The number of bases *N* away from our initial subgraph that we should collect [default: 0 (disabled)].
 
 | **-r, --path-range**
 | Find the node(s) in the specified path range TARGET=path[:pos1[-pos2]]
@@ -85,7 +85,9 @@ Extract Options
   path name per line and a subset of all paths can be specified.
 
 | **-d, --max-distance-subpaths**\ =\ *N*
-| Maximum distance between subpaths allowed for merging them [default: 0 (disabled)].
+| Maximum distance between subpaths allowed for merging them.
+  It reduces the fragmentation of unspecified paths in the input path ranges.
+  Set 0 to disable it.
 
 | **-e, --max-merging-iterations**\ =\ *N*
 | Maximum number of iterations in attempting to merge close subpaths. 

--- a/docs/rst/commands/odgi_extract.rst
+++ b/docs/rst/commands/odgi_extract.rst
@@ -78,7 +78,7 @@ Extract Options
 | List of paths to keep in the extracted graph. The *FILE* must contain one
   path name per line and a subset of all paths can be specified.
  Paths specified in the input path ranges (with ``-r/--path-range`` and/or ``-b/--bed-file``)
- will be keep in any case.
+ will be kept in any case.
 
 | **-R, --lace-paths**\ =\ *FILE*
 | List of paths to fully retain in the extracted graph. Must contain one

--- a/src/algorithms/subgraph/extract.cpp
+++ b/src/algorithms/subgraph/extract.cpp
@@ -52,17 +52,17 @@ namespace odgi {
             return out_name;
         }
 
+        path_handle_t create_subpath(graph_t &subgraph, const string &subpath_name, const bool is_circular) {
+            if (subgraph.has_path(subpath_name)) {
+                subgraph.destroy_path(subgraph.get_path_handle(subpath_name));
+            }
+            return subgraph.create_path_handle(subpath_name, is_circular);
+        };
+
         void add_subpaths_to_subgraph(const graph_t &source, const std::vector<path_handle_t> source_paths,
                                       graph_t &subgraph, const uint64_t num_threads,
                                       const std::string &progress_message) {
             const bool show_progress = !progress_message.empty();
-
-            auto create_subpath = [](graph_t &subgraph, const string &subpath_name, const bool is_circular) {
-                if (subgraph.has_path(subpath_name)) {
-                    subgraph.destroy_path(subgraph.get_path_handle(subpath_name));
-                }
-                path_handle_t path = subgraph.create_path_handle(subpath_name, is_circular);
-            };
 
             std::unique_ptr<algorithms::progress_meter::ProgressMeter> progress;
             if (show_progress) {

--- a/src/algorithms/subgraph/extract.hpp
+++ b/src/algorithms/subgraph/extract.hpp
@@ -19,6 +19,10 @@ namespace odgi {
 
         void add_full_paths_to_component(const graph_t &source, graph_t &component, const uint64_t num_threads);
 
+        std::string make_path_name(const string &path_name, size_t offset, size_t end_offset);
+
+        path_handle_t create_subpath(graph_t &subgraph, const string &subpath_name, const bool is_circular);
+
         /// add subpaths to the subgraph, providing a concatenation of subpaths that are discontiguous over the subgraph
         void add_subpaths_to_subgraph(const graph_t &source, const std::vector<path_handle_t> source_paths,
                                       graph_t &subgraph, uint64_t num_threads,

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -66,7 +66,7 @@ namespace odgi {
                                "Be careful to use it with very complex graphs.",
                                {'E', "full-range"});
         args::ValueFlag<std::string> _path_names_file(extract_opts, "FILE",
-                                                      "List of paths to consider in the extraction. The FILE must "
+                                                      "List of paths to keep in the extracted graph. The FILE must "
                                                       "contain one path name per line and a subset of all paths can be specified.",
                                                       {'p', "paths-to-extract"});
         args::ValueFlag<std::string> _lace_paths_file(extract_opts, "FILE",
@@ -390,7 +390,7 @@ namespace odgi {
         auto prep_graph = [&shift](
                              graph_t &source, const std::vector<path_handle_t>& source_paths,
                              const std::vector<path_handle_t>& lace_paths, graph_t &subgraph,
-                             const std::vector<odgi::path_range_t> path_ranges, const std::vector<std::pair<uint64_t, uint64_t>> pangenomic_ranges,
+                             std::vector<odgi::path_range_t> path_ranges, std::vector<std::pair<uint64_t, uint64_t>> pangenomic_ranges,
                              const uint64_t context_steps, const uint64_t context_bases, const bool full_range, const bool inverse,
                              const uint64_t max_dist_subpaths, const uint64_t num_iterations,
                              const uint64_t num_threads, const bool show_progress) {
@@ -449,7 +449,7 @@ namespace odgi {
                         path_ranges.size(), "[odgi::extract] extracting path ranges");
             }
 
-            // Collect handles in path ranges (it is assumed they were already inverted outside, if needed)
+            // Collect handles in path/pangenomic ranges (it is assumed they were already inverted outside, if needed)
             {
                 atomicbitvector::atomic_bv_t keep_bv(source.get_node_count()+1);
 
@@ -582,6 +582,7 @@ namespace odgi {
                 }
             }
 
+            // ----------------------------------------------------------------------------------
             // Insert the subpaths corresponding to the path ranges (if any)
             // Create subpaths
             std::vector<path_handle_t> subpaths_from_path_ranges;
@@ -616,6 +617,7 @@ namespace odgi {
                             );
                         });
             }
+            // ----------------------------------------------------------------------------------
 
             // rewrite lace paths so that skipped regions are represented as new nodes that we then add to our subgraph
             if (!lace_paths.empty()) {

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -117,8 +117,7 @@ namespace odgi {
         }
 
         if (!_max_dist_subpaths) {
-            std::cerr << "[odgi::extract] error: please specify the expanding context either in steps (with -c/--context-steps) or "
-                         "in bases (-L/--context-bases). Values equal to or greater than 0 are allowed." << std::endl;
+            std::cerr << "[odgi::extract] error: please specify -d/--max-distance-subpaths. Values equal to or greater than 0 are allowed." << std::endl;
             return 1;
         }
         if ((!_max_dist_subpaths || args::get(_max_dist_subpaths) == 0) && _num_iterations) {

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -464,23 +464,22 @@ namespace odgi {
                             [&](const handle_t& handle) {
                                 keep_bv.set(source.get_id(handle) - shift);
                             });
-                    if (!pangenomic_ranges.empty()) {
-                        uint64_t pos = 0;
-                        source.for_each_handle([&](const handle_t &h) {
-                            const uint64_t hl = source.get_length(h);
-
-                            for (auto &pan_range : pangenomic_ranges) {
-                                if (pos + hl >= pan_range.first && pos <= pan_range.second ) {
-                                    keep_bv.set(source.get_id(h) - shift);
-                                    break;
-                                }
-                            }
-
-                            pos += hl;
-                        });
-                    }
                 }
+                if (!pangenomic_ranges.empty()) {
+                    uint64_t pos = 0;
+                    source.for_each_handle([&](const handle_t &h) {
+                        const uint64_t hl = source.get_length(h);
 
+                        for (auto &pan_range : pangenomic_ranges) {
+                            if (pos + hl >= pan_range.first && pos <= pan_range.second ) {
+                                keep_bv.set(source.get_id(h) - shift);
+                                break;
+                            }
+                        }
+
+                        pos += hl;
+                    });
+                }
                 for (auto id_shifted : keep_bv) {
                     const handle_t h = source.get_handle(id_shifted + shift);
                     subgraph.create_handle(source.get_sequence(h),

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -415,7 +415,9 @@ namespace odgi {
                                                                                                                 : "");
             }
 
-            if (inverse) {
+            // Check if there are nodes in the subgraph, to avoid extracting the whole graph
+            // when nodes with functionality other than pangenomic paths/ranges are not specified
+            if (inverse && subgraph.get_path_count() > 0) {
                 unordered_set<nid_t> node_ids_to_ignore;
                 subgraph.for_each_handle([&](const handle_t &h) {
                     node_ids_to_ignore.insert(subgraph.get_id(h));

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -69,7 +69,7 @@ namespace odgi {
                                                       "List of paths to keep in the extracted graph. The FILE must "
                                                       "contain one path name per line and a subset of all paths can be specified. "
                                                       "Paths specified in the input path ranges (with -r/--path-range and/or -b/--bed-file) "
-                                                      "will be keep in any case.",
+                                                      "will be kept in any case.",
                                                       {'p', "paths-to-extract"});
         args::ValueFlag<std::string> _lace_paths_file(extract_opts, "FILE",
                                                        "List of paths to fully retain in the extracted graph. Must "


### PR DESCRIPTION
This avoid subpath fragmentation in the extracted graph for paths specified with `-r/--path-range` and/or `-b/--bed-file`.

For example, with the following input BED file:

```
head ranges.bed

Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94	4595	7098
Oscillatoria.NC_019729.1:1546092-1556092_rt=1.141E-131_cas14=1.700E-93	2955	6066
Oscillatoria.NC_019729.1:2328234-2338234_rt=1.993E-100_cas14=2.344E-94	2265	6437
Oscillatoria.NC_019729.1:2742050-2752050_rt=1.141E-131_cas14=1.491E-92	2837	6013
Oscillatoria.NC_019729.1:4422131-4432131_rt=1.141E-131_cas14=1.271E-113	4631	7010
Oscillatoria.NC_019729.1:5308952-5318951_rt=4.605E-114_cas14=2.344E-94	2339	6509
Oscillatoria.NC_019729.1:5533994-5543994_rt=1.141E-131_cas14=5.600E-95	4342	7139
Oscillatoria.NC_019729.1:5658925-5668925_rt=4.605E-114_cas14=7.375E-85	4591	7124
Oscillatoria.NC_019729.1:7288707-7298706_rt=7.430E-131_cas14=1.461E-72	3130	5510
```

Now we get exactly the input path ranges in the extracted graph:

```
odgi extract -i input.og -b ranges.bed -c 0 -o - | odgi paths -i - --list-paths

Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4595-7098
Oscillatoria.NC_019729.1:1546092-1556092_rt=1.141E-131_cas14=1.700E-93:2955-6066
Oscillatoria.NC_019729.1:2328234-2338234_rt=1.993E-100_cas14=2.344E-94:2265-6437
Oscillatoria.NC_019729.1:2742050-2752050_rt=1.141E-131_cas14=1.491E-92:2837-6013
Oscillatoria.NC_019729.1:4422131-4432131_rt=1.141E-131_cas14=1.271E-113:4631-7010
Oscillatoria.NC_019729.1:5308952-5318951_rt=4.605E-114_cas14=2.344E-94:2339-6509
Oscillatoria.NC_019729.1:5533994-5543994_rt=1.141E-131_cas14=5.600E-95:4342-7139
Oscillatoria.NC_019729.1:5658925-5668925_rt=4.605E-114_cas14=7.375E-85:4591-7124
Oscillatoria.NC_019729.1:7288707-7298706_rt=7.430E-131_cas14=1.461E-72:3130-5510
```

Previously, the extracted graph contained 341 paths:

```
odgi_master extract -i input.og -b ranges.bed -c 0 -o - | odgi paths -i - --list-paths

Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4495-4507
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4508-4513
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4514-4519
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4520-4522
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4523-4525
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4526-4528
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4529-4532
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4533-4534
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4535-4545
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4547-4549
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4551-4558
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4559-4567
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4568-4570
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4571-4579
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4580-4582
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4583-4585
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4586-4588
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4589-4593
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:4595-7098
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:7099-7101
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:7102-7113
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:7114-7115
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:7116-7117
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:7118-7122
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:7123-7131
Oscillatoria.NC_019729.1:756238-766237_rt=4.605E-114_cas14=1.722E-94:7134-7139
... lots of paths ...
```