### PR TITLE
Improve performance of odgi sort

### DIFF
--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -221,6 +221,7 @@ namespace odgi {
                             // we'll sample from all path steps
                             std::uniform_int_distribution<uint64_t> dis_step = std::uniform_int_distribution<uint64_t>(0, np_bv.size() - 1);
                             std::uniform_int_distribution<uint64_t> flip(0, 1);
+                            uint64_t term_updates_local = 0;
                             while (work_todo.load()) {
                                 if (!snapshot_in_progress.load()) {
                                     // sample the first node from all the nodes in the graph
@@ -304,7 +305,7 @@ namespace odgi {
 									}
 									if (!update_term_j && !update_term_i) {
 										// we also have to update the number of terms here, because else we will over sample and the sorting will take much longer
-										term_updates++; // atomic
+										term_updates_local++;
 										if (progress) {
 											progress_meter->increment(1);
 										}
@@ -403,7 +404,11 @@ namespace odgi {
 #ifdef debug_path_sgd
                                     std::cerr << "after X[i] " << X[i].load() << " X[j] " << X[j].load() << std::endl;
 #endif
-                                    term_updates++; // atomic
+                                    term_updates_local++;
+                                    if (term_updates_local >= 1000) {
+                                        term_updates += term_updates_local;
+                                        term_updates_local = 0;
+                                    }
                                     if (progress) {
                                         progress_meter->increment(1);
                                     }


### PR DESCRIPTION
The global atomic `term_updates` is a major bottleneck in odgi sort since all threads are incrementing it in each step operation. Therefore, this implementation improves the performance by incrementing a thread local counter. The global atomic counter is only updated from time to time (update of the global counter is batched) to prevent memory congestion. 

This small change improved the sorting of the Chr6 dataset with 60 threads from 1h 50 Minutes down to 14-15 Minutes (`/usr/bin/time -v ./odgi sort -i chr6.og --threads 60 -Y -o tmp.og`).

We also experimented with other optimizations:
* [Read atomics `work_todo` & `snapshot_in_progress` less frequent](https://github.com/nsmlzl/odgi/commit/814f0e45f1183294c549ff3899e679a636c75065)
* [Update progress less frequent](https://github.com/nsmlzl/odgi/commit/c1ae4b925cebf62d212c5c9b452327027b7bdaa0)
* [Update `delta_max` less frequent](https://github.com/nsmlzl/odgi/commit/9350ba3d7049297d9a5c47bc8e7d0a08937c8521)
* [Use thread-local variables for eta, adj_theta, and cooling instead of reading global atomics](https://github.com/nsmlzl/odgi/commit/96bf40ca7eefaff7e006db3c3d4040feaf3281e0)
* Use of a different update interval

However, those changes did not lead to significant improvements. Therefore, were not added to this PR. In general, the computation time fluctuates by around 2 minutes. This makes it difficult to assess which changes lead to (slight) improvements.

The CPU utilization (measured with `/usr/bin/time -v`) is still a bit lower than the configured value. However, our profiling showed that during the actual SGD algorithm odgi uses the configured number of threads. During major parts of loading the .og graph file, the CPU utilization is single-threaded. For chr6 around 4 minutes (total computation takes ~14-15 minutes) are spend on [this single-threaded `for_each_path_handle` function](https://github.com/pangenome/odgi/blob/a5d5c5e6c031527bf3a17be4f568401357926899/src/algorithms/xp.cpp#L72-L91) in `XP::from_handle_graph_impl`.