### PR TITLE
Improve performance of odgi layout

### DIFF
--- a/src/algorithms/path_sgd_layout.cpp
+++ b/src/algorithms/path_sgd_layout.cpp
@@ -181,6 +181,7 @@ namespace odgi {
                             // we'll sample from all path steps
                             std::uniform_int_distribution<uint64_t> dis_step = std::uniform_int_distribution<uint64_t>(0, np_bv.size() - 1);
                             std::uniform_int_distribution<uint64_t> flip(0, 1);
+                            uint64_t term_updates_local = 0;
                             while (work_todo.load()) {
                                 if (!snapshot_in_progress.load()) {
                                     // sample the first node from all the nodes in the graph
@@ -370,7 +371,11 @@ namespace odgi {
 #ifdef debug_path_sgd
                                     std::cerr << "after X[i] " << X[i].load() << " X[j] " << X[j].load() << std::endl;
 #endif
-                                    term_updates++; // atomic
+                                    term_updates_local++;
+                                    if (term_updates_local >= 1000) {
+                                        term_updates += term_updates_local;
+                                        term_updates_local = 0;
+                                    }
                                     if (progress) {
                                         progress_meter->increment(1);
                                     }


### PR DESCRIPTION
This PR is closely related to #445, only applied to odgi layout. This PR improves the performance by incrementing the global atomic `term_updates` less frequent. Instead it uses a thread local counter and increments the global variable only from time to time to avoid memory congestion.

With this change the computation time of Chr6 improved from around 6h 48Min down to around 57-59 Minutes (running on 60 threads) (`/usr/bin/time -v odgi layout -i chr6.og -o chr6_layout.og.lay -t 60`). 

According to our experience with #445, we have not added any other changes. Since they did not lead to significant improvements in #445 .