### PR TITLE
path keep, path drop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/tips.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/path_jaccard.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/path_length.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/path_keep.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/diffpriv.cpp
   ${lodepng_SOURCES}
   ${handlegraph_sources}
@@ -791,6 +792,7 @@ set(odgi_HEADERS
   ${CMAKE_SOURCE_DIR}/src/algorithms/tips_bed_writer_thread.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/path_jaccard.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/path_length.hpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/path_keep.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/diffpriv.cpp)
 
 target_include_directories(odgi_objs PUBLIC ${odgi_INCLUDES})

--- a/docs/rst/commands/odgi_paths.rst
+++ b/docs/rst/commands/odgi_paths.rst
@@ -64,6 +64,14 @@ Path Investigation Options
 | **-f, --fasta**
 | Print paths in FASTA format to stdout. One line for the FASTA header, another line for the whole sequence.
 
+Path Modification Options
+---------------------
+| **-K, --keep-paths**\ =\ *[FILE]*
+| Keep paths listed (by line) in *FILE*.
+
+| **-X, --drop-paths**\ =\ *[FILE]*
+| Drop paths listed (by line) in *FILE*.
+
 Threading
 ---------
 
@@ -85,16 +93,16 @@ Program Information
 ..
 	EXIT STATUS
 	===========
-	
+
 	| **0**
 	| Success.
-	
+
 	| **1**
 	| Failure (syntax or usage error; parameter error; file processing
 	  failure; unexpected error).
-	
+
 	BUGS
 	====
-	
+
 	Refer to the **odgi** issue tracker at
 	https://github.com/pangenome/odgi/issues.

--- a/src/algorithms/path_keep.cpp
+++ b/src/algorithms/path_keep.cpp
@@ -8,6 +8,17 @@ void keep_paths(const graph_t& graph, graph_t& into, const ska::flat_hash_set<pa
     graph.for_each_handle([&](const handle_t& h) {
         into.create_handle(graph.get_sequence(h), graph.get_id(h));
     });
+    graph.for_each_handle([&](const handle_t& h) {
+        graph.follow_edges(h, false, [&](const handle_t& t) {
+            into.create_edge(into.get_handle(graph.get_id(h), graph.get_is_reverse(h)),
+                             into.get_handle(graph.get_id(t), graph.get_is_reverse(t)));
+        });
+        auto r = graph.flip(h);
+        graph.follow_edges(r, false, [&](const handle_t& t) {
+            into.create_edge(into.get_handle(graph.get_id(r), graph.get_is_reverse(r)),
+                             into.get_handle(graph.get_id(t), graph.get_is_reverse(t)));
+        });
+    });
     std::vector<path_handle_t> paths;
     graph.for_each_path_handle([&](const path_handle_t& p) { paths.push_back(p); });
     // ensure we have the same path handle order as in the original graph

--- a/src/algorithms/path_keep.cpp
+++ b/src/algorithms/path_keep.cpp
@@ -1,0 +1,31 @@
+#include "path_keep.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+void keep_paths(const graph_t& graph, graph_t& into, const ska::flat_hash_set<path_handle_t>& to_keep) {
+    // for each path, find its average orientation
+    graph.for_each_handle([&](const handle_t& h) {
+        into.create_handle(graph.get_sequence(h), graph.get_id(h));
+    });
+    std::vector<path_handle_t> paths;
+    graph.for_each_path_handle([&](const path_handle_t& p) { paths.push_back(p); });
+#pragma omp parallel for
+    for (auto& path : paths) {
+        if (to_keep.count(path)) {
+            // add the path as-is
+            auto w = into.create_path_handle(graph.get_path_name(path));
+            graph.for_each_step_in_path(
+                path,
+                [&w,&into,&graph](const step_handle_t& s) {
+                    auto h = graph.get_handle_of_step(s);
+                    auto q = into.get_handle(graph.get_id(h), graph.get_is_reverse(h));
+                    into.append_step(w, q);
+                });
+        }
+    }
+    into.optimize();
+}
+
+}
+}

--- a/src/algorithms/path_keep.cpp
+++ b/src/algorithms/path_keep.cpp
@@ -10,11 +10,18 @@ void keep_paths(const graph_t& graph, graph_t& into, const ska::flat_hash_set<pa
     });
     std::vector<path_handle_t> paths;
     graph.for_each_path_handle([&](const path_handle_t& p) { paths.push_back(p); });
+    // ensure we have the same path handle order as in the original graph
+    for (auto& path : paths) {
+        if (to_keep.count(path)) {
+            into.create_path_handle(graph.get_path_name(path));
+        }
+    }
+    // then add the steps in parallel
 #pragma omp parallel for
     for (auto& path : paths) {
         if (to_keep.count(path)) {
             // add the path as-is
-            auto w = into.create_path_handle(graph.get_path_name(path));
+            auto w = into.get_path_handle(graph.get_path_name(path));
             graph.for_each_step_in_path(
                 path,
                 [&w,&into,&graph](const step_handle_t& s) {

--- a/src/algorithms/path_keep.hpp
+++ b/src/algorithms/path_keep.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "odgi.hpp"
+#include <iostream>
+#include <omp.h>
+#include "position.hpp"
+#include <handlegraph/path_handle_graph.hpp>
+#include <handlegraph/mutable_path_handle_graph.hpp>
+#include "hash_map.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+void keep_paths(const graph_t& graph, graph_t& into, const ska::flat_hash_set<path_handle_t>& to_keep);
+
+}
+}


### PR DESCRIPTION
We can keep and drop paths based on names listed in files with `odgi paths`.

Much safer than hacking the GFA!