### PR TITLE
Fix segfault when no progress flag set

### DIFF
--- a/src/algorithms/path_sgd_layout.cpp
+++ b/src/algorithms/path_sgd_layout.cpp
@@ -374,7 +374,9 @@ namespace odgi {
                                     term_updates_local++;
                                     if (term_updates_local >= 1000) {
                                         term_updates += term_updates_local;
-                                        progress_meter->increment(term_updates_local);
+                                        if (progress) {
+                                            progress_meter->increment(term_updates_local);
+                                        }
                                         term_updates_local = 0;
                                     }
                                 }


### PR DESCRIPTION
#459 caused (on my machine) segmentation faults when progress indicator not used. This PR fixes this: Only increment progress meter when progress actually used. @AndreaGuarracino 