### PR TITLE
ensure that the optimal sum_of_path_node_distances is actually 1

### DIFF
--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -611,6 +611,7 @@ int main_stats(int argc, char** argv) {
 			}
 
             // TODO Could we run this in parallel?
+			handle_t last_handle;
             graph.for_each_path_handle([&](const path_handle_t &path) {
 #ifdef debug_odgi_stats
                 std::cerr << "path_name: " << graph.get_path_name(path) << std::endl;
@@ -625,9 +626,11 @@ int main_stats(int argc, char** argv) {
 
                 graph.for_each_step_in_path(path, [&](const step_handle_t &occ) {
                     handle_t h = graph.get_handle_of_step(occ);
+					last_handle = h;
 
                     if (graph.has_next_step(occ)){
                         handle_t i = graph.get_handle_of_step(graph.get_next_step(occ));
+						last_handle = i;
 
                         uint64_t unpacked_a = number_bool_packing::unpack_number(h);
                         uint64_t unpacked_b = number_bool_packing::unpack_number(i);
@@ -675,6 +678,10 @@ int main_stats(int argc, char** argv) {
                     len_path_node_space++;
                     len_path_nt_space += graph.get_length(h);
                 });
+
+				// TODO add end of of path
+				sum_path_node_dist_node_space++;
+				sum_path_node_dist_nt_space += graph.get_length(last_handle);
 
 				/// this could land in the YAML, but we don't force it, because we don't need it for the MultiQC module
                 if (args::get(path_statistics)) {

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -679,7 +679,7 @@ int main_stats(int argc, char** argv) {
                     len_path_nt_space += graph.get_length(h);
                 });
 
-				// TODO add end of of path
+				// add end of path so the best metric equals 1
 				sum_path_node_dist_node_space++;
 				sum_path_node_dist_nt_space += graph.get_length(last_handle);
 


### PR DESCRIPTION
Running the 1D `sum_of_path_node_distances` on this very simple graph

```
S	1	ACTACAGTA
S	2	CTGG
S	3	AAGTA
P	Genome1	1+,2+
P	Genome2	1+,3+
L	1	+	2	+	
L	1	+	3	+
```

with

```
odgi stats -i phd2.gfa -p -y -s
---
sum_of_path_node_distances:
  - distance:
      path: Genome1
      in_node_space: 0.5
      in_nucleotide_space: 0.692308
      nodes: 2
      nucleotides: 13
      num_penalties: 0
  - distance:
      path: Genome2
      in_node_space: 1
      in_nucleotide_space: 0.928571
      nodes: 2
      nucleotides: 14
      num_penalties: 0
  - distance:
      path: all_paths
      in_node_space: 0.75
      in_nucleotide_space: 0.814815
      nodes: 4
      nucleotides: 27
      num_penalties: 0
```

I noticed that the best metric goes below 1. Which does not make sense. This PR fixes this by always adding the information of the last node of a path to the sum.