### PR TITLE
`odgi untangle`: verbose log

### DIFF
--- a/src/algorithms/untangle.hpp
+++ b/src/algorithms/untangle.hpp
@@ -49,7 +49,8 @@ public:
                   const step_index_t& step_index,
                   const std::function<bool(const handle_t&)>& is_cut,
                   const uint64_t& merge_dist,
-                  const size_t& num_threads);
+                  const size_t& num_threads,
+                  const bool& show_progress);
     void for_segment_on_node(
         uint64_t node_id,
         const std::function<void(const uint64_t& segment_id, const bool& is_rev)>& func) const;
@@ -125,7 +126,7 @@ void untangle(
     const std::string& cut_points_input,
     const std::string& cut_points_output,
     const size_t& num_threads,
-	const bool& progress,
+	const bool& show_progress,
 	const step_index_t& step_index,
 	const std::vector<path_handle_t>& paths);
 

--- a/src/subcommand/untangle_main.cpp
+++ b/src/subcommand/untangle_main.cpp
@@ -246,7 +246,8 @@ int main_untangle(int argc, char **argv) {
 								 args::get(output_cut_points),
 								 num_threads,
 								 progress,
-								 step_index,paths);
+								 step_index,
+                                 paths);
 		}
     }
 


### PR DESCRIPTION
Useful for debugging

```
[odgi::algorithms::untangle] untangling 9280 queries with 9280 targets
[odgi::algorithms::untangle] establishing initial cuts for 9280 paths
[odgi::algorithms::untangle] set target nodes 100.00% @ 3.70e+04/s elapsed: 00:00:00:00 remain: 00:00:00:00
[odgi::algorithms::untangle] untangle and merge cuts 100.00% @ 1.68e+03/s elapsed: 00:00:00:05 remain: 00:00:00:00
[odgi::algorithms::untangle] mark nodes every 50000 bp 100.00% @ 1.69e+04/s elapsed: 00:00:00:00 remain: 00:00:00:00
[odgi::algorithms::untangle] add new cut points 100.00% @ 3.70e+04/s elapsed: 00:00:00:00 remain: 00:00:00:00
[odgi::algorithms::untangle] building target segment index
[odgi::algorithms::untangle] untangle and merge cuts 100.00% @ 1.06e+03/s elapsed: 00:00:00:08 remain: 00:00:00:00
[odgi::algorithms::untangle] prepare segment cuts 100.00% @ 1.85e+04/s elapsed: 00:00:00:00 remain: 00:00:00:00
[odgi::algorithms::untangle] make the mapping 100.00% @ 2.30e+07/s elapsed: 00:00:00:00 remain: 00:00:00:00
[odgi::algorithms::untangle] untangling 9280 queries 24.74% @ 7.61e+00/s elapsed: 00:00:05:01 remain: 00:00:15:17
```