### PR TITLE
`odgi inject`: use a key that is really unique across annotations

### DIFF
--- a/src/algorithms/inject.cpp
+++ b/src/algorithms/inject.cpp
@@ -158,10 +158,10 @@ void inject_ranges(MutablePathDeletableHandleGraph& graph,
         if (path_intervals.find(path) != path_intervals.end()) {
             auto& intervals = path_intervals.find(path)->second;
             auto ival = intervals.begin();
-            // IMPORTANT: in the key of the map, the end position (uint64_t) has to come
-            //            first to keep the open intervals sorted by end coordinates.
-            //            The annotation name (std::string) is necessary to avoid loosing
-            //            annotations having the same end coordinates.
+            // IMPORTANT: in the key of the map, the end position (uint64_t) has
+            // to come first to keep the open intervals sorted by end coordinates.
+            // The annotation name (std::string) is necessary to avoid losing
+            // annotations having the same end coordinates.
             std::map<std::pair<uint64_t, std::string>, step_handle_t> open_intervals_by_end;
             uint64_t pos = 0;
             handle_t last_h;

--- a/src/algorithms/inject.cpp
+++ b/src/algorithms/inject.cpp
@@ -158,7 +158,7 @@ void inject_ranges(MutablePathDeletableHandleGraph& graph,
         if (path_intervals.find(path) != path_intervals.end()) {
             auto& intervals = path_intervals.find(path)->second;
             auto ival = intervals.begin();
-            std::map<uint64_t, std::pair<std::string, step_handle_t>> open_intervals_by_end;
+            std::map<std::pair<std::string, uint64_t>, std::pair<std::string, step_handle_t>> open_intervals_by_end;
             uint64_t pos = 0;
             handle_t last_h;
             graph.for_each_step_in_path(
@@ -166,15 +166,15 @@ void inject_ranges(MutablePathDeletableHandleGraph& graph,
                 [&](const step_handle_t& step) {
                     // remove intervals that ended before this node
                     while (open_intervals_by_end.size()
-                           && open_intervals_by_end.begin()->first <= pos) {
+                           && open_intervals_by_end.begin()->first.second <= pos) {
                         // get reference to name
                         auto& i = open_intervals_by_end.begin()->second;
                         auto& name = i.first;
-                        if (open_intervals_by_end.begin()->first != pos) {
+                        if (open_intervals_by_end.begin()->first.second != pos) {
                             std::cerr << "[odgi::algorithms::inject_ranges] "
                                       << "injection end point for interval " << name
                                       << " is not at a node boundary: "
-                                      << "off by " << open_intervals_by_end.begin()->first
+                                      << "off by " << open_intervals_by_end.begin()->first.second
                                       << " vs " << pos
                                       << " on a node "
                                       << graph.get_length(graph.get_handle_of_step(step))
@@ -206,7 +206,7 @@ void inject_ranges(MutablePathDeletableHandleGraph& graph,
                            && ival->first.first >= pos
                            && ival->first.first < pos + len) {
                         // the intervals must start at the node start
-                        open_intervals_by_end[ival->first.second] = std::make_pair(ival->second, step);
+                        open_intervals_by_end[std::make_pair(ival->second, ival->first.second)] = std::make_pair(ival->second, step);
                         ++ival;
                         if (show_progress) {
                             progress->increment(1);
@@ -218,7 +218,7 @@ void inject_ranges(MutablePathDeletableHandleGraph& graph,
 
             // Add last paths
             while (open_intervals_by_end.size()
-                   && open_intervals_by_end.begin()->first <= pos) {
+                   && open_intervals_by_end.begin()->first.second <= pos) {
                 // get reference to name
                 auto& i = open_intervals_by_end.begin()->second;
                 auto& name = i.first;


### PR DESCRIPTION
This was leading to invalid paths when there were overlapping annotations to inject. See #475.