### PR TITLE
Optimization of zeta preprocessing

### DIFF
--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -121,12 +121,18 @@ namespace odgi {
                                                                     iter_with_max_learning_rate,
                                                                     eps);
 
-                // cache zipf zetas for our full path space (heavy, but one-off)
+                // cache zipf zetas for our full path space
                 if (progress) {
                     std::cerr << "[odgi::path_linear_sgd] calculating zetas for " << (space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1) << " zipf distributions" << std::endl;
                 }
+                std::cout << "space: " << space << std::endl;
+                std::cout << "space_max: " << space_max << std::endl;
+                std::cout << "space_quantization_step: " << space_quantization_step << std::endl;
 
-                std::vector<double> zetas((space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1)+1);
+                auto start_zeta = std::chrono::high_resolution_clock::now();
+                /*
+                // reference zeta computation
+                std::vector<double> zetas_ref((space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1)+1);
                 uint64_t last_quantized_i = 0;
 #pragma omp parallel for schedule(static,1)
                 for (uint64_t i = 1; i < space+1; ++i) {
@@ -139,11 +145,40 @@ namespace odgi {
 
                     if (quantized_i != last_quantized_i){
                         dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, compressed_space, theta);
-                        zetas[quantized_i] = z_p.zeta();
+                        zetas_ref[quantized_i] = z_p.zeta();
 
                         last_quantized_i = quantized_i;
                     }
                 }
+                */
+                // fast zeta computation
+                std::vector<double> zetas((space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1)+1);
+                double zeta_tmp = 0.0;
+                for (uint64_t i = 1; i < space + 1; i++) {
+                    zeta_tmp += dirtyzipf::fast_precise_pow(1.0 / i, theta);
+                    if (i <= space_max) {
+                        zetas[i] = zeta_tmp;
+                    }
+                    if (i >= space_max && (i - space_max) % space_quantization_step == 0) {
+                        zetas[space_max + 1 + (i - space_max) / space_quantization_step] = zeta_tmp;
+                    }
+                }
+                auto end_zeta = std::chrono::high_resolution_clock::now();
+                uint32_t duration_zeta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_zeta - start_zeta).count();
+                std::cout << "zeta precomputation took " << duration_zeta_ms << "ms" << std::endl;
+
+
+                /*
+                for (int i = 1; i < zetas.size(); i++) {
+                    if (zetas[i] != zetas_ref[i]) {
+                        std::cout << "WARNING[" << i << "]: " << zetas[i] << " vs " << zetas_ref[i] << std::endl;
+                    }
+                }
+
+                std::cout << zetas[zetas.size() - 1] << std::endl;
+                std::vector<double> X_tmp(X.size());
+                return X_tmp;
+                */
 
                 // how many term updates we make
                 std::atomic<uint64_t> term_updates;

--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -125,33 +125,6 @@ namespace odgi {
                 if (progress) {
                     std::cerr << "[odgi::path_linear_sgd] calculating zetas for " << (space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1) << " zipf distributions" << std::endl;
                 }
-                std::cout << "space: " << space << std::endl;
-                std::cout << "space_max: " << space_max << std::endl;
-                std::cout << "space_quantization_step: " << space_quantization_step << std::endl;
-
-                auto start_zeta = std::chrono::high_resolution_clock::now();
-                /*
-                // reference zeta computation
-                std::vector<double> zetas_ref((space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1)+1);
-                uint64_t last_quantized_i = 0;
-#pragma omp parallel for schedule(static,1)
-                for (uint64_t i = 1; i < space+1; ++i) {
-                    uint64_t quantized_i = i;
-                    uint64_t compressed_space = i;
-                    if (i > space_max){
-                        quantized_i = space_max + (i - space_max) / space_quantization_step + 1;
-                        compressed_space = space_max + ((i - space_max) / space_quantization_step) * space_quantization_step;
-                    }
-
-                    if (quantized_i != last_quantized_i){
-                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, compressed_space, theta);
-                        zetas_ref[quantized_i] = z_p.zeta();
-
-                        last_quantized_i = quantized_i;
-                    }
-                }
-                */
-                // fast zeta computation
                 std::vector<double> zetas((space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1)+1);
                 double zeta_tmp = 0.0;
                 for (uint64_t i = 1; i < space + 1; i++) {
@@ -163,22 +136,6 @@ namespace odgi {
                         zetas[space_max + 1 + (i - space_max) / space_quantization_step] = zeta_tmp;
                     }
                 }
-                auto end_zeta = std::chrono::high_resolution_clock::now();
-                uint32_t duration_zeta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_zeta - start_zeta).count();
-                std::cout << "zeta precomputation took " << duration_zeta_ms << "ms" << std::endl;
-
-
-                /*
-                for (int i = 1; i < zetas.size(); i++) {
-                    if (zetas[i] != zetas_ref[i]) {
-                        std::cout << "WARNING[" << i << "]: " << zetas[i] << " vs " << zetas_ref[i] << std::endl;
-                    }
-                }
-
-                std::cout << zetas[zetas.size() - 1] << std::endl;
-                std::vector<double> X_tmp(X.size());
-                return X_tmp;
-                */
 
                 // how many term updates we make
                 std::atomic<uint64_t> term_updates;

--- a/src/algorithms/path_sgd_layout.cpp
+++ b/src/algorithms/path_sgd_layout.cpp
@@ -84,29 +84,6 @@ namespace odgi {
                                                                            eps);
 
                 // cache zipf zetas for our full path space
-                auto start_zeta = std::chrono::high_resolution_clock::now();
-                /*
-                // reference zeta computation
-                std::vector<double> zetas_ref((space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1)+1);
-                uint64_t last_quantized_i = 0;
-#pragma omp parallel for schedule(static,1)
-                for (uint64_t i = 1; i < space+1; ++i) {
-                    uint64_t quantized_i = i;
-                    uint64_t compressed_space = i;
-                    if (i > space_max){
-                        quantized_i = space_max + (i - space_max) / space_quantization_step + 1;
-                        compressed_space = space_max + ((i - space_max) / space_quantization_step) * space_quantization_step;
-                    }
-
-                    if (quantized_i != last_quantized_i){
-                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, compressed_space, theta);
-                        zetas_ref[quantized_i] = z_p.zeta();
-
-                        last_quantized_i = quantized_i;
-                    }
-                }
-                */
-                // fast zeta computation
                 std::vector<double> zetas((space <= space_max ? space : space_max + (space - space_max) / space_quantization_step + 1)+1);
                 double zeta_tmp = 0.0;
                 for (uint64_t i = 1; i < space + 1; i++) {
@@ -118,21 +95,6 @@ namespace odgi {
                         zetas[space_max + 1 + (i - space_max) / space_quantization_step] = zeta_tmp;
                     }
                 }
-                auto end_zeta = std::chrono::high_resolution_clock::now();
-                uint32_t duration_zeta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(end_zeta - start_zeta).count();
-                std::cout << "zeta precomputation took " << duration_zeta_ms << "ms" << std::endl;
-
-
-                /*
-                for (int i = 1; i < zetas.size(); i++) {
-                    if (zetas[i] != zetas_ref[i]) {
-                        std::cout << "WARNING[" << i << "]: " << zetas[i] << " vs " << zetas_ref[i] << std::endl;
-                    }
-                }
-
-                std::cout << zetas[zetas.size() - 1] << std::endl;
-                return;
-                */
 
                 // how many term updates we make
                 std::atomic<uint64_t> term_updates;


### PR DESCRIPTION
We preprocess the zeta values in the sort and the layout subcommands:

Previously we repeated this computation for each value of *N* (1 to x). However, if we examine the [zeta function](https://github.com/ekg/dirtyzipf/blob/093139328966359ba4c2d540ac7d5e547f3b3e9f/dirty_zipfian_int_distribution.h#L165-L171), we can see that we could actually compute all zeta values in a single computation (theta is constant), since the computation of zeta(*N*) includes the computation of zeta(*N*-1). 

```
double zeta(unsigned long __n, double __theta){
      double ans = 0.0;
      for(unsigned long i=1; i<=__n; ++i)
        ans += fast_precise_pow(1.0/i, __theta);
      return ans;
}
```

This PR combines the computation of all zetas into a single computation. For *N* less than or equal to `space_max`, we just store the zeta values directly. For larger *N* we respect `space_quantization_step`. For my configuration it generated exactly the same values as the previous implementation; you can check this for your configuration as well, just undo the cleanup commits, then you will have the code to compare the generated values.

For the layout subcommand, this results in a significant speedup for large pangenomes (e.g., Chr6 from ~230s down to ~40ms). The default configuration of odgi sort seems to generate only a small zeta vector (`space_quantization_step` seems to be huge). With this speedup it might make sense to increase it again.