### PR TITLE
Fix versioning

### DIFF
--- a/scripts/generate_git_version.sh
+++ b/scripts/generate_git_version.sh
@@ -1,5 +1,9 @@
 INC_DIR=$1
 
+# Go to the directory where the script is
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd "$SCRIPT_DIR"
+
 GIT_VERSION=$(git describe --always --tags --long)
 
 echo "#define ODGI_GIT_VERSION" \"$GIT_VERSION\" > $1/odgi_git_version.hpp.tmp


### PR DESCRIPTION
Docker/Singularity images of PGGB display the wrong version of `odgi`. The `odgi` binary is correct, only the version it shows is wrong. In PGGB we use the `odgi` compiled with `smoothxg` and there the script to catch `odgi`'s version wrongly calls `smoothgx`'s git, not `odgi`'s.