### PR TITLE
Init odgi paths

### DIFF
--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -210,17 +210,17 @@ int main_paths(int argc, char** argv) {
         std::vector<std::string> path_groups;
         if (using_delim) {
             delim = args::get(path_delim).at(0);
-            uint32_t i = 0;
-            graph.for_each_path_handle(
-                [&](const path_handle_t& p) {
+        uint32_t i = 0;
+        graph.for_each_path_handle(
+            [&](const path_handle_t& p) {
                     std::string group_name = split(graph.get_path_name(p), delim)[0];
-                    auto f = path_group_ids.find(group_name);
-                    if (f == path_group_ids.end()) {
-                        path_group_ids[group_name] = i++;
-                        path_groups.push_back(group_name);
-                    }
-                    path_handle_group_ids[p] = path_group_ids[group_name];
-                });
+                auto f = path_group_ids.find(group_name);
+                if (f == path_group_ids.end()) {
+                    path_group_ids[group_name] = i++;
+                    path_groups.push_back(group_name);
+                }
+                path_handle_group_ids[p] = path_group_ids[group_name];
+            });
         }
 
         auto get_path_name
@@ -256,9 +256,16 @@ int main_paths(int argc, char** argv) {
                 path_max = std::max(path_max, (uint32_t)as_integer(p));
             });
 
+        // Initialize first to avoid possible bugs later
+        for (uint32_t i = 0; i < path_max; ++i) {
+            path_handle_t p = as_path_handle(i + 1);
+            bp_count[get_path_id(p)] = 0;
+        }
+
 #pragma omp parallel for
         for (uint32_t i = 0; i < path_max; ++i) {
             path_handle_t p = as_path_handle(i + 1);
+
             uint64_t path_length = 0;
             graph.for_each_step_in_path(
                 p,

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -213,7 +213,7 @@ int main_paths(int argc, char** argv) {
             uint32_t i = 0;
             graph.for_each_path_handle(
                 [&](const path_handle_t& p) {
-                        std::string group_name = split(graph.get_path_name(p), delim)[0];
+                    std::string group_name = split(graph.get_path_name(p), delim)[0];
                     auto f = path_group_ids.find(group_name);
                     if (f == path_group_ids.end()) {
                         path_group_ids[group_name] = i++;

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -210,17 +210,17 @@ int main_paths(int argc, char** argv) {
         std::vector<std::string> path_groups;
         if (using_delim) {
             delim = args::get(path_delim).at(0);
-        uint32_t i = 0;
-        graph.for_each_path_handle(
-            [&](const path_handle_t& p) {
-                    std::string group_name = split(graph.get_path_name(p), delim)[0];
-                auto f = path_group_ids.find(group_name);
-                if (f == path_group_ids.end()) {
-                    path_group_ids[group_name] = i++;
-                    path_groups.push_back(group_name);
-                }
-                path_handle_group_ids[p] = path_group_ids[group_name];
-            });
+            uint32_t i = 0;
+            graph.for_each_path_handle(
+                [&](const path_handle_t& p) {
+                        std::string group_name = split(graph.get_path_name(p), delim)[0];
+                    auto f = path_group_ids.find(group_name);
+                    if (f == path_group_ids.end()) {
+                        path_group_ids[group_name] = i++;
+                        path_groups.push_back(group_name);
+                    }
+                    path_handle_group_ids[p] = path_group_ids[group_name];
+                });
         }
 
         auto get_path_name
@@ -265,7 +265,6 @@ int main_paths(int argc, char** argv) {
 #pragma omp parallel for
         for (uint32_t i = 0; i < path_max; ++i) {
             path_handle_t p = as_path_handle(i + 1);
-
             uint64_t path_length = 0;
             graph.for_each_step_in_path(
                 p,


### PR DESCRIPTION
This avoids nasty bugs leading to wrong distance estimations. Strangely, the bug is triggered only when we don't use the `-D xxx` option.