### PR TITLE
`odgi flip`: avoid introducing useless edges and losing edges from the original graph

### DIFF
--- a/src/algorithms/flip.cpp
+++ b/src/algorithms/flip.cpp
@@ -9,25 +9,24 @@ using namespace handlegraph;
 void flip_paths(graph_t& graph,
                 graph_t& into,
                 const std::vector<path_handle_t>& no_flips) {
-    // for each path, find its average orientation
     graph.for_each_handle([&](const handle_t& h) {
         into.create_handle(graph.get_sequence(h), graph.get_id(h));
     });
     graph.for_each_handle([&](const handle_t& h) {
-        graph.follow_edges(h, false, [&](const handle_t& t) {
+        graph.follow_edges(h, false, [&](const handle_t& next) {
             into.create_edge(into.get_handle(graph.get_id(h), graph.get_is_reverse(h)),
-                             into.get_handle(graph.get_id(t), graph.get_is_reverse(t)));
+                             into.get_handle(graph.get_id(next), graph.get_is_reverse(next)));
         });
-        auto r = graph.flip(h);
-        graph.follow_edges(r, false, [&](const handle_t& t) {
-            into.create_edge(into.get_handle(graph.get_id(r), graph.get_is_reverse(r)),
-                             into.get_handle(graph.get_id(t), graph.get_is_reverse(t)));
+        graph.follow_edges(h, true, [&](const handle_t& prev) {
+            into.create_edge(into.get_handle(graph.get_id(prev), graph.get_is_reverse(prev)),
+                             into.get_handle(graph.get_id(h), graph.get_is_reverse(h)));
         });
     });
     ska::flat_hash_set<path_handle_t> no_flip;
     for (auto& p : no_flips) { no_flip.insert(p); }
     std::vector<path_handle_t> paths;
     std::vector<path_handle_t> into_paths;
+    // for each path, find its average orientation
     graph.for_each_path_handle([&](const path_handle_t& p) { paths.push_back(p); });
 #pragma omp parallel for
     for (auto& path : paths) {
@@ -86,6 +85,31 @@ void flip_paths(graph_t& graph,
                 });
         }
     }
+
+    ska::flat_hash_set<std::pair<handle_t, handle_t>> edges_to_create;
+
+#pragma omp parallel for
+    for (auto& path : paths) {
+        // New edges can be due only when paths are flipped
+        if (!no_flip.count(path)) {
+            handle_t last;
+            const step_handle_t begin_step = into.path_begin(path);
+            into.for_each_step_in_path(path, [&](const step_handle_t &step) {
+                handle_t h = into.get_handle_of_step(step);
+                if (step != begin_step && !into.has_edge(last, h)) {
+    #pragma omp critical (edges_to_create)
+                    edges_to_create.insert({last, h});
+                }
+                last = h;
+            });
+        }
+    }
+
+    // add missing edges
+    for (auto edge: edges_to_create) {
+        into.create_edge(edge.first, edge.second);
+    }
+
     into.optimize();
 }
 


### PR DESCRIPTION
This PR introduces a different way to construct the flipped graph:
- copy all edges from the input graph
- flip paths
- check missing edges (due to flipped paths)
- add missing edges (if any)

In the first tests, this avoids introducing edges that are not used in the flipped paths and avoids losing edges that are present in the input graph.