### PR TITLE
add conda-forge to conda installation instructions

### DIFF
--- a/docs/rst/installation.rst
+++ b/docs/rst/installation.rst
@@ -60,7 +60,7 @@ BIOCONDA
 
 .. code-block:: bash
 
-	conda install -c bioconda odgi
+	conda install -c conda-forge -c bioconda odgi
 
 GUIX
 ====


### PR DESCRIPTION
Many packages in bioconda have dependencies in conda-forge. Unless a user has already added conda-forge to [their list of default channels in their config](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-channels.html), the conda installation command will fail to solve.
```
$ conda create -n pangenomes bioconda::odgi
Collecting package metadata (current_repodata.json): done
Solving environment: failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): done
Solving environment: -
Found conflicts! Looking for incompatible packages.
This can take several minutes.  Press CTRL-C to abort.
failed
UnsatisfiableError
```
Adding conda-forge resolves the error.
```
$ conda create -n pangenomes -c conda-forge bioconda::odgi
Collecting package metadata (current_repodata.json): done
Solving environment: done
```