### PR TITLE
make svg drawing work with colors

### DIFF
--- a/src/algorithms/atomic_image.cpp
+++ b/src/algorithms/atomic_image.cpp
@@ -84,6 +84,25 @@ color_t mix(const color_t& a, const color_t& b, const double& f) {
     return out;
 }
 
+std::string to_hex(const color_t& c) {
+	std::stringstream ss;
+	ss << "#";
+	ss << std::hex << std::setfill('0') << std::setw(2) << (int)c.c.r;
+	ss << std::hex << std::setfill('0') << std::setw(2) << (int)c.c.g;
+	ss << std::hex << std::setfill('0') << std::setw(2) << (int)c.c.b;
+	return ss.str();
+}
+
+std::string to_rgba(const color_t& c) {
+	std::stringstream ss;
+	ss << "rgba(";
+	ss << (int)c.c.r << ",";
+	ss << (int)c.c.g << ",";
+	ss << (int)c.c.b << ",";
+	ss << (int)c.c.a << ")";
+	return ss.str();
+}
+
 // helpers
 
 double u_ipart(double x) { return std::floor(x); }

--- a/src/algorithms/atomic_image.hpp
+++ b/src/algorithms/atomic_image.hpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <memory>
 #include <iostream>
+#include <iomanip>
 #include "picosha2.h"
 
 namespace odgi {
@@ -91,6 +92,9 @@ color_t brighten(const color_t& a, const color_t& b, const double& f);
 color_t darkest(const color_t& a, const color_t& b);
 color_t layer(const color_t& a, const color_t& b, const double& f);
 color_t mix(const color_t& a, const color_t& b, const double& f);
+
+std::string to_hex(const color_t& c);
+std::string to_rgba(const color_t& c);
 
 const color_t COLOR_BLACK = { 0xff000000 };
 const color_t COLOR_LIGHTGRAY = { 0xffD3D3D3 };

--- a/src/algorithms/draw.cpp
+++ b/src/algorithms/draw.cpp
@@ -104,7 +104,9 @@ void draw_svg(std::ostream &out,
               const std::vector<double> &Y,
               const PathHandleGraph &graph,
               const double& scale,
-              const double& border) {
+              const double& border,
+			  const double& line_width,
+			  std::vector<algorithms::color_t>& node_id_to_color) {
 
     std::vector<std::vector<handle_t>> weak_components;
     coord_range_2d_t rendered_range;
@@ -124,9 +126,10 @@ void draw_svg(std::ostream &out,
         << "viewBox=\"" << viewbox_x1 << " " << viewbox_y1
         << " " << width << " " << height << "\""
         << " xmlns=\"http://www.w3.org/2000/svg\">"
-        << "<style type=\"text/css\">"
-        << "line{stroke:black;stroke-width:1.0;stroke-opacity:1.0;stroke-linecap:round;};"
-        << "</style>"
+		// interferes with the styling of the lines
+        //<< "<style type=\"text/css\">"
+        //<< "line{stroke:black;stroke-width:1.0;stroke-opacity:1.0;stroke-linecap:round;};"
+        //<< "</style>"
         << std::endl;
 
     auto range_itr = component_ranges.begin();
@@ -134,8 +137,10 @@ void draw_svg(std::ostream &out,
         auto& range = *range_itr++;
         auto& x_off = range.x_offset;
         auto& y_off = range.y_offset;
+		//const algorithms::color_t node_color = !node_id_to_color.empty() ? node_id_to_color[graph.get_id(handle)] : COLOR_BLACK;
         for (auto& handle : component) {
             uint64_t a = 2 * number_bool_packing::unpack_number(handle);
+			algorithms::color_t color = node_id_to_color.empty() ? COLOR_BLACK : node_id_to_color[graph.get_id(handle)];
             out << "<line x1=\""
                 << (X[a] * scale) - x_off
                 << "\" x2=\""
@@ -144,6 +149,8 @@ void draw_svg(std::ostream &out,
                 << (Y[a] * scale) + y_off
                 << "\" y2=\""
                 << (Y[a + 1] * scale) + y_off
+				<< "\" stroke=\"" << to_rgba(color)
+				<< "\" stroke-width=\"" << line_width
                 << "\"/>"
                 << std::endl;
 

--- a/src/algorithms/draw.hpp
+++ b/src/algorithms/draw.hpp
@@ -69,7 +69,9 @@ void draw_svg(std::ostream &out,
               const std::vector<double> &Y,
               const PathHandleGraph &graph,
               const double& scale,
-              const double& border);
+              const double& border,
+			  const double& line_width,
+			  std::vector<algorithms::color_t>& node_id_to_color);
 
 std::vector<uint8_t> rasterize(const std::vector<double> &X,
                                const std::vector<double> &Y,

--- a/src/subcommand/draw_main.cpp
+++ b/src/subcommand/draw_main.cpp
@@ -41,7 +41,7 @@ int main_draw(int argc, char **argv) {
     args::ValueFlag<uint64_t> png_height(visualizations_opts, "FILE", "Height of PNG rendering (default: 1000).", {'H', "png-height"});
     args::ValueFlag<uint64_t> png_border(visualizations_opts, "FILE", "Size of PNG border in bp (default: 10).", {'E', "png-border"});
     args::Flag color_paths(visualizations_opts, "color-paths", "Color paths (in PNG output).", {'C', "color-paths"});
-    args::ValueFlag<double> render_scale(visualizations_opts, "N", "Image scaling (default 1.0).", {'R', "scale"});
+    args::ValueFlag<double> render_scale(visualizations_opts, "N", "Image scaling (default 0.001).", {'R', "scale"});
     args::ValueFlag<double> render_border(visualizations_opts, "N", "Image border (in approximate bp) (default 100.0).", {'B', "border"});
     args::ValueFlag<double> png_line_width(visualizations_opts, "N", "Line width (in approximate bp) (default 0.0).", {'w', "line-width"});
     //args::ValueFlag<double> png_line_overlay(parser, "N", "line width (in approximate bp) (default 10.0)", {'O', "line-overlay"});
@@ -174,7 +174,7 @@ int main_draw(int argc, char **argv) {
     const double _png_line_width = png_line_width ? args::get(png_line_width) : 0;
     const bool _color_paths = args::get(color_paths);
     const double _png_path_line_spacing = png_path_line_spacing ? args::get(png_path_line_spacing) : 0.0;
-    const double svg_scale = !render_scale ? 1.0 : args::get(render_scale);
+    const double svg_scale = !render_scale ? 0.01 : args::get(render_scale);
     size_t max_node_depth = 0;
     graph.for_each_handle(
         [&](const handle_t& h) {
@@ -216,7 +216,7 @@ int main_draw(int argc, char **argv) {
         // todo could be done with callbacks
         std::vector<double> X = layout.get_X();
         std::vector<double> Y = layout.get_Y();
-        algorithms::draw_svg(f, X, Y, graph, svg_scale, border_bp);
+        algorithms::draw_svg(f, X, Y, graph, svg_scale, border_bp, _png_line_width, node_id_to_color);
         f.close();    
     }
 


### PR DESCRIPTION
Allows us to add BED annotations to SVGs, for pretty plots like this:

![image](https://github.com/pangenome/odgi/assets/145425/f3cae29c-793f-450c-b50e-7ccdcd112398)

The scaling of everything in SVG is a bit insane. It could use some work.