### PR TITLE
write highlights over black/grey lines in SVG

### DIFF
--- a/src/algorithms/draw.cpp
+++ b/src/algorithms/draw.cpp
@@ -138,9 +138,34 @@ void draw_svg(std::ostream &out,
         auto& x_off = range.x_offset;
         auto& y_off = range.y_offset;
 		//const algorithms::color_t node_color = !node_id_to_color.empty() ? node_id_to_color[graph.get_id(handle)] : COLOR_BLACK;
+
+        std::vector<handle_t> highlights;
+
         for (auto& handle : component) {
             uint64_t a = 2 * number_bool_packing::unpack_number(handle);
 			algorithms::color_t color = node_id_to_color.empty() ? COLOR_BLACK : node_id_to_color[graph.get_id(handle)];
+            if (color == COLOR_BLACK || color == COLOR_LIGHTGRAY) {
+                out << "<line x1=\""
+                    << (X[a] * scale) - x_off
+                    << "\" x2=\""
+                    << (X[a + 1] * scale) - x_off
+                    << "\" y1=\""
+                    << (Y[a] * scale) + y_off
+                    << "\" y2=\""
+                    << (Y[a + 1] * scale) + y_off
+                    << "\" stroke=\"" << to_hexrgb(color) //to_rgba(color) // with rgb, nodes are invisible with InkScape
+                    << "\" stroke-width=\"" << line_width
+                    << "\"/>"
+                    << std::endl;
+            } else {
+                highlights.push_back(handle);
+            }
+        }
+
+        // color highlights
+        for (auto& handle : highlights) {
+            uint64_t a = 2 * number_bool_packing::unpack_number(handle);
+            algorithms::color_t color = node_id_to_color.empty() ? COLOR_BLACK : node_id_to_color[graph.get_id(handle)];
             out << "<line x1=\""
                 << (X[a] * scale) - x_off
                 << "\" x2=\""
@@ -149,11 +174,10 @@ void draw_svg(std::ostream &out,
                 << (Y[a] * scale) + y_off
                 << "\" y2=\""
                 << (Y[a + 1] * scale) + y_off
-				<< "\" stroke=\"" << to_hexrgb(color) //to_rgba(color) // with rgb, nodes are invisible with InkScape
-				<< "\" stroke-width=\"" << line_width
+                << "\" stroke=\"" << to_hexrgb(color) //to_rgba(color) // with rgb, nodes are invisible with InkScape
+                << "\" stroke-width=\"" << line_width
                 << "\"/>"
                 << std::endl;
-
         }
     }
 

--- a/src/subcommand/draw_main.cpp
+++ b/src/subcommand/draw_main.cpp
@@ -41,7 +41,7 @@ int main_draw(int argc, char **argv) {
     args::ValueFlag<uint64_t> png_height(visualizations_opts, "FILE", "Height of PNG rendering (default: 1000).", {'H', "png-height"});
     args::ValueFlag<uint64_t> png_border(visualizations_opts, "FILE", "Size of PNG border in bp (default: 10).", {'E', "png-border"});
     args::Flag color_paths(visualizations_opts, "color-paths", "Color paths (in PNG output).", {'C', "color-paths"});
-    args::ValueFlag<double> render_scale(visualizations_opts, "N", "Image scaling (default 0.001).", {'R', "scale"});
+    args::ValueFlag<double> svg_render_scale(visualizations_opts, "N", "SVG image scaling (default 0.01).", {'R', "scale"});
     args::ValueFlag<double> render_border(visualizations_opts, "N", "Image border (in approximate bp) (default 100.0).", {'B', "border"});
     args::ValueFlag<double> png_line_width(visualizations_opts, "N", "Line width (in approximate bp) (default 10.0).", {'w', "line-width"});
     //args::ValueFlag<double> png_line_overlay(parser, "N", "line width (in approximate bp) (default 10.0)", {'O', "line-overlay"});
@@ -174,7 +174,7 @@ int main_draw(int argc, char **argv) {
     const double _png_line_width = png_line_width ? args::get(png_line_width) : 10.0;
     const bool _color_paths = args::get(color_paths);
     const double _png_path_line_spacing = png_path_line_spacing ? args::get(png_path_line_spacing) : 0.0;
-    const double svg_scale = !render_scale ? 0.01 : args::get(render_scale);
+    const double svg_scale = !svg_render_scale ? 0.01 : args::get(svg_render_scale);
     size_t max_node_depth = 0;
     graph.for_each_handle(
         [&](const handle_t& h) {


### PR DESCRIPTION
Mimic #547  logic also for the SVG files in order to avoid
![image](https://github.com/pangenome/odgi/assets/62253982/16347b72-a83c-4f9a-9af3-eb20934a4769)

and get instead
![image](https://github.com/pangenome/odgi/assets/62253982/2d0a1863-33b3-443e-8977-9059522e93dc)
