### PR TITLE
`odgi draw`: add node sparsification factor for SVG output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ docs/sphinx_build_man
 docs/_build
 Testing/
 .idea/
+.vscode/
+.cmake/
+cmake-build-debug/

--- a/src/algorithms/draw.hpp
+++ b/src/algorithms/draw.hpp
@@ -73,7 +73,8 @@ void draw_svg(std::ostream &out,
 			  const double& line_width,
 			  std::vector<algorithms::color_t>& node_id_to_color,
               ska::flat_hash_map<handlegraph::nid_t, std::set<std::string>>& node_id_to_label_map,
-              const float& sparsification_factor);
+              const float& sparsification_factor,
+              const bool& lengthen_left_nodes);
 
 std::vector<uint8_t> rasterize(const std::vector<double> &X,
                                const std::vector<double> &Y,

--- a/src/algorithms/draw.hpp
+++ b/src/algorithms/draw.hpp
@@ -72,7 +72,8 @@ void draw_svg(std::ostream &out,
               const double& border,
 			  const double& line_width,
 			  std::vector<algorithms::color_t>& node_id_to_color,
-              ska::flat_hash_map<handlegraph::nid_t, std::set<std::string>>& node_id_to_label_map);
+              ska::flat_hash_map<handlegraph::nid_t, std::set<std::string>>& node_id_to_label_map,
+              const float& sparsification_factor);
 
 std::vector<uint8_t> rasterize(const std::vector<double> &X,
                                const std::vector<double> &Y,

--- a/src/subcommand/draw_main.cpp
+++ b/src/subcommand/draw_main.cpp
@@ -51,7 +51,7 @@ int main_draw(int argc, char **argv) {
                                                 "Colors are derived from the 4th column, if present, else from the path name."
                                                 "If the 4th column value is in the format 'string#RRGGBB', the RRGGBB color (in hex notation) will be used.",
                                                 {'b', "bed-file"});
-    args::ValueFlag<float> node_sparsification(parser, "N", "Remove this fraction of nodes from the SVG output (to output smaller files) (default: 0.0, keep all nodes).", {'f', "sparse-factor-svg"});
+    args::ValueFlag<float> node_sparsification(parser, "N", "Remove this fraction of nodes from the SVG output (to output smaller files) (default: 0.0, keep all nodes).", {'f', "svg-sparse-factor"});
     args::Group threading(parser, "[ Threading ]");
 	args::ValueFlag<uint64_t> nthreads(threading, "N", "Number of threads to use for parallel operations.", {'t', "threads"});
 	args::Group processing_info_opts(parser, "[ Processing Information ]");
@@ -92,6 +92,12 @@ int main_draw(int argc, char **argv) {
         std::cerr
             << "[odgi::draw] error: please specify an output file to where to store the layout via -p/--png=[FILE], -s/--svg=[FILE], -T/--tsv=[FILE]"
             << std::endl;
+        return 1;
+    }
+
+    const float sparse_nodes = node_sparsification ? args::get(node_sparsification) : 0.0;
+    if (sparse_nodes < 0.0 || sparse_nodes > 1.0) {
+        std::cerr << "[odgi::draw] error: -f/--svg-sparse-factor must be in the range [0.0, 1.0]." << std::endl;
         return 1;
     }
 
@@ -220,7 +226,6 @@ int main_draw(int argc, char **argv) {
 
     if (svg_out_file) {
         const double svg_scale = !svg_render_scale ? 0.01 : args::get(svg_render_scale);
-        const float sparse_nodes = node_sparsification ? args::get(node_sparsification) : 0.0;
         auto& outfile = args::get(svg_out_file);
         ofstream f(outfile.c_str());
         // todo could be done with callbacks

--- a/src/subcommand/draw_main.cpp
+++ b/src/subcommand/draw_main.cpp
@@ -51,7 +51,8 @@ int main_draw(int argc, char **argv) {
                                                 "Colors are derived from the 4th column, if present, else from the path name."
                                                 "If the 4th column value is in the format 'string#RRGGBB', the RRGGBB color (in hex notation) will be used.",
                                                 {'b', "bed-file"});
-    args::ValueFlag<float> node_sparsification(parser, "N", "Remove this fraction of nodes from the SVG output (to output smaller files) (default: 0.0, keep all nodes).", {'f', "svg-sparse-factor"});
+    args::ValueFlag<float> node_sparsification(visualizations_opts, "N", "Remove this fraction of nodes from the SVG output (to output smaller files) (default: 0.0, keep all nodes).", {'f', "svg-sparse-factor"});
+    args::Flag lengthen_left_nodes(visualizations_opts, "lengthen", "When node sparsitication is active, lengthen the remaining nodes proportionally with the sparsification factor", {'l', "svg-lengthen-nodes"});
     args::Group threading(parser, "[ Threading ]");
 	args::ValueFlag<uint64_t> nthreads(threading, "N", "Number of threads to use for parallel operations.", {'t', "threads"});
 	args::Group processing_info_opts(parser, "[ Processing Information ]");
@@ -111,7 +112,7 @@ int main_draw(int argc, char **argv) {
             if (infile == "-") {
                 graph.deserialize(std::cin);
             } else {
-                utils::handle_gfa_odgi_input(infile, "draw", args::get(progress), num_threads, graph);
+                utils::handle_gfa_odgi_input(infile, "draw", lengthen_left_nodes, num_threads, graph);
             }
         }
     }
@@ -231,7 +232,7 @@ int main_draw(int argc, char **argv) {
         // todo could be done with callbacks
         std::vector<double> X = layout.get_X();
         std::vector<double> Y = layout.get_Y();
-        algorithms::draw_svg(f, X, Y, graph, svg_scale, border_bp, _png_line_width, node_id_to_color, node_id_to_label_map, sparse_nodes);
+        algorithms::draw_svg(f, X, Y, graph, svg_scale, border_bp, _png_line_width, node_id_to_color, node_id_to_label_map, sparse_nodes, args::get(lengthen_left_nodes));
         f.close();    
     }
 


### PR DESCRIPTION
This allows us to make smaller SVG output for big graphs

**-f 0.1**
![x_0 1](https://github.com/pangenome/odgi/assets/62253982/f703b425-c529-49a0-8e16-2282364e2e7d)

**-f 0.3**
![x_0 3](https://github.com/pangenome/odgi/assets/62253982/2b0d766b-e7bd-496f-9605-a77db46d592b)

**-f 0.5**
![x_0 5](https://github.com/pangenome/odgi/assets/62253982/ed9a232a-a3c2-49e7-b8c7-0760fa6c5be4)

**-f 0.7**
![x_0 7](https://github.com/pangenome/odgi/assets/62253982/1176e27a-82a8-41cd-8b16-d4b4f973b9ec)

**-f 0.9**
![x_0 9](https://github.com/pangenome/odgi/assets/62253982/939bf015-8ce5-4233-9184-d6b8271b599b)

**-f 1.0** (no node sparsification)
![x_1 0](https://github.com/pangenome/odgi/assets/62253982/7ae53094-808b-4a5b-8ef9-a1c8e7dfac5b)
