### PR TITLE
fix outgoing links of the last node

### DIFF
--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -739,11 +739,16 @@ namespace odgi {
 
         auto add_edge_from_handles = [&](const handle_t& h, const handle_t& o) {
             // map into our bins
-            const uint64_t _a = position_map[number_bool_packing::unpack_number(h) + !number_bool_packing::unpack_bit(h) - shift] / _bin_width + 1;
-            const uint64_t _b = position_map[number_bool_packing::unpack_number(o) + number_bool_packing::unpack_bit(o) - shift] / _bin_width + 1;
+            const uint64_t index_h = number_bool_packing::unpack_number(h) + !number_bool_packing::unpack_bit(h) - shift;
+            const uint64_t index_o = number_bool_packing::unpack_number(o) + number_bool_packing::unpack_bit(o) - shift;
+            const uint64_t _a = position_map[index_h] / _bin_width;
+            const uint64_t _b = position_map[index_o] / _bin_width;
+
+            // The last node has to be treated differently, as it has no following node, and its outgoing links would start outside the image
+            const double x_shift = (index_h == position_map.size() - 1) || (index_o == position_map.size() - 1) ? (1.0 / _bin_width) : 0.0;
 
             const uint64_t a = std::min(_a, _b);
-            const uint64_t b = std::max(_a, _b);
+            const uint64_t b = std::max(_a, _b) >= x_shift ? (std::max(_a, _b) - x_shift) : 0;
 
 #ifdef debug_odgi_viz
             std::cerr << graph.get_id(h) << " (" << number_bool_packing::unpack_bit(h) << ") --> " << graph.get_id(o) << " (" << number_bool_packing::unpack_bit(o) << ") " << std::endl;


### PR DESCRIPTION
The last node has no following nodes, so its outgoing links, when in forward, started outside the image range, resulting in missing vertical black lines.