### PR TITLE
Include STL so steps_of_handle works

### DIFF
--- a/src/pythonmodule.cpp
+++ b/src/pythonmodule.cpp
@@ -5,6 +5,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/functional.h>
 #include <pybind11/iostream.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 


### PR DESCRIPTION
This patch fixes a minor bug in the python API wherein `std::vector<handlegraph::step_handle_t, std::allocator<handlegraph::step_handle_t> >` returned by `steps_of_handle()` is an unregistered type:

    TypeError: Unregistered type : std::vector<handlegraph::step_handle_t, std::allocator<handlegraph::step_handle_t> >

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "/local0/phylosopher/user_dirs/dryan/pangenome/wtf.py", line 45, in <module>
        og.for_each_step_in_path(ph, lambda nodeH: filterNodes(nog, og, nodeH, addedNodes, excludedNodes, args.minLen, args.minPaths))
      File "/local0/phylosopher/user_dirs/dryan/pangenome/wtf.py", line 45, in <lambda>
        og.for_each_step_in_path(ph, lambda nodeH: filterNodes(nog, og, nodeH, addedNodes, excludedNodes, args.minLen, args.minPaths))
                                               
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/local0/phylosopher/user_dirs/dryan/pangenome/wtf.py", line 18, in filterNodes
        for step in og.steps_of_handle(h, False):  # ignore orientation with False
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    TypeError: Unable to convert function return value to a Python type! The signature was
            (self: odgi.graph, arg0: odgi.handle, arg1: bool) -> std::vector<handlegraph::step_handle_t, std::allocator<handlegraph::step_handle_t> >

    Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
    <pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
    conversions are optional and require extra headers to be included
    when compiling your pybind11 module.

I've tested locally and this minor change corrects this and this function now returns an iterable list in python.