### PR TITLE
WIP: Improving random number generation on gpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -637,6 +637,7 @@ add_library(odgi_objs OBJECT
 )
 if (USE_GPU)
   target_sources(odgi_objs PRIVATE "${CMAKE_SOURCE_DIR}/src/cuda/layout.cu")
+  # target_compile_options(odgi_objs PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas="-v">)
 endif (USE_GPU)
 
 set(odgi_DEPS
@@ -704,8 +705,19 @@ set(odgi_INCLUDES
   "${xoshiro_INCLUDE}"
   "${atomicbitvector_INCLUDE}"
   "${mio_INCLUDE}")
+
+include(FetchContent)
+FetchContent_Declare(
+  crng
+  GIT_REPOSITORY https://github.com/msu-sparta/OpenRAND.git
+  GIT_TAG        main
+)
+
+FetchContent_MakeAvailable(crng)
+  
 if (USE_GPU)
   list(APPEND odgi_INCLUDES "${CUDA_INCLUDE_DIRS}")
+  list(APPEND odgi_INCLUDES "${crng_SOURCE_DIR}/include")
 endif (USE_GPU)
 
 set(odgi_LIBS
@@ -857,10 +869,16 @@ else (NOT PIC)
   add_dependencies(libodgi_shared ${odgi_DEPS})
 endif (NOT PIC)
 
+
 add_executable(odgi
   $<TARGET_OBJECTS:odgi_objs>
   ${CMAKE_SOURCE_DIR}/src/main.cpp)
 target_link_libraries(odgi ${odgi_LIBS})
+# if (USE_GPU)
+#   message(STATUS "OPENRAND: ${crng_SOURCE_DIR}")
+#   target_link_libraries(odgi crng)
+#   target_include_directories(odgi PRIVATE ${crng_SOURCE_DIR}/include)
+# endif (USE_GPU)
 set_target_properties(odgi PROPERTIES OUTPUT_NAME "odgi")
 
 


### PR DESCRIPTION
Hi,

This PR attempts to improve the random number generation component of GPU accelerated `odgi-layout`. It replaces the current generator with a counter-based one: Philox. These can be created, used and discarded all from within thread registers, completely eliminating any global memory bookkeeping, communication etc. It also makes the code reproducible and it is statistically very robust.  

On a V100 GPU, I noticed performance improvement of around 17%. On A100-SXM4 with significantly higher memory speed, the effect was a little less pronouned. But it was still around 10%.

This is a work-in-progress, it needs a bit of cleanup. I am more than happy to hear you suggestions, feedback and incorporate them back into the code. 

On a relevant note, I am still trying to figure things out, but it seems the current code assumes there can be at most one thread block running on a SM. There appears to be one `curandStateXORWOWCoalesced_t` object _per SM_, so if there is more than one block on a SM, that could create race condition. 

Thanks to @tonyjie, @subwaystation for helping me set this odgi up.