### PR TITLE
added checks for apple sillicon and cmake4.0+ version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin") # untested
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
   set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS} -lomp")
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -lomp")  # explicitly link OpenMP for building shared libs
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  find_package(OpenMP REQUIRED)
   # add the flags it detects to the compile flags
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -fopenmp")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -fopenmp")


### PR DESCRIPTION
Was able to successfully build ODGI on M2 Mac Pro with these changes.


The primary errors that were seen:

1. Existing flags for linking OpenMP for MacOS was used to link just the executable, leading to failures when building `libodgi.dylib`. We need to set CMAKE_SHARED_LINKER_FLAGS to link openMP for building `libodgi.dylib` which is a shared library. Other option is to globally set `$LDFLAGS` to include -lomp.
2.  CMake has removed direct compatibility with versions older than 3.5 starting 4.0. This led to errors when version < 3.5 was specified in cmake_minimum_required. The fix was to add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 flag to override the minimum version.
3. jemalloc lib is usualy installed via homebrew in mac. Added support to identify and link homebrew libraries.



System Description:

```
cmake version 4.0.3

Homebrew clang version 17.0.6
Target: arm64-apple-darwin24.5.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm@17/bin

$CPPFLAGS
-I/opt/homebrew/opt/zlib/include -I/opt/homebrew/opt/libomp/include -I/opt/homebrew/opt/llvm@17/include

$LDFLAGS
-L/opt/homebrew/opt/zlib/lib -L/opt/homebrew/opt/libomp/lib -L/opt/homebrew/opt/llvm@17/lib

$PKG_CONFIG_PATH
/opt/homebrew/lib/pkgconfig:
```

Build Description:

```
 cmake -H. -Bbuild -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 cmake --build build -- -j 3
```

References: 
1. https://github.com/ekg/seqwish/issues/117
2. https://github.com/pangenome/odgi/pull/494
3. https://github.com/waveygang/wfmash/pull/361