### PR TITLE
Fix compilation on aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ endif()
 
 # Set optimization through command line; see INSTALL.md
 if (${CMAKE_BUILD_TYPE} MATCHES Release)
-  set(EXTRA_FLAGS "-Ofast -march=native -pipe -msse4.2 -funroll-all-loops") #  -fprofile-generate=../pgo")
+  set(EXTRA_FLAGS "-Ofast -march=native -pipe -funroll-all-loops") #  -fprofile-generate=../pgo")
   set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG") # reset CXX_FLAGS to be able to replace -O3 with -Ofast
 endif ()
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,9 @@ void odgi_help(char** argv) {
 
 // We make sure to compile main for the lowest common denominator architecture.
 // This works on GCC and Clang. But we have to declare main and then define it.
+#if __x86_64__
 int main(int argc, char *argv[]) __attribute__((__target__("arch=x86-64")));
+#endif
 
 int main(int argc, char *argv[]) {
     // set a higher value for tcmalloc warnings


### PR DESCRIPTION
Makes `__target__("arch=x86-64")` conditional and removes `-msse4.2` (as `-march=native` will automatically apply it for platforms that support it).