### PR TITLE
`odgi prune`: add options to preserve paths during pruning (split or drop affected paths)

### DIFF
--- a/docs/rst/commands/odgi_prune.rst
+++ b/docs/rst/commands/odgi_prune.rst
@@ -91,6 +91,12 @@ Path Options
 | **-y, --drop-empty-paths**
 | Remove empty paths from the graph.
 
+| **-S, --split-paths**
+| When pruning nodes/edges, keep the surviving paths by splitting them into subpaths (named *PATH:START-END*) at every removed node and edge, instead of dropping all paths. Without **-S** or **-A**, pruning removes every path from the output (a warning is printed) because removing a node or an edge breaks the paths that traverse it.
+
+| **-A, --drop-affected-paths**
+| When pruning nodes/edges, drop only the paths that traverse a removed node or edge, keeping the untouched paths intact, instead of dropping all paths. Mutually exclusive with **-S, --split-paths**.
+
 | **-m, --cut-tips-min-depth**\ =\ *N*
 | Remove nodes which are graph tips and have less than *N* path depth.
 

--- a/docs/rst/commands/odgi_prune.rst
+++ b/docs/rst/commands/odgi_prune.rst
@@ -97,6 +97,12 @@ Path Options
 | **-A, --drop-affected-paths**
 | When pruning nodes/edges, drop only the paths that traverse a removed node or edge, keeping the untouched paths intact, instead of dropping all paths. Mutually exclusive with **-S, --split-paths**.
 
+| **-K, --keep-paths-intact**\ =\ *FILE*
+| Keep the paths named in *FILE* (one name per line) intact: the nodes and edges they use are never pruned, so these paths survive whole (e.g. to keep reference paths uncut) while the rest are split or dropped. Requires **-S, --split-paths** or **-A, --drop-affected-paths**.
+
+| **--keep-path-prefix**\ =\ *PREFIX*
+| Keep every path whose name starts with *PREFIX* intact, as with **-K, --keep-paths-intact**. May be given multiple times. Requires **-S, --split-paths** or **-A, --drop-affected-paths**.
+
 | **-m, --cut-tips-min-depth**\ =\ *N*
 | Remove nodes which are graph tips and have less than *N* path depth.
 

--- a/src/algorithms/prune.cpp
+++ b/src/algorithms/prune.cpp
@@ -36,7 +36,7 @@ std::vector<recorded_path_t> record_paths(const graph_t& graph) {
 
 prune_path_rebuild_stats_t rebuild_pruned_paths(const std::vector<recorded_path_t>& recorded_paths,
                                                 graph_t& subgraph,
-                                                const damaged_path_policy_t policy) {
+                                                const affected_path_policy_t policy) {
     prune_path_rebuild_stats_t stats;
     // A run is a maximal stretch of steps that is a valid walk in the pruned subgraph: every node
     // present, consecutive nodes joined by a surviving edge.
@@ -78,7 +78,7 @@ prune_path_rebuild_stats_t rebuild_pruned_paths(const std::vector<recorded_path_
         }
         const uint64_t path_len = walked;
 
-        // An empty path (no steps) cannot be damaged; treat it as intact.
+        // An empty path (no steps) cannot be affected; treat it as intact.
         if (rp.steps.empty()) {
             subgraph.create_path_handle(rp.name, rp.is_circular);
             ++stats.paths_intact;
@@ -95,7 +95,7 @@ prune_path_rebuild_stats_t rebuild_pruned_paths(const std::vector<recorded_path_
                 subgraph.append_step(np, h);
             }
             ++stats.paths_intact;
-        } else if (policy == damaged_path_policy_t::drop_affected) {
+        } else if (policy == affected_path_policy_t::drop_affected) {
             ++stats.paths_dropped;
         } else { // split
             if (runs.empty()) {

--- a/src/algorithms/prune.cpp
+++ b/src/algorithms/prune.cpp
@@ -1,8 +1,120 @@
 #include "prune.hpp"
+#include "algorithms/subgraph/extract.hpp" // make_path_name, for consistent subpath naming
 
 namespace odgi {
 
 namespace algorithms {
+
+static_assert(sizeof(recorded_step_t) == 12, "recorded_step_t should pack into 12 bytes");
+
+std::vector<recorded_path_t> record_paths(const graph_t& graph) {
+    // The node id is kept full-width; only the length is packed (31 bits), so guard against overflow.
+    std::vector<recorded_path_t> recorded;
+    recorded.reserve(graph.get_path_count());
+    graph.for_each_path_handle([&](const path_handle_t& p) {
+        recorded_path_t rp;
+        rp.name = graph.get_path_name(p);
+        rp.is_circular = graph.get_is_circular(p);
+        graph.for_each_step_in_path(p, [&](const step_handle_t& step) {
+            const handle_t h = graph.get_handle_of_step(step);
+            const uint64_t len = graph.get_length(h);
+            if (len > 0x7FFFFFFFull) {
+                std::cerr << "[odgi::prune] error: node " << graph.get_id(h) << " length " << len
+                          << " exceeds 2^31; -S/-A path rebuilding is unsupported for this graph." << std::endl;
+                exit(1);
+            }
+            recorded_step_t s;
+            s.set_node_id(graph.get_id(h));
+            s.length = (uint32_t)len;
+            s.is_rev = graph.get_is_reverse(h);
+            rp.steps.push_back(s);
+        });
+        recorded.push_back(std::move(rp));
+    });
+    return recorded;
+}
+
+prune_path_rebuild_stats_t rebuild_pruned_paths(const std::vector<recorded_path_t>& recorded_paths,
+                                                graph_t& subgraph,
+                                                const damaged_path_policy_t policy) {
+    prune_path_rebuild_stats_t stats;
+    // A run is a maximal stretch of steps that is a valid walk in the pruned subgraph: every node
+    // present, consecutive nodes joined by a surviving edge.
+    struct run_t {
+        uint64_t start = 0;                 // path offset (bp) at the run's start
+        uint64_t end = 0;                   // path offset (bp) at the run's end
+        std::vector<handle_t> handles;      // subgraph handles in path order
+    };
+
+    // Single-threaded: concurrent append_step to shared nodes races on the in-place graph.
+    for (auto& rp : recorded_paths) {
+        std::vector<run_t> runs;
+        uint64_t walked = 0;      // bp walked along the recorded path
+        bool in_run = false;
+        handle_t prev_dest;
+
+        for (auto& st : rp.steps) {
+            if (subgraph.has_node(st.node_id())) {
+                const handle_t dest_h = subgraph.get_handle(st.node_id(), st.is_rev);
+                if (!in_run) {
+                    runs.push_back({walked, 0, {dest_h}});
+                    in_run = true;
+                } else if (subgraph.has_edge(prev_dest, dest_h)) {
+                    runs.back().handles.push_back(dest_h);
+                } else {
+                    // both nodes survived but the connecting edge was pruned: break here
+                    runs.back().end = walked;
+                    runs.push_back({walked, 0, {dest_h}});
+                }
+                prev_dest = dest_h;
+            } else if (in_run) {
+                runs.back().end = walked;
+                in_run = false;
+            }
+            walked += st.length;
+        }
+        if (in_run) {
+            runs.back().end = walked;
+        }
+        const uint64_t path_len = walked;
+
+        // An empty path (no steps) cannot be damaged; treat it as intact.
+        if (rp.steps.empty()) {
+            subgraph.create_path_handle(rp.name, rp.is_circular);
+            ++stats.paths_intact;
+            continue;
+        }
+
+        const bool intact = (runs.size() == 1
+                             && runs.front().start == 0
+                             && runs.front().end == path_len);
+
+        if (intact) {
+            const path_handle_t np = subgraph.create_path_handle(rp.name, rp.is_circular);
+            for (auto& h : runs.front().handles) {
+                subgraph.append_step(np, h);
+            }
+            ++stats.paths_intact;
+        } else if (policy == damaged_path_policy_t::drop_affected) {
+            ++stats.paths_dropped;
+        } else { // split
+            if (runs.empty()) {
+                ++stats.paths_dropped;
+            } else {
+                for (auto& run : runs) {
+                    const path_handle_t np = subgraph.create_path_handle(
+                        make_path_name(rp.name, run.start, run.end), false);
+                    for (auto& h : run.handles) {
+                        subgraph.append_step(np, h);
+                    }
+                    ++stats.subpaths_created;
+                }
+                ++stats.paths_split;
+            }
+        }
+    }
+    return stats;
+}
 
 std::vector<edge_t> find_edges_to_prune(const HandleGraph& graph,
                                         size_t k, size_t edge_max,

--- a/src/algorithms/prune.hpp
+++ b/src/algorithms/prune.hpp
@@ -8,8 +8,9 @@
 #include <handlegraph/util.hpp>
 #include <handlegraph/handle_graph.hpp>
 #include "position.hpp"
+#include "odgi.hpp"
 
-/** \file 
+/** \file
  * Functions for working with `kmers_t`'s in HandleGraphs.
  */
 
@@ -18,6 +19,49 @@ namespace odgi {
 using namespace handlegraph;
 
 namespace algorithms {
+
+/// How to treat paths damaged when prune removes nodes and/or edges.
+enum class damaged_path_policy_t {
+    split,          // break each path into subpaths at every removed node/edge
+    drop_affected   // keep only fully-intact paths; drop the rest
+};
+
+/// One step of a recorded path in 12 bytes. The node id is kept full-width (nid_t) as two uint32
+/// halves so the struct stays 4-byte aligned; only the length is packed (31 bits, guarded in
+/// record_paths). Lengths let us name split subpaths in original path coordinates.
+struct recorded_step_t {
+    uint32_t id_low;
+    uint32_t id_high;
+    uint32_t length : 31;
+    uint32_t is_rev : 1;
+    nid_t node_id() const { return (nid_t)(((uint64_t)id_high << 32) | id_low); }
+    void set_node_id(nid_t v) { id_low = (uint32_t)v; id_high = (uint32_t)((uint64_t)v >> 32); }
+};
+
+/// A path snapshot taken while the graph is still intact.
+struct recorded_path_t {
+    std::string name;
+    bool is_circular = false;
+    std::vector<recorded_step_t> steps;
+};
+
+struct prune_path_rebuild_stats_t {
+    uint64_t paths_intact = 0;     // re-embedded whole (untouched by pruning)
+    uint64_t paths_split = 0;      // affected paths that yielded >=1 subpath
+    uint64_t subpaths_created = 0; // total subpaths from split paths
+    uint64_t paths_dropped = 0;    // nothing left, or dropped by drop_affected
+};
+
+/// Snapshot every path so it can be rebuilt after pruning. Must run before any destroy; we
+/// snapshot rather than graph_t::copy because that copy corrupts path linkage.
+std::vector<recorded_path_t> record_paths(const graph_t& graph);
+
+/// Re-embed recorded paths into the already-pruned `subgraph` (which must have no paths). A run
+/// breaks at any removed node or removed edge. split emits every maximal run (whole-path runs keep
+/// the name, broken pieces are PATH:START-END); drop_affected keeps a path only if fully intact.
+prune_path_rebuild_stats_t rebuild_pruned_paths(const std::vector<recorded_path_t>& recorded_paths,
+                                                graph_t& subgraph,
+                                                const damaged_path_policy_t policy);
 
 /// Record a <=k-length walk in the context of a graph.
 struct walk_t {

--- a/src/algorithms/prune.hpp
+++ b/src/algorithms/prune.hpp
@@ -20,8 +20,8 @@ using namespace handlegraph;
 
 namespace algorithms {
 
-/// How to treat paths damaged when prune removes nodes and/or edges.
-enum class damaged_path_policy_t {
+/// How to treat paths affected when prune removes nodes and/or edges.
+enum class affected_path_policy_t {
     split,          // break each path into subpaths at every removed node/edge
     drop_affected   // keep only fully-intact paths; drop the rest
 };
@@ -61,7 +61,7 @@ std::vector<recorded_path_t> record_paths(const graph_t& graph);
 /// the name, broken pieces are PATH:START-END); drop_affected keeps a path only if fully intact.
 prune_path_rebuild_stats_t rebuild_pruned_paths(const std::vector<recorded_path_t>& recorded_paths,
                                                 graph_t& subgraph,
-                                                const damaged_path_policy_t policy);
+                                                const affected_path_policy_t policy);
 
 /// Record a <=k-length walk in the context of a graph.
 struct walk_t {

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -132,13 +132,13 @@ int main_prune(int argc, char** argv) {
     // with -S/-A we snapshot the paths first (before any filter, since -d clears them), run the
     // filters, then rebuild the survivors edge-aware (algorithms::rebuild_pruned_paths).
     const uint64_t n_paths_before = graph.get_path_count();
-    // -c1 alone removes only depth-0 (unpathed) nodes, so it can't damage a path; other filters can.
+    // -c1 alone removes only depth-0 (unpathed) nodes, so it can't affect a path; other filters can.
     const bool only_depth0 = (args::get(min_depth) == 1 && args::get(max_depth) == 0)
         && !args::get(max_degree) && !args::get(max_furcations) && !args::get(best_edges);
-    const bool damages_paths = n_paths_before > 0 && !only_depth0
+    const bool affects_paths = n_paths_before > 0 && !only_depth0
         && (args::get(max_degree) || args::get(max_furcations)
             || args::get(min_depth) || args::get(max_depth) || args::get(best_edges));
-    const bool rebuild = rebuild_paths_requested && damages_paths;
+    const bool rebuild = rebuild_paths_requested && affects_paths;
 
     std::vector<algorithms::recorded_path_t> recorded_paths;
     if (rebuild) {
@@ -154,7 +154,7 @@ int main_prune(int argc, char** argv) {
         for (auto& edge : to_prune) {
             graph.destroy_edge(edge);
         }
-        // leaves edge-damaged paths in place; the path handling below drops or rebuilds them
+        // leaves edge-affected paths in place; the path handling below drops or rebuilds them
     }
     if (args::get(min_depth) || args::get(max_depth) || args::get(best_edges)) {
         std::vector<handle_t> handles_to_drop;
@@ -205,16 +205,16 @@ int main_prune(int argc, char** argv) {
         }
     }
 
-    // Rebuild or drop the damaged paths, once, for whichever filters ran above.
+    // Rebuild or drop the affected paths, once, for whichever filters ran above.
     if (rebuild) {
         graph.clear_paths(); // drop any partial/invalid paths a filter left behind (e.g. -e)
-        const algorithms::damaged_path_policy_t policy = split_paths_requested
-            ? algorithms::damaged_path_policy_t::split
-            : algorithms::damaged_path_policy_t::drop_affected;
+        const algorithms::affected_path_policy_t policy = split_paths_requested
+            ? algorithms::affected_path_policy_t::split
+            : algorithms::affected_path_policy_t::drop_affected;
         const algorithms::prune_path_rebuild_stats_t st =
             algorithms::rebuild_pruned_paths(recorded_paths, graph, policy);
         if (split_paths_requested) {
-            std::cerr << "[odgi::prune] split " << st.paths_split << " damaged path(s) into "
+            std::cerr << "[odgi::prune] split " << st.paths_split << " affected path(s) into "
                       << st.subpaths_created << " subpath(s), kept " << st.paths_intact
                       << " path(s) intact";
             if (st.paths_dropped) {
@@ -225,8 +225,8 @@ int main_prune(int argc, char** argv) {
             std::cerr << "[odgi::prune] kept " << st.paths_intact << " intact path(s), dropped "
                       << st.paths_dropped << " affected path(s)." << std::endl;
         }
-    } else if (damages_paths && !args::get(expand_path_length)) {
-        // Default: ensure the damaged paths are gone (some filters, e.g. -e, keep them) and warn.
+    } else if (affects_paths && !args::get(expand_path_length)) {
+        // Default: ensure the affected paths are gone (some filters, e.g. -e, keep them) and warn.
         // -p re-embeds paths itself, so it is excluded here.
         if (graph.get_path_count() > 0) {
             graph.clear_paths();

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -9,6 +9,9 @@
 #include "algorithms/remove_isolated.hpp"
 #include "algorithms/expand_context.hpp"
 #include "utils.hpp"
+#include <unordered_set>
+#include <set>
+#include <algorithm>
 
 namespace odgi {
 
@@ -54,6 +57,8 @@ int main_prune(int argc, char** argv) {
     args::Flag drop_empty_paths(path_opts, "bool", "Remove empty paths from the graph.", {'y', "drop-empty-paths"});
     args::Flag split_paths(path_opts, "bool", "When pruning nodes/edges, keep the surviving paths by splitting them into subpaths (named *PATH:START-END*) at every removed node and edge, instead of dropping all paths.", {'S', "split-paths"});
     args::Flag drop_affected_paths(path_opts, "bool", "When pruning nodes/edges, drop only the paths that traverse a removed node or edge, keeping the untouched paths intact, instead of dropping all paths.", {'A', "drop-affected-paths"});
+    args::ValueFlag<std::string> keep_paths_file(path_opts, "FILE", "Keep the paths named in *FILE* (one per line) intact: never prune the nodes or edges they use, so they survive pruning whole. Requires **-S** or **-A**.", {'K', "keep-paths-intact"});
+    args::ValueFlagList<std::string> keep_path_prefix(path_opts, "PREFIX", "Keep every path whose name starts with *PREFIX* intact (repeatable). Requires **-S** or **-A**.", {"keep-path-prefix"});
     args::ValueFlag<uint64_t> cut_tips_min_depth(path_opts, "N", "Remove nodes which are graph tips and have less than *N* path depth.", {'m', "cut-tips-min-depth"});
     args::Flag remove_isolated(path_opts, "bool", "Remove isolated nodes covered by a single path.", {'I', "remove-isolated"});
     args::Group threading_opts(parser, "[ Threading ]");
@@ -112,6 +117,14 @@ int main_prune(int argc, char** argv) {
         }
     }
 
+    // Paths to keep intact: their nodes/edges are excluded from every removal list below, so they
+    // survive pruning whole while the rest are split (-S) or dropped (-A).
+    const bool keep_intact_requested = keep_paths_file || !args::get(keep_path_prefix).empty();
+    if (keep_intact_requested && !rebuild_paths_requested) {
+        std::cerr << "[odgi::prune] error: --keep-paths-intact / --keep-path-prefix require -S/--split-paths or -A/--drop-affected-paths." << std::endl;
+        return 1;
+    }
+
 	const int n_threads = threads ? args::get(threads) : 1;
 
 	graph_t graph;
@@ -145,12 +158,62 @@ int main_prune(int argc, char** argv) {
         recorded_paths = algorithms::record_paths(graph);
     }
 
+    // Collect the nodes and edges used by the paths we must keep intact (by name or prefix), so we
+    // can drop them from the removal lists. Edges are stored in both orientations because a removal
+    // list may reference the same edge either way (edge_handle does not canonicalize).
+    std::unordered_set<nid_t> protected_nodes;
+    std::set<std::pair<uint64_t, uint64_t>> protected_edges;
+    if (keep_intact_requested) {
+        std::unordered_set<std::string> keep_names;
+        if (keep_paths_file) {
+            std::ifstream in(args::get(keep_paths_file));
+            std::string line;
+            while (std::getline(in, line)) {
+                if (!line.empty()) keep_names.insert(line);
+            }
+        }
+        const std::vector<std::string> prefixes = args::get(keep_path_prefix);
+        uint64_t n_kept_paths = 0;
+        graph.for_each_path_handle([&](const path_handle_t& p) {
+            const std::string name = graph.get_path_name(p);
+            bool keep = keep_names.count(name) > 0;
+            for (auto it = prefixes.begin(); !keep && it != prefixes.end(); ++it) {
+                keep = name.size() >= it->size() && name.compare(0, it->size(), *it) == 0;
+            }
+            if (!keep) return;
+            ++n_kept_paths;
+            handle_t prev;
+            bool first = true;
+            graph.for_each_step_in_path(p, [&](const step_handle_t& s) {
+                const handle_t h = graph.get_handle_of_step(s);
+                protected_nodes.insert(graph.get_id(h));
+                if (!first) {
+                    protected_edges.insert({as_integer(prev), as_integer(h)});
+                    protected_edges.insert({as_integer(graph.flip(h)), as_integer(graph.flip(prev))});
+                }
+                prev = h;
+                first = false;
+            });
+        });
+        std::cerr << "[odgi::prune] keeping " << n_kept_paths << " path(s) intact ("
+                  << protected_nodes.size() << " protected node(s))." << std::endl;
+    }
+    auto node_protected = [&](const handle_t& h) {
+        return protected_nodes.count(graph.get_id(h)) > 0;
+    };
+    auto edge_protected = [&](const edge_t& e) {
+        return protected_edges.count({as_integer(e.first), as_integer(e.second)}) > 0;
+    };
+
     if (args::get(max_degree)) {
         graph.clear_paths();
         algorithms::remove_high_degree_nodes(graph, args::get(max_degree));
     }
     if (args::get(max_furcations)) {
         std::vector<edge_t> to_prune = algorithms::find_edges_to_prune(graph, args::get(kmer_length), args::get(max_furcations), n_threads);
+        if (keep_intact_requested) {
+            to_prune.erase(std::remove_if(to_prune.begin(), to_prune.end(), edge_protected), to_prune.end());
+        }
         for (auto& edge : to_prune) {
             graph.destroy_edge(edge);
         }
@@ -168,6 +231,11 @@ int main_prune(int argc, char** argv) {
         }
         if (args::get(best_edges)) {
             edges_to_drop_best = algorithms::keep_mutual_best_edges(graph, args::get(best_edges));
+        }
+        if (keep_intact_requested) {
+            handles_to_drop.erase(std::remove_if(handles_to_drop.begin(), handles_to_drop.end(), node_protected), handles_to_drop.end());
+            edges_to_drop_depth.erase(std::remove_if(edges_to_drop_depth.begin(), edges_to_drop_depth.end(), edge_protected), edges_to_drop_depth.end());
+            edges_to_drop_best.erase(std::remove_if(edges_to_drop_best.begin(), edges_to_drop_best.end(), edge_protected), edges_to_drop_best.end());
         }
         auto do_destroy =
             [&]() {

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -52,6 +52,8 @@ int main_prune(int argc, char** argv) {
                                                   {'r', "drop-paths"});
     args::Flag drop_all_paths(path_opts, "bool", "Remove all paths from the graph.", {'D', "drop-all-paths"});
     args::Flag drop_empty_paths(path_opts, "bool", "Remove empty paths from the graph.", {'y', "drop-empty-paths"});
+    args::Flag split_paths(path_opts, "bool", "When pruning nodes/edges, keep the surviving paths by splitting them into subpaths (named *PATH:START-END*) at every removed node and edge, instead of dropping all paths.", {'S', "split-paths"});
+    args::Flag drop_affected_paths(path_opts, "bool", "When pruning nodes/edges, drop only the paths that traverse a removed node or edge, keeping the untouched paths intact, instead of dropping all paths.", {'A', "drop-affected-paths"});
     args::ValueFlag<uint64_t> cut_tips_min_depth(path_opts, "N", "Remove nodes which are graph tips and have less than *N* path depth.", {'m', "cut-tips-min-depth"});
     args::Flag remove_isolated(path_opts, "bool", "Remove isolated nodes covered by a single path.", {'I', "remove-isolated"});
     args::Group threading_opts(parser, "[ Threading ]");
@@ -90,6 +92,26 @@ int main_prune(int argc, char** argv) {
         return 1;
     }
 
+    // How to treat paths affected by pruning
+    const bool split_paths_requested = args::get(split_paths);
+    const bool drop_affected_requested = args::get(drop_affected_paths);
+    const bool rebuild_paths_requested = split_paths_requested || drop_affected_requested;
+    if (rebuild_paths_requested) {
+        if (split_paths_requested && drop_affected_requested) {
+            std::cerr << "[odgi::prune] error: -S/--split-paths and -A/--drop-affected-paths are mutually exclusive." << std::endl;
+            return 1;
+        }
+        if (!(args::get(max_degree) || args::get(max_furcations) || args::get(min_depth)
+              || args::get(max_depth) || args::get(best_edges))) {
+            std::cerr << "[odgi::prune] error: -S/--split-paths and -A/--drop-affected-paths require a node/edge pruning filter (-d/--max-degree, -e/--max-furcations, -c/--min-depth, -C/--max-depth, -E/--edge-depth, or -b/--best-edges)." << std::endl;
+            return 1;
+        }
+        if (args::get(expand_path_length)) {
+            std::cerr << "[odgi::prune] error: -S/--split-paths and -A/--drop-affected-paths cannot be combined with -p/--expand-path-length, which already preserves paths as segments." << std::endl;
+            return 1;
+        }
+    }
+
 	const int n_threads = threads ? args::get(threads) : 1;
 
 	graph_t graph;
@@ -106,18 +128,33 @@ int main_prune(int argc, char** argv) {
 
     omp_set_num_threads(n_threads);
 
+    // Removing a node/edge breaks the paths through it. By default we drop all paths and warn;
+    // with -S/-A we snapshot the paths first (before any filter, since -d clears them), run the
+    // filters, then rebuild the survivors edge-aware (algorithms::rebuild_pruned_paths).
+    const uint64_t n_paths_before = graph.get_path_count();
+    // -c1 alone removes only depth-0 (unpathed) nodes, so it can't damage a path; other filters can.
+    const bool only_depth0 = (args::get(min_depth) == 1 && args::get(max_depth) == 0)
+        && !args::get(max_degree) && !args::get(max_furcations) && !args::get(best_edges);
+    const bool damages_paths = n_paths_before > 0 && !only_depth0
+        && (args::get(max_degree) || args::get(max_furcations)
+            || args::get(min_depth) || args::get(max_depth) || args::get(best_edges));
+    const bool rebuild = rebuild_paths_requested && damages_paths;
+
+    std::vector<algorithms::recorded_path_t> recorded_paths;
+    if (rebuild) {
+        recorded_paths = algorithms::record_paths(graph);
+    }
+
     if (args::get(max_degree)) {
         graph.clear_paths();
         algorithms::remove_high_degree_nodes(graph, args::get(max_degree));
     }
     if (args::get(max_furcations)) {
         std::vector<edge_t> to_prune = algorithms::find_edges_to_prune(graph, args::get(kmer_length), args::get(max_furcations), n_threads);
-        //std::cerr << "edges to prune: " << to_prune.size() << std::endl;
         for (auto& edge : to_prune) {
             graph.destroy_edge(edge);
         }
-        // we're just removing edges, so paths shouldn't be damaged
-        //std::cerr << "done prune" << std::endl;
+        // leaves edge-damaged paths in place; the path handling below drops or rebuilds them
     }
     if (args::get(min_depth) || args::get(max_depth) || args::get(best_edges)) {
         std::vector<handle_t> handles_to_drop;
@@ -132,18 +169,11 @@ int main_prune(int argc, char** argv) {
         if (args::get(best_edges)) {
             edges_to_drop_best = algorithms::keep_mutual_best_edges(graph, args::get(best_edges));
         }
-        // TODO this needs fixing
-        // we should split up the paths rather than drop them
-        // remove the paths, because it's likely we have damaged some
-        // and at present, we have no mechanism to reconstruct them
         auto do_destroy =
             [&]() {
-                if (args::get(min_depth) == 1 && args::get(max_depth) == 0) {
-                    // we could not have damaged any paths
-                } else {
+                if (!only_depth0) {
                     graph.clear_paths();
                 }
-                //std::cerr << "got " << to_drop.size() << " handles to drop" << std::endl;
                 for (auto& edge : edges_to_drop_depth) {
                     graph.destroy_edge(edge);
                 }
@@ -154,24 +184,53 @@ int main_prune(int argc, char** argv) {
                     graph.destroy_handle(handle);
                 }
             };
-        if (args::get(expand_steps)) {
-            graph_t source;
+        // A copy of the graph topology is needed to expand the pruned graph against the original.
+        const bool need_source =
+            args::get(expand_steps) || args::get(expand_length) || args::get(expand_path_length);
+        graph_t source;
+        if (need_source) {
             source.copy(graph);
-            do_destroy();
+        }
+        do_destroy();
+        if (args::get(expand_steps)) {
             algorithms::expand_context(&source, &graph, args::get(expand_steps), true);
         } else if (args::get(expand_length)) {
-            graph_t source;
-            source.copy(graph);
-            do_destroy();
             algorithms::expand_context(&source, &graph, args::get(expand_length), false);
         } else if (args::get(expand_path_length)) {
-            graph_t source;
-            source.copy(graph);
-            do_destroy();
             algorithms::expand_context_with_paths(&source, &graph, args::get(expand_length), false);
-        } else {
-            do_destroy();
         }
+    }
+
+    // Rebuild or drop the damaged paths, once, for whichever filters ran above.
+    if (rebuild) {
+        graph.clear_paths(); // drop any partial/invalid paths a filter left behind (e.g. -e)
+        const algorithms::damaged_path_policy_t policy = split_paths_requested
+            ? algorithms::damaged_path_policy_t::split
+            : algorithms::damaged_path_policy_t::drop_affected;
+        const algorithms::prune_path_rebuild_stats_t st =
+            algorithms::rebuild_pruned_paths(recorded_paths, graph, policy);
+        if (split_paths_requested) {
+            std::cerr << "[odgi::prune] split " << st.paths_split << " damaged path(s) into "
+                      << st.subpaths_created << " subpath(s), kept " << st.paths_intact
+                      << " path(s) intact";
+            if (st.paths_dropped) {
+                std::cerr << ", dropped " << st.paths_dropped << " fully removed path(s)";
+            }
+            std::cerr << "." << std::endl;
+        } else {
+            std::cerr << "[odgi::prune] kept " << st.paths_intact << " intact path(s), dropped "
+                      << st.paths_dropped << " affected path(s)." << std::endl;
+        }
+    } else if (damages_paths && !args::get(expand_path_length)) {
+        // Default: ensure the damaged paths are gone (some filters, e.g. -e, keep them) and warn.
+        // -p re-embeds paths itself, so it is excluded here.
+        if (graph.get_path_count() > 0) {
+            graph.clear_paths();
+        }
+        std::cerr << "[odgi::prune] warning: pruning removed nodes/edges used by the paths, so all "
+                  << n_paths_before << " path(s) were dropped from the output. "
+                  << "Re-run with -S/--split-paths (keep them as subpaths) or "
+                  << "-A/--drop-affected-paths (drop only the touched paths)." << std::endl;
     }
     if (args::get(cut_tips)) {
         algorithms::cut_tips(graph, args::get(cut_tips_min_depth));


### PR DESCRIPTION
Fixes #634 