### PR TITLE
Fix path corruption in graph_t::copy, cut_tips, and prune -p

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -595,6 +595,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/unittest/edge.cpp
   ${CMAKE_SOURCE_DIR}/src/unittest/extract.cpp
   ${CMAKE_SOURCE_DIR}/src/unittest/stepindex.cpp
+  ${CMAKE_SOURCE_DIR}/src/unittest/path_regressions.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/subcommand.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/build_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/test_main.cpp

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -217,17 +217,17 @@ void node_t::set_step_is_rev(const uint64_t& rank, const bool& is_rev) {
 
 void node_t::set_step_is_start(const uint64_t& rank, const bool& is_start) {
     uint64_t idx = PATH_RECORD_LENGTH*rank+1;
-    paths[idx] = paths[idx] & ~(1UL << 1) | is_start;
+    paths[idx] = (paths[idx] & ~(1UL << 1)) | ((uint64_t)is_start << 1);
 }
 
 void node_t::set_step_is_end(const uint64_t& rank, const bool& is_end) {
     uint64_t idx = PATH_RECORD_LENGTH*rank+1;
-    paths[idx] = paths[idx] & ~(1UL << 2) | is_end;
+    paths[idx] = (paths[idx] & ~(1UL << 2)) | ((uint64_t)is_end << 2);
 }
 
 void node_t::set_step_is_del(const uint64_t& rank, const bool& is_del) {
     uint64_t idx = PATH_RECORD_LENGTH*rank+1;
-    paths[idx] = paths[idx] & ~(1UL << 3) | is_del;
+    paths[idx] = (paths[idx] & ~(1UL << 3)) | ((uint64_t)is_del << 3);
 }
 
 uint64_t node_t::step_path_id(const uint64_t& rank) const {

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -1285,14 +1285,29 @@ void graph_t::destroy_step(const step_handle_t& step_handle) {
     if (has_prev) {
         // nothing
     } else if (has_next) {
+        // removing the first step: promote the next step to the path's start, dropping its
+        // back-link to this (soon-deleted) step so no dangling reference survives into optimize().
         auto step = get_next_step(step_handle);
         path_meta.first = step;
+        node_t& next_node = get_node_ref(get_handle_of_step(step));
+        next_node.get_lock();
+        const uint64_t next_rank = as_integers(step)[1];
+        next_node.set_step_is_start(next_rank, true);
+        next_node.set_step_prev_id(next_rank, get_id(get_handle_of_step(step))); // self
+        next_node.clear_lock();
     }
     if (has_next) {
         // nothing
     } else if (has_prev) {
+        // removing the last step: promote the previous step to the path's end (symmetric).
         auto step = get_previous_step(step_handle);
         path_meta.last = step;
+        node_t& prev_node = get_node_ref(get_handle_of_step(step));
+        prev_node.get_lock();
+        const uint64_t prev_rank = as_integers(step)[1];
+        prev_node.set_step_is_end(prev_rank, true);
+        prev_node.set_step_next_id(prev_rank, get_id(get_handle_of_step(step))); // self
+        prev_node.clear_lock();
     }
     // reduce the step count in the path
     --path_meta.length;

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -1722,13 +1722,15 @@ void graph_t::copy(const graph_t& other) {
     deleted_nodes = other.deleted_nodes;
     // copy the path metadata
     // the paths themselves should have been copied
-    // XXX SLOW
     other.for_each_path_handle(
         [&](const path_handle_t& p) {
-            auto new_path = create_path_handle(other.get_path_name(p),
-                                               other.get_is_circular(p));
-            auto& new_path_meta = get_path_metadata(new_path);
-            new_path_meta.copy(other.path_metadata(p));
+            // Path IDs are stored in each node's step records, so preserve them exactly.
+            // create_path_handle() would allocate after other._path_handle_next and leave the
+            // copied metadata unreachable under its original path ID.
+            auto* new_path_meta = new path_metadata_t;
+            new_path_meta->copy(other.path_metadata(p));
+            path_metadata_h->Insert(as_integer(p), new_path_meta);
+            path_name_h->Insert(new_path_meta->name, new_path_meta);
         });
 }
 

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -1710,9 +1710,14 @@ void graph_t::copy(const graph_t& other) {
     _id_increment.store(other._id_increment);
     node_v.resize(other.node_v.size());
     for (size_t i = 0; i < other.node_v.size(); ++i) {
-        node_v[i] = new node_t;
-        auto* node = node_v[i];
-        node->copy(other.get_node_cref(as_handle(i)));
+        // get_node_cref(as_handle(i)) resolves to other.node_v[i>>1] (as_handle does not pack the
+        // orientation bit), copying the wrong node; index node_v directly instead.
+        if (other.node_v[i] != nullptr) {
+            node_v[i] = new node_t;
+            node_v[i]->copy(*other.node_v[i]);
+        } else {
+            node_v[i] = nullptr;
+        }
     }
     deleted_nodes = other.deleted_nodes;
     // copy the path metadata

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -168,7 +168,7 @@ int main_prune(int argc, char** argv) {
             graph_t source;
             source.copy(graph);
             do_destroy();
-            algorithms::expand_context_with_paths(&source, &graph, args::get(expand_length), false);
+            algorithms::expand_context_with_paths(&source, &graph, args::get(expand_path_length), false);
         } else {
             do_destroy();
         }

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -168,6 +168,10 @@ int main_prune(int argc, char** argv) {
             graph_t source;
             source.copy(graph);
             do_destroy();
+            // expand_context_with_paths re-embeds the source paths as fresh segments and requires
+            // an empty target; do_destroy() leaves the paths in place for the -c1 case, so clear
+            // them here to avoid a duplicate path-name error.
+            graph.clear_paths();
             algorithms::expand_context_with_paths(&source, &graph, args::get(expand_path_length), false);
         } else {
             do_destroy();

--- a/src/unittest/path_regressions.cpp
+++ b/src/unittest/path_regressions.cpp
@@ -1,6 +1,7 @@
 #include "catch.hpp"
 
 #include "algorithms/cut_tips.hpp"
+#include "algorithms/expand_context.hpp"
 #include "odgi.hpp"
 
 #include <vector>
@@ -65,6 +66,49 @@ TEST_CASE("Cutting boundary tips preserves the remaining path", "[paths][cut_tip
         path_ids.push_back(graph.get_id(graph.get_handle_of_step(step)));
     });
     REQUIRE(path_ids == std::vector<nid_t>{graph.get_id(graph.get_handle(1))});
+}
+
+TEST_CASE("expand_context_with_paths re-embeds paths from a copied graph", "[paths][expand][regression]") {
+    // Mirrors the prune -p code path: copy the graph, then expand a subgraph and re-embed paths.
+    // A broken copy left the source paths unreadable, which segfaulted here.
+    graph_t original;
+    original.destroy_path(original.create_path_handle("removed")); // non-contiguous path IDs
+
+    std::vector<handle_t> handles;
+    for (const auto& sequence : {"A", "C", "G", "T", "N"}) {
+        handles.push_back(original.create_handle(sequence));
+    }
+    for (size_t i = 0; i + 1 < handles.size(); ++i) {
+        original.create_edge(handles[i], handles[i + 1]);
+    }
+    auto path = original.create_path_handle("path");
+    for (const auto& handle : handles) {
+        original.append_step(path, handle);
+    }
+
+    graph_t source;
+    source.copy(original);
+
+    const nid_t seed = original.get_id(handles[2]);
+    graph_t subgraph;
+    subgraph.create_handle(source.get_sequence(source.get_handle(seed)), seed);
+
+    algorithms::expand_context_with_paths(&source, &subgraph, 100, false);
+
+    REQUIRE(subgraph.get_path_count() >= 1);
+    subgraph.for_each_path_handle([&](const path_handle_t& subpath) {
+        handle_t prev;
+        bool first = true;
+        subgraph.for_each_step_in_path(subpath, [&](const step_handle_t& step) {
+            const handle_t current = subgraph.get_handle_of_step(step);
+            REQUIRE(subgraph.has_node(subgraph.get_id(current)));
+            if (!first) {
+                REQUIRE(subgraph.has_edge(prev, current));
+            }
+            prev = current;
+            first = false;
+        });
+    });
 }
 
 }

--- a/src/unittest/path_regressions.cpp
+++ b/src/unittest/path_regressions.cpp
@@ -1,0 +1,71 @@
+#include "catch.hpp"
+
+#include "algorithms/cut_tips.hpp"
+#include "odgi.hpp"
+
+#include <vector>
+
+namespace odgi {
+namespace unittest {
+
+using namespace handlegraph;
+
+TEST_CASE("Copying a graph preserves path traversal", "[paths][copy][regression]") {
+    graph_t source;
+    auto removed_path = source.create_path_handle("removed");
+    source.destroy_path(removed_path);
+
+    std::vector<handle_t> source_handles;
+    for (const auto& sequence : {"A", "C", "G", "T", "N"}) {
+        source_handles.push_back(source.create_handle(sequence));
+    }
+
+    auto source_path = source.create_path_handle("path");
+    for (const auto& handle : source_handles) {
+        source.append_step(source_path, handle);
+    }
+    REQUIRE(source.get_id(source.get_handle_of_step(source.path_begin(source_path))) == source.get_id(source_handles.front()));
+
+    graph_t copy;
+    copy.copy(source);
+
+    auto copied_path = copy.get_path_handle("path");
+    auto step = copy.path_begin(copied_path);
+    for (const auto& handle : source_handles) {
+        REQUIRE(copy.get_id(copy.get_handle_of_step(step)) == source.get_id(handle));
+        step = copy.get_next_step(step);
+    }
+    REQUIRE(step == copy.path_end(copied_path));
+}
+
+TEST_CASE("Cutting boundary tips preserves the remaining path", "[paths][cut_tips][regression]") {
+    graph_t graph;
+    auto left = graph.create_handle("A");
+    auto middle = graph.create_handle("C");
+    auto right = graph.create_handle("G");
+    graph.create_edge(left, middle);
+    graph.create_edge(middle, right);
+
+    auto path = graph.create_path_handle("path");
+    graph.append_step(path, left);
+    graph.append_step(path, middle);
+    graph.append_step(path, right);
+
+    algorithms::cut_tips(graph, 0);
+
+    REQUIRE(graph.get_step_count(path) == 1);
+    auto remaining = graph.path_begin(path);
+    REQUIRE(graph.get_id(graph.get_handle_of_step(remaining)) == graph.get_id(middle));
+    REQUIRE_FALSE(graph.has_previous_step(remaining));
+    REQUIRE_FALSE(graph.has_next_step(remaining));
+
+    graph.optimize();
+    std::vector<nid_t> path_ids;
+    graph.for_each_step_in_path(path, [&](const step_handle_t& step) {
+        path_ids.push_back(graph.get_id(graph.get_handle_of_step(step)));
+    });
+    REQUIRE(path_ids == std::vector<nid_t>{graph.get_id(graph.get_handle(1))});
+}
+
+}
+}


### PR DESCRIPTION
Fixes several path-integrity bugs in core graph operations that surface
through `odgi prune`, each with a regression test.

- **`graph_t::copy`**: copied the wrong node per slot (`node_v[i>>1]`) and re-keyed path metadata under fresh IDs; copies now preserve nodes and paths exactly.
- **`cut_tips` / `optimize`** (`prune -T`): `destroy_step` left a dangling back-pointer that `optimize` turned into a bad link, and `set_step_is_*` wrote the wrong bit; boundary steps are now promoted correctly.
- **`prune -p`**: no longer crashes, and uses `--expand-path-length` (it was reading `--expand-length`, so it never expanded); `-c1 -p` no longer aborts on duplicate path names.