### PR TITLE
Fix out-of-bounds in step index, untangle, and path index (#632, #489, #548)

### DIFF
--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -556,7 +556,7 @@ namespace odgi {
             std::cerr << "components count: " << weak_components.size() << std::endl;
 #endif
             std::vector<std::pair<double, uint64_t>> weak_component_order;
-            for (int i = 0; i < weak_components.size(); i++) {
+            for (size_t i = 0; i < weak_components.size(); i++) {
                 auto &weak_component = weak_components[i];
                 uint64_t id_sum = 0;
                 for (auto node_id : weak_component) {
@@ -575,7 +575,7 @@ namespace odgi {
             std::vector<uint64_t> weak_components_map;
             weak_components_map.resize(graph.get_node_count());
             // reserve the space we need
-            for (int i = 0; i < weak_components.size(); i++) {
+            for (size_t i = 0; i < weak_components.size(); i++) {
                 auto &weak_component = weak_components[i];
                 // store for each node identifier to component start index
                 for (auto node_id : weak_component) {

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -24,7 +24,16 @@ step_index_t::step_index_t(const PathHandleGraph& graph,
 		collecting_steps_progress_meter = std::make_unique<algorithms::progress_meter::ProgressMeter>(
 				paths.size(), "[odgi::algorithms::stepindex] Collecting Steps Progress:");
 	}
-	path_len.resize(paths.size());
+	// path_len is indexed by the global path id (as_integer(path)-1), so it must be sized to the
+	// largest id among `paths`, not their count: a subset of paths (as untangle passes) can have
+	// ids larger than the count, which otherwise writes out of bounds (issue #632).
+	uint64_t path_len_size = 0;
+	for (auto& path : paths) {
+		if ((uint64_t) as_integer(path) > path_len_size) {
+			path_len_size = as_integer(path);
+		}
+	}
+	path_len.resize(path_len_size);
 #pragma omp parallel for schedule(dynamic,1)
     for (auto& path : paths) {
         std::vector<step_handle_t> my_steps;

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -378,7 +378,7 @@ segment_map_t::segment_map_t(
         progress->finish();
     }
 
-    auto max_id = graph.get_node_count();
+    auto max_id = graph.max_node_id(); // node ids may be non-contiguous; pad up to the largest id
     while (prev_node < max_id) {
         node_idx.push_back(segments.size());
         ++prev_node;
@@ -720,7 +720,9 @@ void untangle(
 
     // collect all possible cuts
     // we'll use this to drive the subsequent segmentation
-    atomicbitvector::atomic_bv_t cut_nodes(graph.get_node_count()+1);
+    // node-id-indexed structures must be sized to max_node_id()+1, not get_node_count()+1: node ids
+    // are not necessarily contiguous (e.g. after prune), so an id can exceed the count (issue #489).
+    atomicbitvector::atomic_bv_t cut_nodes(graph.max_node_id()+1);
 
     if (cut_points_input.empty()) {
         if (show_progress) {
@@ -733,7 +735,7 @@ void untangle(
         }
 
         // which nodes are traversed by our target paths?
-        atomicbitvector::atomic_bv_t target_nodes(graph.get_node_count() + 1);
+        atomicbitvector::atomic_bv_t target_nodes(graph.max_node_id() + 1);
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
         for (auto& target : targets) {
             graph.for_each_step_in_path(
@@ -814,7 +816,7 @@ void untangle(
             uint64_t pos = 0;
             uint64_t last = 0;
             uint64_t segment = 0;
-            std::vector<uint64_t> node_to_segment(graph.get_node_count()+1);
+            std::vector<uint64_t> node_to_segment(graph.max_node_id()+1);
             graph.for_each_handle(
                 [&](const handle_t& h) {
                     auto l = graph.get_length(h);

--- a/src/algorithms/xp.cpp
+++ b/src/algorithms/xp.cpp
@@ -123,12 +123,14 @@ namespace xp {
         // fill the node->path vectors
         uint64_t  np_offset = 0;
         for (int64_t i = 0; i < graph.get_node_count(); i++) {
-            np_bv[np_offset] = 1; // mark node start
-            uint64_t has_steps = false;
+            bool node_start = true;
             node_path_ms.for_values_of(i+1, [&](const std::tuple<uint64_t, uint64_t, uint64_t, uint64_t>& v) {
+                if (node_start) {
+                    np_bv[np_offset] = 1; // mark the node's first step; nodes without steps get no mark
+                    node_start = false;
+                }
                 nr_iv[np_offset] = std::get<3>(v); // handle_rank_of_path
                 npi_iv[np_offset] = std::get<2>(v); // path id
-                has_steps = true;
                 np_offset++;
             });
         }

--- a/src/unittest/pathindex.cpp
+++ b/src/unittest/pathindex.cpp
@@ -306,5 +306,49 @@ namespace odgi {
                 // REQUIRE(loaded_path_index.get_pangenome_pos("4", 1) == 0);
             }
         }
+
+        TEST_CASE("XP construction over a graph whose highest-id node has no path steps stays in bounds", "[pathindex]") {
+            // Regression for #548: np_bv is sized to the total number of path steps, but the
+            // fill loop used to write a node-start marker for every node, step-less ones included.
+            // When the highest-id node carries no steps, np_offset has already reached np_bv.size()
+            // and that write is out of bounds (sdsl int_vector<1> assert, the crash reported in #548).
+            graph_t graph;
+            handle_t n1 = graph.create_handle("ACGT");
+            handle_t n2 = graph.create_handle("ACGT");
+            handle_t n3 = graph.create_handle("ACGT"); // highest id, deliberately on no path
+            graph.create_edge(n1, n2);
+            graph.create_edge(n2, n3);
+
+            graph.create_path_handle("x", false);
+            path_handle_t x = graph.get_path_handle("x");
+            graph.append_step(x, n1);
+            graph.append_step(x, n2);
+
+            // contiguous ids 1..3 => passes the "graph is optimized" guard in from_handle_graph
+            REQUIRE(graph.get_node_count() == 3);
+            REQUIRE(graph.min_node_id() == 1);
+            REQUIRE(graph.max_node_id() == 3);
+
+            XP path_index;
+            path_index.from_handle_graph(graph, 1); // must not write past np_bv on the step-less top node
+
+            sdsl::bit_vector np_bv = path_index.get_np_bv();
+            REQUIRE(np_bv.size() == 2); // one bit per path step; node 3 contributes none
+
+            uint64_t np_size = 0;
+            graph.for_each_handle([&](const handle_t &h) {
+                bool first_step_passed = false;
+                graph.for_each_step_on_handle(h, [&](const step_handle_t &step_handle) {
+                    if (!first_step_passed) {
+                        REQUIRE(np_bv[np_size] == 1); // first step of a node with steps
+                        first_step_passed = true;
+                    } else {
+                        REQUIRE(np_bv[np_size] == 0);
+                    }
+                    np_size++;
+                });
+            });
+            REQUIRE(np_size == np_bv.size()); // step-less node 3 added no steps and no marker
+        }
     }
 }

--- a/src/unittest/stepindex.cpp
+++ b/src/unittest/stepindex.cpp
@@ -752,5 +752,36 @@ namespace odgi {
 			}
 
 		}
+
+		TEST_CASE("step index over a subset of high-id paths stays in bounds", "[stepindex]") {
+			// Regression for issue #632: step_index_t sized path_len to paths.size() but indexed it
+			// by the global path id, so building over a subset (as untangle does) whose id exceeds
+			// the subset size wrote out of bounds.
+			graph_t graph;
+			handle_t a = graph.create_handle("ACG");
+			handle_t b = graph.create_handle("TT");
+			handle_t c = graph.create_handle("GATTACA");
+			graph.create_edge(a, b);
+			graph.create_edge(b, c);
+			// two decoy paths first, so the path we index gets a high global id
+			for (const std::string& name : {std::string("decoy1"), std::string("decoy2")}) {
+				path_handle_t d = graph.create_path_handle(name);
+				graph.append_step(d, a);
+				graph.append_step(d, b);
+			}
+			path_handle_t target = graph.create_path_handle("target"); // global path id 3
+			graph.append_step(target, a);
+			graph.append_step(target, b);
+			graph.append_step(target, c);
+
+			// index ONLY the high-id path (subset of size 1), mirroring untangle
+			std::vector<path_handle_t> subset = { target };
+			step_index_t step_index(graph, subset, 1, false, 1);
+
+			const uint64_t expected_len =
+				graph.get_length(a) + graph.get_length(b) + graph.get_length(c);
+			REQUIRE(step_index.get_path_len(target) == expected_len);
+			REQUIRE(step_index.get_position(graph.path_end(target), graph) == expected_len);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #632, #489, #548.

Three independent succinct-index out-of-bounds bugs, each reproduced and covered by the test suite.

### #632 — step index over a path subset (`stepindex.cpp`)
`step_index_t`'s `path_len` was indexed by global path id but sized to the number of *selected* paths, so building a step index over a subset of high-id paths (e.g. `odgi untangle` with query/target subsets) read and wrote out of bounds. Now sized to the greatest selected path id. Regression test added.

### #489 — untangle on graphs with id holes (`untangle.cpp`)
Untangle's node-id-indexed vectors were sized to `get_node_count()`, which is smaller than `max_node_id()` once a graph has id holes (e.g. after `prune`), so the atomic bitvectors indexed past their end. Now sized to `max_node_id()`. Output verified identical on the C4 and LPA graphs.

### #548 — path index for `sort -Y` (`xp.cpp`)
The path index used by path-guided 1D SGD wrote a node-start marker for every node into `np_bv`, which is sized to the total path-step count. When the highest-id node carries no path steps, that marker lands one past the end — the `sdsl::int_vector<1>` assertion reported in the issue. The marker is now written on the node's first step, so step-less nodes are skipped. Added a regression test that aborts under SDSL assertions on the old code and passes on the fix; the default NDEBUG suite cannot catch this because the stray write is silent without bounds checking.

### Cleanup
The two weakly-connected-component loop counters in `path_sgd.cpp` were `int` while `weak_components.size()` is `size_t`; widened to `size_t` (latent 32-bit truncation past 2^31 components). Not the cause of any of the three issues, kept as a separate commit.
