### PR TITLE
Document default --temp-dir as the current working directory (#627)

### DIFF
--- a/docs/rst/commands/odgi_layout.rst
+++ b/docs/rst/commands/odgi_layout.rst
@@ -46,7 +46,7 @@ Files IO
 | not have to be created for the layout calculation.
 
 | **-C, --temp-dir**\ =\ *PATH*
-| Directory for temporary files.
+| Directory for temporary files. Defaults to the current working directory.
 
 | **-f, --path-sgd-use-paths**\ =\ *FILE*
 | Specify a line separated list of paths to sample from for the on the fly term generation process in the path guided 2D SGD (default: sample from all paths).

--- a/docs/rst/commands/odgi_sort.rst
+++ b/docs/rst/commands/odgi_sort.rst
@@ -80,7 +80,7 @@ Files IO Options
   identifier.
 
 | **-C, --temp-dir**\ =\ *PATH*
-| Directory for temporary files.
+| Directory for temporary files. Defaults to the current working directory.
 
 Topological Sort Options
 -----------------

--- a/src/algorithms/temp_file.cpp
+++ b/src/algorithms/temp_file.cpp
@@ -93,7 +93,7 @@ void set_dir(const std::string& new_temp_dir) {
 std::string get_dir() {
     std::lock_guard<std::recursive_mutex> lock(monitor);
 
-    // Get the default temp dir from environment variables.
+    // Default to the current working directory when no temp dir was set.
     if (temp_dir.empty()) {
         char cwd[512];
         getcwd(cwd, sizeof(cwd));

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -33,7 +33,7 @@ int main_layout(int argc, char **argv) {
     args::ValueFlag<std::string> layout_out_file(files_io_opts, "FILE", "Write the layout coordinates to this FILE in .lay binary format.", {'o', "out"});
     args::ValueFlag<std::string> tsv_out_file(files_io_opts, "FILE", "Write the layout in TSV format to this FILE.", {'T', "tsv"});
     args::ValueFlag<std::string> xp_in_file(files_io_opts, "FILE", "Load the path index from this FILE so that it does not have to be created for the layout calculation.", {'X', "path-index"});
-    args::ValueFlag<std::string> tmp_base(files_io_opts, "PATH", "directory for temporary files", {'C', "temp-dir"});
+    args::ValueFlag<std::string> tmp_base(files_io_opts, "PATH", "directory for temporary files (default: current working directory)", {'C', "temp-dir"});
     /// Path-guided-2D-SGD parameters
     args::ValueFlag<std::string> p_sgd_in_file(files_io_opts, "FILE",
                                                "Specify a line separated list of paths to sample from for the on the fly term generation process in the path guided 2D SGD (default: sample from all paths).",

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -37,7 +37,7 @@ int main_sort(int argc, char** argv) {
     args::Group files_io_opts(parser, "[ Files IO Options ]");
     args::ValueFlag<std::string> xp_in_file(files_io_opts, "FILE", "Load the succinct variation graph index from this *FILE*. The file name usually ends with *.xp*.", {'X', "path-index"});
     args::ValueFlag<std::string> sort_order_in(files_io_opts, "FILE", "*FILE* containing the sort order. Each line contains one node identifer.", {'s', "sort-order"});
-    args::ValueFlag<std::string> tmp_base(files_io_opts, "PATH", "directory for temporary files", {'C', "temp-dir"});
+    args::ValueFlag<std::string> tmp_base(files_io_opts, "PATH", "directory for temporary files (default: current working directory)", {'C', "temp-dir"});
     args::Group topo_sorts_opts(parser, "[ Topological Sort Options ]");
     args::Flag breadth_first(topo_sorts_opts, "breadth_first", "Use a (chunked) breadth first topological sort.", {'b', "breadth-first"});
     args::ValueFlag<uint64_t> breadth_first_chunk(topo_sorts_opts, "N", "Chunk size for breadth first topological sort. Specify how many"


### PR DESCRIPTION
Fixes #627.

When `--temp-dir` is unset, the default temporary-file directory is the current working directory: `temp_file::get_dir()` falls back to `getcwd()` (the earlier `$TMPDIR`/`/tmp` logic is commented out). This was undocumented.

- `odgi sort --help` and `odgi layout --help` now state the default (the two subcommands that expose `-C, --temp-dir`).
- Updated the matching `odgi_sort.rst` and `odgi_layout.rst` command docs.
- Corrected a stale comment in `temp_file.cpp` that still claimed the default came from environment variables.

Documentation only; no behavior change.
