### PR TITLE
Retry transient apt failures in Docker CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ LABEL about.home="https://github.com/pangenome/odgi"
 LABEL about.license="SPDX:MIT"
 
 # dependencies
-RUN apt-get update \
-    && apt-get install -y \
+# retry transient mirror failures (e.g. "Connection reset by peer") instead of failing the build
+RUN apt-get update -o Acquire::Retries=5 \
+    && apt-get install -y -o Acquire::Retries=5 \
                        git \
                        bash \
                        cmake \


### PR DESCRIPTION
The "Docker Image CI for DockerHub" workflow failed on master (the push for #639) because a single transient mirror error during `apt-get install` aborted the whole build:

    E: Failed to fetch http://deb.debian.org/debian/pool/main/libn/libnsl/libnsl-dev_1.3.0-2_amd64.deb  Error reading from server - read (104: Connection reset by peer)

The Dockerfile was unchanged and the same step passed ~30 minutes earlier (#638), so this is a flaky network fetch, not a missing/removed package. Adding `-o Acquire::Retries=5` to the `apt-get update` and `apt-get install` commands makes apt retry transient fetch failures instead of failing the whole image build on the first hiccup.

Verified locally: `docker build --no-cache` of the retry-enabled apt step installs every dependency successfully.
