### PR TITLE
Clear errors for duplicate and non-integer node ids on GFA build (#590)

### DIFF
--- a/src/gfa_graph_to_handle.cpp
+++ b/src/gfa_graph_to_handle.cpp
@@ -93,6 +93,13 @@ void gfa_graph_to_handle(GfaGraph& gfa_graph,
                 node_count, "[odgi::gfa_graph_to_handle] building nodes:");
         }
         for (uint64_t id = 1; id <= node_count; ++id) {
+            // GFAz reconstructs dense 1-based ids, so this cannot trigger in practice; it
+            // guards against a malformed .gfaz slipping a duplicate past create_handle's assert.
+            if (graph->has_node(id)) {
+                std::cerr << "[odgi::gfa_graph_to_handle] error: duplicate node id " << id
+                          << " while building nodes from GFAz" << std::endl;
+                exit(1);
+            }
             graph->create_handle(gfa_graph.node_sequences[id], id);
             if (show_progress) progress_meter->increment(1);
         }

--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -72,13 +72,26 @@ void gfa_to_handle(const string& gfa_filename,
         gg.for_each_sequence_line_in_file(
             filename,
             [&](const gfak::sequence_elem& s) {
-                try {
-                    uint64_t id = stol(s.name);
-                    graph->create_handle(s.sequence, id - id_increment);
-                } catch (const std::exception& e) {
-                    std::cerr << "[odgi::gfa_to_handle] Error creating node '" << s.name << ": " << e.what() << std::endl;
+                if (s.name.empty() || s.name.find_first_not_of("0123456789") != std::string::npos) {
+                    std::cerr << "[odgi::gfa_to_handle] error: segment name '" << s.name
+                              << "' is not a non-negative integer node id" << std::endl;
                     exit(1);
                 }
+                uint64_t id = 0;
+                try {
+                    id = std::stoull(s.name);
+                } catch (const std::exception& e) {
+                    std::cerr << "[odgi::gfa_to_handle] error: could not parse segment name '" << s.name
+                              << "' as a node id: " << e.what() << std::endl;
+                    exit(1);
+                }
+                const uint64_t node_id = id - id_increment;
+                if (graph->has_node(node_id)) {
+                    std::cerr << "[odgi::gfa_to_handle] error: duplicate node id " << node_id
+                              << " (segment '" << s.name << "'); GFA node ids must be unique" << std::endl;
+                    exit(1);
+                }
+                graph->create_handle(s.sequence, node_id);
                 if (progress) progress_meter->increment(1);
             });
         if (progress) {


### PR DESCRIPTION
Fixes #590 (same failure as #282).

`odgi build` from a GFA aborted with the cryptic `create_handle: Assertion '!has_node(id)' failed` when the GFA contained a duplicate node id. Worse, on release (NDEBUG) builds where that assert is compiled out, odgi silently overwrote the node and produced a corrupt graph with the wrong node count and exit code 0.

Both root causes are now reported with a clear, actionable error in all build configs, instead of the assert / silent corruption:

- **Duplicate node id.** Two segments map to the same id. Reporters' `uniq` checks missed this because `uniq` without `sort` only removes *adjacent* duplicates (the reliable check is `grep '^S' file.gfa | cut -f2 | sort | uniq -d`). odgi now prints e.g. `error: duplicate node id 2 (segment '2'); GFA node ids must be unique` and exits.

- **Non-integer segment names.** odgi parsed ids with `stol`, which stops at the first non-digit, so `2` and `2x` silently collapsed to the same id. Segment names that aren't plain non-negative integers are now rejected: `error: segment name '2x' is not a non-negative integer node id`.

The GFAz path (`gfa_graph_to_handle.cpp`) reconstructs dense 1-based ids and already range-checks edge/path references, so a duplicate cannot reach `create_handle` there; a defensive guard is added for symmetry and to future-proof the invariant.

Verified: duplicate-id and non-integer GFAs now exit 1 with the messages above; valid GFAs (including non-contiguous ids and `-O`) build unchanged; the full `odgi test` suite passes.
