### PR TITLE
Skip empty path segment tokens on GFA load instead of aborting

### DIFF
--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -149,6 +149,7 @@ void gfa_to_handle(const string& gfa_filename,
                     if (path_queue.try_pop(p)) {
                         uint64_t i = 0;
                         for (auto& s : p->gfak.segment_names) {
+                            if (s.empty()) { ++i; continue; } // empty path field: stepless path, don't abort
                             uint64_t id = 0;
                             try {
                                 id = std::stoull(s) - id_increment;


### PR DESCRIPTION
A GFA `P` line with an empty path field (e.g. `P<TAB>name<TAB><TAB>`, emitted by some vg/VCF-derived graphs) is parsed by gfakluge as a single empty segment name. `gfa_to_handle` then throws in `std::stoull("")` and calls `exit(1)`, aborting the entire load.

This skips empty segment tokens so such a path loads with zero steps instead of killing the process. No effect on normal paths.