### PR TITLE
Tolerate CRLF path-name files in untangle -R/-Q (#581)

### DIFF
--- a/src/subcommand/untangle_main.cpp
+++ b/src/subcommand/untangle_main.cpp
@@ -121,6 +121,7 @@ int main_untangle(int argc, char **argv) {
         std::string line;
         std::vector<path_handle_t> paths;
         while (std::getline(path_names_in, line)) {
+            if (!line.empty() && line.back() == '\r') line.pop_back(); // tolerate CRLF
             if (!line.empty()) {
                 if (graph.has_path(line)) {
                     const path_handle_t path = graph.get_path_handle(line);


### PR DESCRIPTION
Fixes #581. The -R/-Q path-name loader kept the trailing `\r` from CRLF files, so `has_path` failed and every name but the last was silently dropped (reporter saw only the last reference used). Strip trailing `\r` after getline. Verified on DRB1 and LPA: CRLF output now matches LF (was 0-1 of the refs).