### PR TITLE
Tolerate CRLF BED files in odgi inject (#543)

### DIFF
--- a/src/subcommand/inject_main.cpp
+++ b/src/subcommand/inject_main.cpp
@@ -85,6 +85,7 @@ int main_inject(int argc, char **argv) {
         std::ifstream bed(args::get(_bed_targets).c_str());
         std::string line;
         while (std::getline(bed, line)) {
+            if (!line.empty() && line.back() == '\r') line.pop_back(); // tolerate CRLF
             if (!line.empty()) {
                 auto vals = split(line, '\t');
                 if (vals.size() < 3) {


### PR DESCRIPTION
Fixes #543. inject's BED parser kept the trailing `\r` from CRLF files, so the injected path name became `NAME\r` — `paths -L` showed it but `untangle -r NAME` failed "no path found". Strip trailing `\r` after getline. Verified on DRB1 and LPA: injected name is clean and `untangle -r` finds it (13 rows vs. error before).