### PR TITLE
Reject malformed P-line segments in odgi build (#495)

### DIFF
--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -152,7 +152,13 @@ void gfa_to_handle(const string& gfa_filename,
                             if (s.empty()) { ++i; continue; } // empty path field: stepless path, don't abort
                             uint64_t id = 0;
                             try {
-                                id = std::stoull(s) - id_increment;
+                                size_t parsed = 0;
+                                id = std::stoull(s, &parsed) - id_increment;
+                                if (parsed != s.size()) { // reject trailing junk, e.g. a space before * instead of a tab
+                                    std::cerr << "[odgi::gfa_to_handle] error: malformed path segment '" << s
+                                              << "' in path '" << graph->get_path_name(p->path) << "'" << std::endl;
+                                    exit(1);
+                                }
                                 if (graph->has_node(id)) {
                                     graph->append_step(p->path,
                                                 graph->get_handle(id,


### PR DESCRIPTION
Fixes #495. A P-line with a space before the overlaps field (`1+,2+,3+,4+ *`) let gfakluge fold `+ ` into the last segment name; `stoull` truncated the id but the orientation silently flipped (4+ -> 4-), yielding a graph that fails `validate`. Reject a segment name `stoull` doesn't fully consume. Build of a 500k-step graph is unchanged (~0.9s before/after).