### PR TITLE
extract: allow non-compacted node IDs (#497)

### DIFF
--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -191,10 +191,6 @@ namespace odgi {
         }
 
         const uint64_t shift = graph.min_node_id();
-        if (graph.max_node_id() - shift >= graph.get_node_count()){
-            std::cerr << "[odgi::extract] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-            exit(1);
-        }
 
         // Prepare all paths for parallelize the next step (actually, not all paths are always present in the subgraph)
         std::vector<path_handle_t> paths;
@@ -457,7 +453,8 @@ namespace odgi {
                             path_ranges.size(), "[odgi::extract] extracting path ranges");
                 }
 
-                atomicbitvector::atomic_bv_t keep_bv(source.get_node_count()+1);
+                // size by node-id span (not node count) so non-compacted graphs work
+                atomicbitvector::atomic_bv_t keep_bv(source.max_node_id() - shift + 1);
 
 #pragma omp parallel for schedule(dynamic,1)
                 for (auto &path_range : path_ranges) {


### PR DESCRIPTION
Fixes #497.

`odgi extract` refused non-compacted graphs with *"the node IDs are not compacted. Please run 'odgi sort' using -O"*. But optimizing renumbers nodes, breaking cross-reference with a VCF that carries the original IDs.

The check existed because the keep-bitvector was sized by node count yet indexed by `id - min_id`, so a sparse ID space overflowed it. Sizing the bitvector by the node-id span (`max_id - min_id + 1`) removes the need for compaction. Original IDs are preserved in the output.

For compacted graphs the size is unchanged (`max_id - min_id + 1 == node_count`), so no perf impact.

Tested: non-contiguous IDs 1/5/10 extract and validate, context expansion pulls in the right non-contiguous neighbours, compacted graphs unchanged, full suite passes (26,079,805 assertions).