### PR TITLE
Extend non-compacted node ID support to viz/depth/degree/stats/paths

### DIFF
--- a/src/algorithms/degree.cpp
+++ b/src/algorithms/degree.cpp
@@ -8,10 +8,6 @@ namespace odgi {
 									   const std::vector<bool>& paths_to_consider,
 									   const std::function<void(const path_range_t&, const double&)>& func) {
 			const uint64_t shift = graph.min_node_id();
-			if (graph.max_node_id() - shift >= graph.get_node_count()){
-				std::cerr << "[degree::for_each_path_range_degree] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-				exit(1);
-			}
 			// are we subsetting?
 			const bool subset_paths = !paths_to_consider.empty();
 			// sort path ranges
@@ -40,7 +36,7 @@ namespace odgi {
 				p = n;
 			}
 			// precompute degrees for all handles in parallel
-			std::vector<uint64_t> degree(graph.get_node_count() + 1);
+			std::vector<uint64_t> degree(graph.max_node_id() - shift + 1);
 			graph.for_each_handle(
 					[&](const handle_t& h) {
 						auto id = graph.get_id(h);

--- a/src/algorithms/depth.cpp
+++ b/src/algorithms/depth.cpp
@@ -103,10 +103,6 @@ void for_each_path_range_depth(const PathHandleGraph& graph,
                                const std::vector<bool>& paths_to_consider,
                                const std::function<void(const path_range_t&, const double&)>& func) {
 	const uint64_t shift = graph.min_node_id();
-	if (graph.max_node_id() - shift >= graph.get_node_count()){
-		std::cerr << "[depth::for_each_path_range_depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-		exit(1);
-	}
     // are we subsetting?
     const bool subset_paths = !paths_to_consider.empty();
     // sort path ranges
@@ -135,7 +131,7 @@ void for_each_path_range_depth(const PathHandleGraph& graph,
         p = n;
     }
     // precompute depths for all handles in parallel
-    std::vector<uint64_t> depths(graph.get_node_count() + 1);
+    std::vector<uint64_t> depths(graph.max_node_id() - shift + 1);
     graph.for_each_handle(
         [&](const handle_t& h) {
             auto id = graph.get_id(h);

--- a/src/subcommand/degree_main.cpp
+++ b/src/subcommand/degree_main.cpp
@@ -147,12 +147,6 @@ int main_degree(int argc, char** argv) {
 
     omp_set_num_threads((int) num_threads);
 	const uint64_t shift = graph.min_node_id();
-	if (_windows_in || _windows_out) {
-		if (graph.max_node_id() - shift >= graph.get_node_count()){
-			std::cerr << "[odgi::degree] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-			exit(1);
-		}
-	}
 
 	std::vector<bool> paths_to_consider;
 	if (_subset_paths) {
@@ -427,7 +421,7 @@ int main_degree(int argc, char** argv) {
 		});
 
 		// precompute degrees for all handles in parallel
-		std::vector<uint64_t> degrees(graph.get_node_count() + 1);
+		std::vector<uint64_t> degrees(graph.max_node_id() - shift + 1);
 		graph.for_each_handle(
 				[&](const handle_t& h) {
 					auto id = graph.get_id(h);

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -151,12 +151,6 @@ namespace odgi {
 
         omp_set_num_threads((int) num_threads);
 		const uint64_t shift = graph.min_node_id();
-		if (_windows_in || _windows_out) {
-			if (graph.max_node_id() - shift >= graph.get_node_count()){
-				std::cerr << "[odgi::depth] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-				exit(1);
-			}
-		}
 
         std::vector<bool> paths_to_consider;
         if (_subset_paths) {
@@ -436,7 +430,7 @@ namespace odgi {
             }
 
             // precompute depths for all handles in parallel
-            std::vector<uint64_t> depths(graph.get_node_count() + 1);
+            std::vector<uint64_t> depths(graph.max_node_id() - shift + 1);
 
             graph.for_each_handle(
                 [&](const handle_t& h) {

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -165,17 +165,6 @@ int main_paths(int argc, char** argv) {
     }
 
     const uint64_t shift = graph.min_node_id();
-    if (
-        args::get(haplo_matrix) || 
-        (non_reference_nodes && !args::get(non_reference_nodes).empty()) ||
-        (non_reference_ranges && !args::get(non_reference_ranges).empty())
-        ) {
-        // Check if the node IDs are compacted
-        if (graph.max_node_id() - shift >= graph.get_node_count()){
-            std::cerr << "[odgi::paths] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-            exit(1);
-        }
-    }
 
     if (list_path_start_end && list_names) {
     	std::vector<path_handle_t> paths;
@@ -286,11 +275,8 @@ int main_paths(int argc, char** argv) {
                 std::string path_name = (delim ? full_path_name.substr(cnt_pos.second+1) : full_path_name);
                 uint64_t path_length = 0;
                 uint64_t path_step_count = 0;
-                std::vector<uint64_t> row(graph.get_node_count());
-                // Initialize first to avoid possible bugs later
-                for (uint32_t i = 0; i < graph.get_node_count(); ++i) {
-                    row[i] = 0;
-                }
+                // indexed by node rank (id - shift); size by id span so non-contiguous ids fit
+                std::vector<uint64_t> row(graph.max_node_id() - shift + 1, 0);
 
                 graph.for_each_step_in_path(
                     p,
@@ -306,15 +292,11 @@ int main_paths(int argc, char** argv) {
                 std::cout << path_name << "\t"
                           << path_length << "\t"
                           << path_step_count;
-                if (node_length_scale) {
-                    for (uint64_t i = 0; i < row.size(); ++i) {
-                        std::cout << "\t" << row[i] * graph.get_length(graph.get_handle(i+shift));
-                    }
-                } else {
-                    for (uint64_t i = 0; i < row.size(); ++i) {
-                        std::cout << "\t" << row[i];
-                    }
-                }
+                // emit one column per real node in the same order as the header (for_each_handle)
+                graph.for_each_handle([&](const handle_t& h) {
+                    const uint64_t count = row[graph.get_id(h) - shift];
+                    std::cout << "\t" << (node_length_scale ? count * graph.get_length(h) : count);
+                });
                 std::cout << std::endl;
             });
     }
@@ -470,13 +452,13 @@ int main_paths(int argc, char** argv) {
         if (non_reference_nodes && !args::get(non_reference_nodes).empty()){
             // Emit non-reference nodes
 
-            // Set non-reference nodes
-            atomicbitvector::atomic_bv_t non_reference_nodes(graph.get_node_count());
-            for(uint64_t x = 0; x < non_reference_nodes.size(); ++x) {
-                if (min_size_in_bp == 0 || graph.get_length(graph.get_handle(x + shift)) >= min_size_in_bp) {
-                    non_reference_nodes.set(x);
+            // Set non-reference nodes (indexed by node rank; size by id span for non-contiguous ids)
+            atomicbitvector::atomic_bv_t non_reference_nodes(graph.max_node_id() - shift + 1);
+            graph.for_each_handle([&](const handle_t& h) {
+                if (min_size_in_bp == 0 || graph.get_length(h) >= min_size_in_bp) {
+                    non_reference_nodes.set(graph.get_id(h) - shift);
                 }
-            }
+            });
 #pragma omp parallel for schedule(dynamic,1)
             for (auto &path : reference_paths) {
                 graph.for_each_step_in_path(path, [&](const step_handle_t& step) {
@@ -517,8 +499,8 @@ int main_paths(int argc, char** argv) {
 
             const bool _show_step_ranges = args::get(show_step_ranges);
 
-            // Set the reference nodes
-            atomicbitvector::atomic_bv_t reference_nodes(graph.get_node_count());
+            // Set the reference nodes (indexed by node rank; size by id span for non-contiguous ids)
+            atomicbitvector::atomic_bv_t reference_nodes(graph.max_node_id() - shift + 1);
     #pragma omp parallel for schedule(dynamic,1)
             for (auto &path : reference_paths) {
                 graph.for_each_step_in_path(path, [&](const step_handle_t& step) {

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -166,10 +166,15 @@ int main_stats(int argc, char** argv) {
     }
 
 	const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
+	// node rank span (max_id - min_id); equals node_count-1 only when ids are compacted
+	const uint64_t max_rank = number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift;
 
-    if (args::get(mean_links_length) || args::get(sum_of_path_node_distances)) {
-		if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
-			std::cerr << "[odgi::stats] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+    // Only the 2D metrics (-l/--layout) require id-compacted node IDs: X/Y are indexed by node rank
+    // and come from a layout that itself assumes compaction. The 1D metrics work on non-contiguous ids.
+    if ((args::get(mean_links_length) || args::get(sum_of_path_node_distances))
+        && layout_in_file && !args::get(layout_in_file).empty()) {
+		if (max_rank >= graph.get_node_count()){
+			std::cerr << "[odgi::stats] error: the 2D metrics (-l/--layout) require id-compacted node IDs. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
 			exit(1);
 		}
     }
@@ -392,8 +397,13 @@ int main_stats(int argc, char** argv) {
 	}
 
     if (args::get(mean_links_length) || args::get(sum_of_path_node_distances)) {
-        // This vector is needed for computing the metrics in 1D and for detecting gap-links
-        std::vector<uint64_t> position_map(graph.get_node_count() + 1);
+        // This vector is needed for computing the metrics in 1D and for detecting gap-links.
+        // Indexed by node rank (unpack_number - shift), plus one sentinel for the right end of the
+        // last node; sized by the id span so non-contiguous node ids do not overflow it.
+        std::vector<uint64_t> position_map(max_rank + 2);
+        // node-space coordinate per rank boundary: number of real nodes before this rank.
+        // Makes node-space distances independent of id gaps (nspace[k]==k when ids are compacted).
+        std::vector<uint64_t> nspace(max_rank + 2);
 
         // These vectors are needed for computing the metrics in 2D
         std::vector<double> X, Y;
@@ -418,15 +428,24 @@ int main_stats(int argc, char** argv) {
 
         {
             uint64_t len = 0;
+            uint64_t dense = 0; // real nodes seen so far
+            // gap ranks inherit the next real node's start (the previous node's end) so the
+            // position_map[rank+1] right-end lookups used by the 1D metric stay correct on gaps
+            int64_t prev = -1;
             graph.for_each_handle([&](const handle_t &h) {
-                position_map[number_bool_packing::unpack_number(h) - shift] = len;
-                uint64_t hl = graph.get_length(h);
-                len += hl;
-#ifdef debug_odgi_viz
-                std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << number_bool_packing::unpack_number(h) << ") = " << len << std::endl;
-#endif
+                const uint64_t r = number_bool_packing::unpack_number(h) - shift;
+                for (uint64_t k = (uint64_t)(prev + 1); k <= r; ++k) {
+                    position_map[k] = len;
+                    nspace[k] = dense;
+                }
+                prev = (int64_t)r;
+                ++dense;
+                len += graph.get_length(h);
             });
-            position_map[position_map.size() - 1] = len;
+            for (uint64_t k = (uint64_t)(prev + 1); k < position_map.size(); ++k) {
+                position_map[k] = len;
+                nspace[k] = dense;
+            }
         }
 
         if (args::get(mean_links_length)){
@@ -500,7 +519,7 @@ int main_stats(int argc, char** argv) {
                                 sum_2D_space += sqrt(dx * dx + dy * dy);
                             }else{
                                 // 1D metric (in node space and in nucleotide space)
-                                sum_node_space += _info_b - _info_a;
+                                sum_node_space += nspace[_info_b - shift] - nspace[_info_a - shift];
                                 sum_nt_space += position_map[_info_b - shift] - position_map[_info_a - shift];
 
 #ifdef debug_odgi_stats
@@ -680,7 +699,7 @@ int main_stats(int argc, char** argv) {
                             std::cerr << unpacked_b << " - " << unpacked_a << ": " << position_map[unpacked_b - shift] - position_map[unpacked_a - shift] << " * " << weight << std::endl;
 #endif
 
-                            sum_path_node_dist_node_space += weight * (unpacked_b - unpacked_a);
+                            sum_path_node_dist_node_space += weight * (nspace[unpacked_b - shift] - nspace[unpacked_a - shift]);
                             sum_path_node_dist_nt_space += weight * (position_map[unpacked_b - shift] - position_map[unpacked_a - shift]);
                         }
 
@@ -688,7 +707,7 @@ int main_stats(int argc, char** argv) {
                             if (layout_in_file) {
                                 sum_path_node_dist_2D_space += 2 * euclidean_distance_2D;
                             }else{
-                                sum_path_node_dist_node_space += 2 * (unpacked_b - unpacked_a);
+                                sum_path_node_dist_node_space += 2 * (nspace[unpacked_b - shift] - nspace[unpacked_a - shift]);
                                 sum_path_node_dist_nt_space += 2 * (position_map[unpacked_b - shift] - position_map[unpacked_a - shift]);
                             }
 
@@ -895,7 +914,8 @@ int main_stats(int argc, char** argv) {
 			std::cout << "path\tlinks_length_per_nuc" << std::endl;
 		}
 		// TODO maybe combine this with other position_maps?
-		std::vector<uint64_t> pan_pos(graph.get_node_count());
+		// indexed by node rank (unpack_number - shift); size by id span for non-contiguous ids
+		std::vector<uint64_t> pan_pos(max_rank + 1);
 		uint64_t pos = 0;
 		graph.for_each_handle([&](const handle_t &h) {
 			pan_pos[number_bool_packing::unpack_number(h) - shift] = pos;

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -416,23 +416,30 @@ namespace odgi {
             }
         }
 
-        std::vector<uint64_t> position_map(graph.get_node_count() + 1);
         const uint64_t shift = number_bool_packing::unpack_number(graph.get_handle(graph.min_node_id()));
+        // position_map is indexed by node rank (unpack_number - shift); size by the id span
+        // (dense span + 1 sentinel) so non-contiguous node ids do not overflow it
+        const uint64_t max_rank = number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift;
+        std::vector<uint64_t> position_map(max_rank + 2);
         uint64_t len = 0;
         {
-            if (number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) - shift >= graph.get_node_count()){
-                std::cerr << "[odgi::viz] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-                exit(1);
-            }
+            // fill pangenome start positions; gap ranks inherit the next real node's start
+            // (the previous node's end) so edge endpoints read via position_map[rank+1] stay correct
+            int64_t prev = -1;
             graph.for_each_handle([&](const handle_t &h) {
-                position_map[number_bool_packing::unpack_number(h) - shift] = len;
-                uint64_t hl = graph.get_length(h);
-                len += hl;
+                const uint64_t r = number_bool_packing::unpack_number(h) - shift;
+                for (uint64_t k = (uint64_t)(prev + 1); k <= r; ++k) {
+                    position_map[k] = len;
+                }
+                prev = (int64_t)r;
+                len += graph.get_length(h);
 #ifdef debug_odgi_viz
-                std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << (number_bool_packing::unpack_number(h) - shift) << ") = " << len << std::endl;
+                std::cerr << "SEGMENT ID: " << graph.get_id(h) << " - " << as_integer(h) << " - index_in_position_map (" << r << ") = " << len << std::endl;
 #endif
             });
-            position_map[position_map.size() - 1] = len;
+            for (uint64_t k = (uint64_t)(prev + 1); k < position_map.size(); ++k) {
+                position_map[k] = len;
+            }
         }
 
         double pangenomic_start_pos = 0.0;


### PR DESCRIPTION
Follow-through on #497: `viz`, `depth`, `degree`, `stats`, `paths` refused non-contiguous node IDs ("not compacted, run sort -O"). Now they size node-id-indexed arrays by the id span instead of the node count, like extract/untangle.

- **degree/depth**: resize arrays, drop guard (arrays are `for_each_handle`-filled, no loop changes).
- **paths**: resize; rewrite `get_handle(i+shift)` loops (which segfault on gap ids) to `for_each_handle`.
- **viz/stats**: resize `position_map` + forward-fill gap ranks so edge/link endpoints stay correct. stats maps node-space through a dense index so metrics ignore id gaps; 2D metrics (`-c` layout) stay guarded (layout needs compaction); also fixes a pre-existing unguarded `pan_pos` overflow in `links_length_per_nuc`.

Verified: suite passes (26,079,805 assertions); byte-identical to master on compacted graphs (DRB1, chr6.C4, LPA); label-invariant on x7-remapped gapped twins incl. viz PNG; no segfaults.
