### PR TITLE
Fix node-id compaction hazards in tips/tension/bin/similarity/sort/cuda

### DIFF
--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -33,8 +33,9 @@ namespace odgi {
                            uint64_t bin_width,
                            bool drop_gap_links,
                            bool progress) {
-            // the graph must be compacted for this to work
-            std::vector<uint64_t> position_map(graph.get_node_count() + 1);
+            // position_map is indexed by node rank (unpack_number); size by the rank span
+            // (+1 sentinel) so non-contiguous node ids do not overflow it
+            std::vector<uint64_t> position_map(number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) + 2);
             uint64_t len = 0;
             std::string graph_seq;
             graph.for_each_handle([&](const handle_t &h) {

--- a/src/cuda/layout.cu
+++ b/src/cuda/layout.cu
@@ -315,9 +315,12 @@ void gpu_layout(layout_config_t config, const odgi::graph_t &graph, std::vector<
     // create node data structure
     // consisting of sequence length and coords
     uint32_t node_count = graph.get_node_count();
-    assert(graph.min_node_id() == 1);
-    assert(graph.max_node_id() == node_count);
-    assert(graph.max_node_id() - graph.min_node_id() + 1 == node_count);
+    // node ids are used directly as dense indices below (get_handle(node_idx+1)); require compaction.
+    // a runtime check (asserts are compiled out under NDEBUG in release builds)
+    if (graph.min_node_id() != 1 || (uint64_t) graph.max_node_id() != (uint64_t) node_count) {
+        fprintf(stderr, "[odgi::layout] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph.\n");
+        exit(1);
+    }
 
     cuda::node_data_t node_data;
     node_data.node_count = node_count;

--- a/src/subcommand/similarity_main.cpp
+++ b/src/subcommand/similarity_main.cpp
@@ -146,37 +146,41 @@ int main_similarity(int argc, char** argv) {
 
     // ska::flat_hash_map<std::pair<uint64_t, uint64_t>, uint64_t> leads to huge memory usage with deep graphs
     // Load mask if specified
-    // this command indexes node-id arrays by rank and iterates ids 1..node_count, so it requires compaction
-    if (graph.max_node_id() - graph.min_node_id() >= graph.get_node_count()) {
-        std::cerr << "[odgi::similarity] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
-        exit(1);
-    }
-    std::vector<bool> node_mask(graph.get_node_count(), true);  // Default all nodes included
+    // node_mask is indexed by node rank (id - shift); size by the id span so it works on
+    // non-contiguous / non-1-based node ids. Mask lines are positional: the i-th line refers
+    // to the i-th node in id order (unchanged from before).
+    const uint64_t shift = graph.min_node_id();
+    std::vector<bool> node_mask(graph.max_node_id() - shift + 1, true);  // Default all nodes included
     if (mask_file) {
         std::ifstream mask_in(args::get(mask_file));
         std::string line;
-        uint64_t line_count = 0;
+        std::vector<bool> mask_lines;
+        mask_lines.reserve(graph.get_node_count());
         while (std::getline(mask_in, line)) {
-            if (line_count >= graph.get_node_count()) {
-                std::cerr << "[odgi::similarity] error: mask file has more lines than graph nodes (" 
+            if (mask_lines.size() >= graph.get_node_count()) {
+                std::cerr << "[odgi::similarity] error: mask file has more lines than graph nodes ("
                          << graph.get_node_count() << ")" << std::endl;
                 return 1;
             }
             if (line == "0") {
-                node_mask[line_count] = false;
+                mask_lines.push_back(false);
             } else if (line == "1") {
-                node_mask[line_count] = true;
+                mask_lines.push_back(true);
             } else {
                 std::cerr << "[odgi::similarity] error: mask file should contain only 0 or 1 values, found: " << line << std::endl;
                 return 1;
             }
-            line_count++;
         }
-        if (line_count != graph.get_node_count()) {
-            std::cerr << "[odgi::similarity] error: mask file should have exactly " << graph.get_node_count() 
-                     << " lines, found: " << line_count << std::endl;
+        if (mask_lines.size() != graph.get_node_count()) {
+            std::cerr << "[odgi::similarity] error: mask file should have exactly " << graph.get_node_count()
+                     << " lines, found: " << mask_lines.size() << std::endl;
             return 1;
         }
+        // map the i-th positional line to the i-th node in id order
+        uint64_t d = 0;
+        graph.for_each_handle([&](const handle_t& h) {
+            node_mask[graph.get_id(h) - shift] = mask_lines[d++];
+        });
     }
 
     auto get_path_name
@@ -227,7 +231,7 @@ int main_similarity(int argc, char** argv) {
             [&](const step_handle_t& s) {
                 auto h = graph.get_handle_of_step(s);
                 // Skip masked-out nodes
-                if (!node_mask[graph.get_id(h) - 1]) {
+                if (!node_mask[graph.get_id(h) - shift]) {
                     return;
                 }
                 path_length += graph.get_length(h);
@@ -293,6 +297,10 @@ int main_similarity(int argc, char** argv) {
     std::vector<ska::flat_hash_map<uint64_t, uint64_t>> thread_local_maps(max_local_maps - 1);
     std::vector<std::mutex> map_mutexes(max_local_maps);
 
+    // loop-invariant id bounds; we iterate the id range and skip gaps so non-contiguous ids work
+    const uint64_t min_id = graph.min_node_id();
+    const uint64_t max_id = graph.max_node_id();
+
 #pragma omp parallel
     {
         int thread_id = omp_get_thread_num();
@@ -311,10 +319,13 @@ int main_similarity(int argc, char** argv) {
         }
         
 #pragma omp for
-        for (uint64_t node_id = 1; node_id <= graph.get_node_count(); ++node_id) {
+        for (uint64_t node_id = min_id; node_id <= max_id; ++node_id) {
+            if (!graph.has_node(node_id)) {
+                continue;
+            }
             handle_t h = graph.get_handle(node_id);
             // Skip masked-out nodes
-            if (!node_mask[graph.get_id(h) - 1]) {
+            if (!node_mask[node_id - shift]) {
                 continue;
             }
             ska::flat_hash_map<uint32_t, uint64_t> local_path_lengths;

--- a/src/subcommand/similarity_main.cpp
+++ b/src/subcommand/similarity_main.cpp
@@ -146,6 +146,11 @@ int main_similarity(int argc, char** argv) {
 
     // ska::flat_hash_map<std::pair<uint64_t, uint64_t>, uint64_t> leads to huge memory usage with deep graphs
     // Load mask if specified
+    // this command indexes node-id arrays by rank and iterates ids 1..node_count, so it requires compaction
+    if (graph.max_node_id() - graph.min_node_id() >= graph.get_node_count()) {
+        std::cerr << "[odgi::similarity] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+        exit(1);
+    }
     std::vector<bool> node_mask(graph.get_node_count(), true);  // Default all nodes included
     if (mask_file) {
         std::ifstream mask_in(args::get(mask_file));

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -264,6 +264,11 @@ int main_sort(int argc, char** argv) {
 	};
 
 	auto sort_graph_by_target_paths = [&](graph_t& graph, std::vector<path_handle_t> target_paths, std::vector<bool>& is_ref) {
+		// is_ref is indexed by (id - 1) and gaps are filled via get_handle(i+1), so this requires compaction
+		if (graph.max_node_id() - graph.min_node_id() >= graph.get_node_count()) {
+			std::cerr << "[odgi::sort] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
+			exit(1);
+		}
 		std::vector<handle_t> target_order;
 		std::fill_n(std::back_inserter(is_ref), graph.get_node_count(), false);
 		std::unique_ptr <odgi::algorithms::progress_meter::ProgressMeter> target_paths_progress;

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -264,8 +264,9 @@ int main_sort(int argc, char** argv) {
 	};
 
 	auto sort_graph_by_target_paths = [&](graph_t& graph, std::vector<path_handle_t> target_paths, std::vector<bool>& is_ref) {
-		// is_ref is indexed by (id - 1) and gaps are filled via get_handle(i+1), so this requires compaction
-		if (graph.max_node_id() - graph.min_node_id() >= graph.get_node_count()) {
+		// is_ref is indexed by (id - 1) and gaps are filled via get_handle(i+1), so this requires
+		// ids to be exactly 1..node_count (min==1 && max==node_count), i.e. an optimized graph
+		if (!graph.is_optimized()) {
 			std::cerr << "[odgi::sort] error: the node IDs are not compacted. Please run 'odgi sort' using -O, --optimize to optimize the graph." << std::endl;
 			exit(1);
 		}

--- a/src/subcommand/tension_main.cpp
+++ b/src/subcommand/tension_main.cpp
@@ -245,7 +245,8 @@ int main_tension(int argc, char **argv) {
 		// tension = (lay/nuc);
 		// if (tension < 1) { tension = 1/tension };
 	} else {
-		std::vector<double> node_tensions(graph.get_node_count() + 1, 0.0);
+		// indexed by raw node id; size by max id so non-contiguous ids fit
+		std::vector<double> node_tensions(graph.max_node_id() + 1, 0.0);
 		std::unique_ptr<algorithms::progress_meter::ProgressMeter> progress_meter;
 		if (progress) {
 			progress_meter = std::make_unique<algorithms::progress_meter::ProgressMeter>(

--- a/src/subcommand/tips_main.cpp
+++ b/src/subcommand/tips_main.cpp
@@ -205,7 +205,8 @@ namespace odgi {
 				// make bit vector across nodes to tell us if we have a hit
 				// this is a speed up compared to iterating through all steps of a potential node for each walked step
 				std::vector<bool> target_handles;
-				target_handles.resize(graph.get_node_count(), false);
+				// indexed by node rank (unpack_number); size by rank span so non-contiguous ids fit
+				target_handles.resize(number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) + 1, false);
 				graph.for_each_step_in_path(target_path_t, [&](const step_handle_t &step) {
 					handle_t h = graph.get_handle_of_step(step);
 					target_handles[number_bool_packing::unpack_number(h)] = true;
@@ -249,7 +250,8 @@ namespace odgi {
 				// make bit vector across nodes to tell us if we have a hit
 				// this is a speed up compared to iterating through all steps of a potential node for each walked step
 				std::vector<bool> target_handles;
-				target_handles.resize(graph.get_node_count(), false);
+				// indexed by node rank (unpack_number); size by rank span so non-contiguous ids fit
+				target_handles.resize(number_bool_packing::unpack_number(graph.get_handle(graph.max_node_id())) + 1, false);
 				graph.for_each_step_in_path(target_path_t, [&](const step_handle_t &step) {
 					handle_t h = graph.get_handle_of_step(step);
 					target_handles[number_bool_packing::unpack_number(h)] = true;


### PR DESCRIPTION
The repo-wide audit behind #657 turned up the same node-id hazard (arrays sized by node count but indexed by rank/id) in commands outside that PR. On non-contiguous ids they segfaulted.

**Now support non-compacted** (resized/rewritten to id-span indexing; label-invariant on remapped twins, byte-identical to master on compacted graphs):
- `tips`, `tension`, `bin`
- `similarity` — `node_mask` indexed by id span; positional mask lines still map to the i-th node in id order (format unchanged); the main OMP loop iterates the id range skipping gaps. Works for any id layout, incl. non-1-based.

**Guard cleanly** (error "not compacted, run sort -O" instead of segfaulting; compaction-bound internally):
- `sort` reference-guided PG-SGD (`-p Y -H`) — builds a dense node order indexed by `id-1`
- `cuda/layout.cu` — used `assert(min==1 && max==node_count)`, compiled out under `NDEBUG`, so release builds segfaulted; now a runtime check

(`layout` already guarded via `is_optimized()`.)

**Fixed a guard-strictness bug (review feedback):** the initial `max_id - min_id >= node_count` check passed for contiguous ids starting above 1 (e.g. `100,101`), which then segfaulted. `sort` now guards on `!is_optimized()` (`min==1 && max==node_count`); `similarity` needs no guard now that it supports any layout.

Verified: suite passes (26,079,805 assertions); similarity byte-identical to master on compacted graphs (incl. `--mask`); label-invariant and multithread-consistent on gapped / start-above-1 graphs; no more segfaults.
