### PR TITLE
extract: --drop-pathless to remove nodes not covered by any path (#526)

### DIFF
--- a/docs/rst/commands/odgi_extract.rst
+++ b/docs/rst/commands/odgi_extract.rst
@@ -74,6 +74,11 @@ Extract Options
   position touched by the given path ranges. This ensures that all the paths of the subgraph are not split by node, but that the nodes are laced together again. Comparable to **-R, --lace-paths=FILE**, but specifically for all paths in the resulting subgraph. Be careful to use it with
   very complex graphs.
 
+| **--drop-pathless**
+| Remove nodes (and their edges) not covered by any path from the extracted
+  graph. Useful with **-E, --full-range**, which otherwise laces in nodes
+  untouched by any path.
+
 | **-p, --paths-to-extract**\ =\ *FILE*
 | List of paths to keep in the extracted graph. The *FILE* must contain one
   path name per line and a subset of all paths can be specified.

--- a/src/subcommand/extract_main.cpp
+++ b/src/subcommand/extract_main.cpp
@@ -88,6 +88,8 @@ namespace odgi {
                              {'O', "optimize"});
         args::Flag _keep_full_path_names(extract_opts, "keep-full-path-names", "Keep the original path name (no :start-end suffix) when an extracted subpath spans the whole source path.",
                              {'K', "keep-full-path-names"});
+        args::Flag _drop_pathless(extract_opts, "drop-pathless", "Remove nodes (and their edges) not covered by any path from the extracted graph. Useful with -E, --full-range, which otherwise laces in nodes untouched by any path.",
+                             {"drop-pathless"});
         args::Group threading_opts(parser, "[ Threading ]");
         args::ValueFlag<uint64_t> nthreads(threading_opts, "N", "Number of threads to use for parallel operations.",
                                            {'t', "threads"});
@@ -413,7 +415,7 @@ namespace odgi {
                              const uint64_t context_steps, const uint64_t context_bases, const bool full_range, const bool inverse,
                              const uint64_t max_dist_subpaths, const uint64_t num_iterations,
                              const uint64_t num_threads, const bool show_progress, const bool optimize,
-                             const bool keep_full_path_names) {
+                             const bool keep_full_path_names, const bool drop_pathless) {
             // Check if there are nodes in the subgraph, to avoid extracting the whole graph
             // when nodes with functionality other than pangenomic paths/ranges are not specified
             if (inverse && subgraph.get_node_count() > 0) {
@@ -792,6 +794,22 @@ namespace odgi {
             // This should not be necessary, if the extraction works correctly
             // subgraph.remove_orphan_edges();
 
+            // drop nodes not covered by any path (and their edges)
+            if (drop_pathless) {
+                std::vector<handle_t> pathless;
+                subgraph.for_each_handle([&](const handle_t& h) {
+                    if (subgraph.get_step_count(h) == 0) {
+                        pathless.push_back(h);
+                    }
+                });
+                for (auto& h : pathless) {
+                    subgraph.destroy_handle(h);
+                }
+                if (show_progress && !pathless.empty()) {
+                    std::cerr << "[odgi::extract] dropped " << pathless.size() << " node(s) not covered by any path." << std::endl;
+                }
+            }
+
             if (optimize) {
                 subgraph.optimize();
             }
@@ -828,7 +846,7 @@ namespace odgi {
                     {path_range}, *pangenomic_ranges,
                     context_steps, context_bases, _full_range, false,
                     max_dist_subpaths, num_iterations,
-                    num_threads, show_progress, optimize, args::get(_keep_full_path_names));
+                    num_threads, show_progress, optimize, args::get(_keep_full_path_names), args::get(_drop_pathless));
 
                 const string filename = graph.get_path_name(path_range.begin.path) + ":" + to_string(path_range.begin.offset) + "-" + to_string(path_range.end.offset) + ".og";
 
@@ -861,7 +879,7 @@ namespace odgi {
                 *path_ranges, *pangenomic_ranges,
                 context_steps, context_bases, _full_range, _inverse,
                 max_dist_subpaths, num_iterations,
-                num_threads, show_progress, optimize, args::get(_keep_full_path_names));
+                num_threads, show_progress, optimize, args::get(_keep_full_path_names), args::get(_drop_pathless));
 
             {
                 const std::string outfile = args::get(og_out_file);


### PR DESCRIPTION
Fixes #526.

`odgi extract -E/--full-range` laces in **all** nodes in the id range between the touched positions, including nodes (and their edges) covered by **no path**. On a real HPRC chr6 MHC extraction the reporter saw ~1/4 of nodes and ~1/3 of edges pathless, cluttering `odgi viz`.

**New flag `--drop-pathless`**: after the subgraph's paths are embedded (and before `-O/--optimize`), remove every node with zero path steps and its incident edges. Default behavior is unchanged.

Verified:
- Small graph: `-E` leaks a pathless node; `--drop-pathless` removes it; result validates and paths are intact.
- chr6.C4 `-E` extract (3 paths): dropped 148 pathless nodes + their edges (1317→1169 nodes, 1636→1339 edges), **steps unchanged** (paths fully preserved), validates, zero pathless nodes remain.
- Default (no flag) output byte-identical to master; full suite passes (26,079,805 assertions).
