### PR TITLE
odgi: clear error instead of assert(false) on unknown path name/handle

### DIFF
--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -198,8 +198,12 @@ graph_t::path_metadata_t& graph_t::get_path_metadata(const path_handle_t& path) 
     if (path_metadata_h->Find(as_integer(path), p)) {
         return *p;
     } else {
-        assert(false);
-        return *p; // won't reach unless assert is disabled
+        // A miss here means a stale or cross-graph path handle was used. Fail with a clear
+        // message rather than assert(false) (which is compiled out in release builds, leaving
+        // an uninitialized pointer dereference).
+        std::cerr << "[odgi] error: path handle " << as_integer(path)
+                  << " is not present in this graph (stale or cross-graph path handle)." << std::endl;
+        exit(1);
     }
 }
 
@@ -208,8 +212,12 @@ const graph_t::path_metadata_t& graph_t::path_metadata(const path_handle_t& path
     if (path_metadata_h->Find(as_integer(path), p)) {
         return *p;
     } else {
-        assert(false);
-        return *p; // won't reach unless assert is disabled
+        // A miss here means a stale or cross-graph path handle was used. Fail with a clear
+        // message rather than assert(false) (which is compiled out in release builds, leaving
+        // an uninitialized pointer dereference).
+        std::cerr << "[odgi] error: path handle " << as_integer(path)
+                  << " is not present in this graph (stale or cross-graph path handle)." << std::endl;
+        exit(1);
     }
 }
 
@@ -226,8 +234,10 @@ path_handle_t graph_t::get_path_handle(const std::string& path_name) const {
     if (path_name_h->Find(path_name, p)) {
         return p->handle;
     } else {
-        assert(false);
-        return as_path_handle(0); // won't reach unless assert is disabled
+        // Fail clearly with the missing name rather than assert(false) (compiled out in release,
+        // then returning path handle 0 whose later use aborts opaquely in get_path_metadata).
+        std::cerr << "[odgi] error: path '" << path_name << "' is not present in this graph." << std::endl;
+        exit(1);
     }
 }
 


### PR DESCRIPTION
Relates to #464 and #516 (same crash: `Assertion 'false' failed` in `graph_t::get_path_metadata`, odgi.cpp:201, during `odgi extract`).

`get_path_handle`, `get_path_metadata` and `path_metadata` used `assert(false)` on a lookup miss:

```cpp
if (path_name_h->Find(path_name, p)) { return p->handle; }
else { assert(false); return as_path_handle(0); }
```

Two problems:
1. In **release builds** `assert` is compiled out, so these fall through to `return as_path_handle(0)` / `return *p` with `p` uninitialized — an invalid handle whose later use aborts opaquely (or segfaults).
2. Even where the assert fires, `Assertion 'false' failed` gives the user nothing to act on.

This replaces all three with a clear message and `exit(1)`. `get_path_handle` now prints the **missing path name**, which is diagnostic: the extract crash in #464/#516 goes through `add_subpaths_to_subgraph` looking up a subpath by name (`extract.cpp:151`/`173`), so the message will reveal exactly which subpath name is not found — pinpointing the underlying create-vs-lookup naming bug without needing the reporter's full graph.

No behavior change on the happy path; full suite passes (26,079,805 assertions).
