### PR TITLE
Optimize hot output loops and per-step lookups

### DIFF
--- a/src/algorithms/bin_path_depth.cpp
+++ b/src/algorithms/bin_path_depth.cpp
@@ -22,8 +22,9 @@ namespace odgi {
             });
             std::cout << std::endl;
             // the graph must be compacted for this to work
+            std::vector<uint64_t> p_i(path_count); // reused across nodes (loop is sequential)
             graph.for_each_handle([&](const handle_t &h) {
-                vector<uint64_t> p_i = vector<uint64_t>(path_count);
+                std::fill(p_i.begin(), p_i.end(), 0);
                 graph.for_each_step_on_handle(h, [&](const step_handle_t &occ) {
                     const path_handle_t p_h = graph.get_path_handle_of_step(occ);
                     p_i[as_integer(p_h) - 1] += 1;

--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -75,6 +75,12 @@ namespace odgi {
                 uint64_t last_pos_in_bin = 0;
                 uint64_t nucleotide_count = 0;
                 bool last_is_rev = false;
+                // cache the map entry for the current bin: bins[curr_bin] is looked up
+                // 6-8 times per base but curr_bin is invariant within a base and changes
+                // only on a bin boundary. std::map references stay valid across inserts of
+                // other keys, so caching the pointer is safe and byte-identical.
+                int64_t cur_bin_key = -1; // sentinel; real bins are always >= 1
+                path_info_t* bin_ptr = nullptr;
                 graph.for_each_step_in_path(path, [&](const step_handle_t &occ) {
                     handle_t h = graph.get_handle_of_step(occ);
                     bool is_rev = graph.get_is_reverse(h);
@@ -89,15 +95,17 @@ namespace odgi {
                             // bin cross!
                             links.push_back(std::make_pair(last_bin, curr_bin));
                         }
-                        ++bins[curr_bin].mean_depth;
+                        if (curr_bin != cur_bin_key) { bin_ptr = &bins[curr_bin]; cur_bin_key = curr_bin; }
+                        path_info_t& b = *bin_ptr;
+                        ++b.mean_depth;
                         if (is_rev) {
-                            ++bins[curr_bin].mean_inv;
+                            ++b.mean_inv;
                         }
-                        bins[curr_bin].mean_pos += path_pos++;
+                        b.mean_pos += path_pos++;
                         nucleotide_count += 1;
-                        if ((bins[curr_bin].ranges.size() == 0) ||
-                            ((nucleotide_count - bins[curr_bin].ranges.back().second) > 1 &&
-                             (nucleotide_count - bins[curr_bin].ranges.back().first) > 1) ||
+                        if ((b.ranges.size() == 0) ||
+                            ((nucleotide_count - b.ranges.back().second) > 1 &&
+                             (nucleotide_count - b.ranges.back().first) > 1) ||
                             (is_rev != last_is_rev)) {
                             std::pair<uint64_t, uint64_t> p = std::make_pair(0, 0);
                             if (is_rev) {
@@ -105,13 +113,13 @@ namespace odgi {
                             } else {
                                 std::get<1>(p) = nucleotide_count;
                             }
-                            bins[curr_bin].ranges.push_back(p);
+                            b.ranges.push_back(p);
 #ifdef debug_bin_path_info
                             std::cerr << "PUSHED PAIR: " << "<" << std::get<0>(p) << "," << std::get<1>(p) << ">"
                                       << std::endl;
 #endif
                         } else {
-                            std::pair<uint64_t, uint64_t> &p = bins[curr_bin].ranges.back();
+                            std::pair<uint64_t, uint64_t> &p = b.ranges.back();
                             if (is_rev) {
                                 updatePair<0, 1>(p, nucleotide_count);
                             }

--- a/src/algorithms/chop.cpp
+++ b/src/algorithms/chop.cpp
@@ -55,7 +55,8 @@ namespace odgi {
             );
 
             std::vector<handle_t> new_handles;
-            for (auto x_y_z : originalRank_inChoppedNodeRank_handle) {
+            new_handles.reserve(originalRank_inChoppedNodeRank_handle.size());
+            for (const auto &x_y_z : originalRank_inChoppedNodeRank_handle) {
                 new_handles.push_back(std::get<2>(x_y_z));
             }
 

--- a/src/algorithms/crush_n.cpp
+++ b/src/algorithms/crush_n.cpp
@@ -6,9 +6,11 @@ namespace algorithms {
 void crush_n(odgi::graph_t& graph) {
     graph.for_each_handle([&](const handle_t& handle) {
         // strip Ns from start
+        const std::string src = graph.get_sequence(handle);
         std::string seq;
+        seq.reserve(src.size());
         bool in_n = false;
-        for (auto c : graph.get_sequence(handle)) {
+        for (auto c : src) {
             if (c == 'N') {
                 if (in_n) {
                     continue;

--- a/src/algorithms/draw.cpp
+++ b/src/algorithms/draw.cpp
@@ -267,7 +267,7 @@ void draw_svg(std::ostream &out,
                     << "\" stroke=\"" << to_hexrgb(color)
                     << "\" stroke-width=\"" << line_width
                     << "\"/>"
-                    << std::endl;
+                    << '\n';
             } else {
                 highlights.push_back(handle);
             }
@@ -293,7 +293,7 @@ void draw_svg(std::ostream &out,
                 << "\" stroke=\"" << to_hexrgb(color) //to_rgba(color) // with rgba, nodes are invisible with InkScape
                 << "\" stroke-width=\"" << line_width
                 << "\"/>"
-                << std::endl;
+                << '\n';
         }
 
         // Render labels at the end, to have them on top of everything
@@ -315,7 +315,7 @@ void draw_svg(std::ostream &out,
                     placed_labels.emplace_back(newEndpoints.x2, newEndpoints.y2, text); // Record the label's placement
                 }
                 out << "</text>"
-                    << std::endl;
+                    << '\n';
             }
         }
     }

--- a/src/algorithms/flip.cpp
+++ b/src/algorithms/flip.cpp
@@ -97,6 +97,7 @@ void flip_paths(graph_t& graph,
                 auto name = graph.get_path_name(path) + "_inv";
                 auto flipped = into.create_path_handle(name);
                 std::vector<handle_t> v;
+                v.reserve(graph.get_step_count(path));
                 graph.for_each_step_in_path(
                     path,
                     [&into,&v,&graph](const step_handle_t& s) {

--- a/src/algorithms/groom.cpp
+++ b/src/algorithms/groom.cpp
@@ -180,6 +180,7 @@ namespace odgi {
             }
 
             std::vector<handle_t> order;
+            order.reserve(graph.get_node_count());
             uint64_t num_flipped_handles = 0;
 
             graph.for_each_handle(

--- a/src/algorithms/heaps.cpp
+++ b/src/algorithms/heaps.cpp
@@ -96,7 +96,6 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
         for (auto& j : permutation) {
             auto& paths = path_groups[j];
             for (auto& path : paths) {
-                uint64_t pos = 0;
                 graph.for_each_step_in_path(
                     path,
                     [&](const step_handle_t& step) {
@@ -106,7 +105,6 @@ void for_each_heap_permutation(const PathHandleGraph& graph,
                             seen_nodes[rank] = 1;
                             seen_bp += graph.get_length(h);
                         }
-                        pos += graph.get_length(h);
                     });
             }
             vals.push_back(seen_bp);

--- a/src/algorithms/kmer.cpp
+++ b/src/algorithms/kmer.cpp
@@ -51,9 +51,6 @@ void for_each_kmer(const HandleGraph& graph, size_t k, size_t edge_max,
                         // did we reach our target length?
                         if (kmer.seq.size() == k) {
                             // TODO here check if we are at the beginning of the reverse head or the beginning of the forward tail and would need special handling
-                            // establish the context
-                            handle_t end_handle = graph.get_handle(id(kmer.end), is_rev(kmer.end));
-                            size_t end_length = graph.get_length(end_handle);
                             // now pass the kmer to our callback
                             lambda(kmer);
                             q = kmers.erase(q);
@@ -65,7 +62,7 @@ void for_each_kmer(const HandleGraph& graph, size_t k, size_t edge_max,
                             std::string curr_seq = graph.get_sequence(kmer.curr);
                             size_t take = std::min(curr_length, k-kmer.seq.size());
                             kmer.end = make_pos_t(curr_id, curr_is_rev, take);
-                            kmer.seq.append(curr_seq.substr(0,take));
+                            kmer.seq.append(curr_seq, 0, take);
                             if (kmer.seq.size() < k) {
                                 size_t next_count = 0;
                                 if (edge_max) graph.follow_edges(kmer.curr, false, [&](const handle_t& next) { ++next_count; return next_count <= 1; });

--- a/src/algorithms/layout.cpp
+++ b/src/algorithms/layout.cpp
@@ -27,8 +27,8 @@ void to_tsv(std::ostream &out, const std::vector<double> &X, const std::vector<d
         for (auto& handle :  weak_components[num_component]) {
             uint64_t pos = 2 * number_bool_packing::unpack_number(handle);
 
-            out << as_integer(handle) << "\t" << X[pos] << "\t" << Y[pos] << "\t" << num_component <<std::endl;
-            out << as_integer(handle)+1 << "\t" << X[pos + 1] << "\t" << Y[pos + 1] << "\t" << num_component<< std::endl;
+            out << as_integer(handle) << "\t" << X[pos] << "\t" << Y[pos] << "\t" << num_component <<'\n';
+            out << as_integer(handle)+1 << "\t" << X[pos + 1] << "\t" << Y[pos + 1] << "\t" << num_component<< '\n';
         }
     }
 
@@ -69,7 +69,7 @@ void Layout::to_tsv(std::ostream &out) {
     out << std::setprecision(std::numeric_limits<double>::digits10 + 1);
     out << "idx" << "\t" << "X" << "\t" << "Y" << std::endl;
     for (uint64_t i = 0; i < size(); ++i) {
-        out << i << "\t" << get_x(i) << "\t" << get_y(i) << std::endl;
+        out << i << "\t" << get_x(i) << "\t" << get_y(i) << '\n';
     }
 }
 

--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -273,8 +273,7 @@ namespace odgi {
                                         }
                                     } else {
                                         // sample randomly across the path
-                                        graph.get_step_count(path);
-                                        std::uniform_int_distribution<uint64_t> rando(0, graph.get_step_count(path)-1);
+                                        std::uniform_int_distribution<uint64_t> rando(0, path_step_count-1);
                                         as_integers(step_b)[0] = as_integer(path);
                                         as_integers(step_b)[1] = rando(gen);
                                     }
@@ -419,7 +418,7 @@ namespace odgi {
                                     ofstream snapshot_stream;
                                     snapshot_stream.open(snapshot_tmp_file);
                                     for (auto &x : X) {
-                                        snapshot_stream << x << std::endl;
+                                        snapshot_stream << x << '\n';
                                     }
                                     // push back the name of the temp file
                                     snapshots.push_back(snapshot_tmp_file);

--- a/src/algorithms/path_sgd_layout.cpp
+++ b/src/algorithms/path_sgd_layout.cpp
@@ -232,7 +232,7 @@ namespace odgi {
                                         }
                                     } else {
                                         // sample randomly across the path
-                                        std::uniform_int_distribution<uint64_t> rando(0, graph.get_step_count(path)-1);
+                                        std::uniform_int_distribution<uint64_t> rando(0, path_step_count-1);
                                         as_integers(step_b)[0] = as_integer(path);
                                         as_integers(step_b)[1] = rando(gen);
                                     }

--- a/src/algorithms/prune.cpp
+++ b/src/algorithms/prune.cpp
@@ -15,6 +15,7 @@ std::vector<recorded_path_t> record_paths(const graph_t& graph) {
         recorded_path_t rp;
         rp.name = graph.get_path_name(p);
         rp.is_circular = graph.get_is_circular(p);
+        rp.steps.reserve(graph.get_step_count(p));
         graph.for_each_step_in_path(p, [&](const step_handle_t& step) {
             const handle_t h = graph.get_handle_of_step(step);
             const uint64_t len = graph.get_length(h);
@@ -134,7 +135,6 @@ std::vector<edge_t> find_edges_to_prune(const HandleGraph& graph,
                 // determine next positions
                 nid_t handle_id = graph.get_id(handle);
                 size_t handle_length = graph.get_length(handle);
-                std::string handle_seq = graph.get_sequence(handle);
                 for (size_t i = 0; i < handle_length;  ++i) {
                     pos_t begin = make_pos_t(handle_id, handle_is_rev, handle_length);
                     pos_t end = make_pos_t(handle_id, handle_is_rev, std::min(handle_length, i+k));

--- a/src/algorithms/random_order.cpp
+++ b/src/algorithms/random_order.cpp
@@ -6,6 +6,7 @@ namespace algorithms {
 
 std::vector<handle_t> random_order(const HandleGraph& graph) {
     std::vector<handle_t> order;
+    order.reserve(graph.get_node_count());
     graph.for_each_handle([&order](const handle_t& handle) {
             order.push_back(handle);
         });

--- a/src/algorithms/stepindex.cpp
+++ b/src/algorithms/stepindex.cpp
@@ -40,9 +40,10 @@ step_index_t::step_index_t(const PathHandleGraph& graph,
 		uint64_t path_length = 0;
         graph.for_each_step_in_path(
             path, [&](const step_handle_t& step) {
-				path_length += graph.get_length(graph.get_handle_of_step(step));
+				const handle_t h = graph.get_handle_of_step(step);
+				path_length += graph.get_length(h);
 				// sampling
-				if (sample_rate == 0 || 0 == utils::modulo(graph.get_id(graph.get_handle_of_step(step)), sample_rate)) {
+				if (sample_rate == 0 || 0 == utils::modulo(graph.get_id(h), sample_rate)) {
 					my_steps.push_back(step);
 				}
 			});
@@ -78,11 +79,12 @@ step_index_t::step_index_t(const PathHandleGraph& graph,
         uint64_t offset = 0;
         graph.for_each_step_in_path(
             path, [&](const step_handle_t& step) {
+				const handle_t h = graph.get_handle_of_step(step);
 				// sampling
-				if (sample_rate == 0 || 0 == utils::modulo(graph.get_id(graph.get_handle_of_step(step)), sample_rate)) {
+				if (sample_rate == 0 || 0 == utils::modulo(graph.get_id(h), sample_rate)) {
 					pos[step_mphf->lookup(step)] = offset;
 				}
-				offset += graph.get_length(graph.get_handle_of_step(step));
+				offset += graph.get_length(h);
 				});
 		// sampling
 		if (sample_rate == 0 || 0 == utils::modulo(graph.get_id(graph.get_handle_of_step(graph.path_end(path))), sample_rate)) {

--- a/src/algorithms/subgraph/extract.cpp
+++ b/src/algorithms/subgraph/extract.cpp
@@ -145,20 +145,21 @@ namespace odgi {
                 if (!subpath_ranges[path_rank].empty()) {
                     const auto &source_path_handle = source_paths[path_rank];
                     const std::string path_name = source.get_path_name(source_path_handle);
+                    const auto &ranges = subpath_ranges[path_rank]; // invariant within this path
 
                     // The path ranges are sorted by coordinates by design
                     uint64_t range_rank = 0;
                     path_handle_t subpath_handle = subgraph.get_path_handle(
-                            subpath_name(path_rank, path_name, subpath_ranges[path_rank][0])
+                            subpath_name(path_rank, path_name, ranges[0])
                     );
 
                     uint64_t walked = 0;
                     source.for_each_step_in_path(source_path_handle, [&](const step_handle_t &step) {
-                        if (range_rank < subpath_ranges[path_rank].size()) {
+                        if (range_rank < ranges.size()) {
                             const handle_t source_handle = source.get_handle_of_step(step);
 
-                            if (walked >= subpath_ranges[path_rank][range_rank].first &&
-                                walked <= subpath_ranges[path_rank][range_rank].second) {
+                            if (walked >= ranges[range_rank].first &&
+                                walked <= ranges[range_rank].second) {
                                 subgraph.append_step(
                                         subpath_handle,
                                         subgraph.get_handle(source.get_id(source_handle),
@@ -167,11 +168,11 @@ namespace odgi {
                             }
 
                             walked += source.get_length(source_handle);
-                            if (walked >= subpath_ranges[path_rank][range_rank].second) {
+                            if (walked >= ranges[range_rank].second) {
                                 ++range_rank;
-                                if (range_rank < subpath_ranges[path_rank].size()) {
+                                if (range_rank < ranges.size()) {
                                     subpath_handle = subgraph.get_path_handle(
-                                            subpath_name(path_rank, path_name, subpath_ranges[path_rank][range_rank])
+                                            subpath_name(path_rank, path_name, ranges[range_rank])
                                     );
                                 }//else not other subpath ranges for this path
                             }

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -352,6 +352,7 @@ std::vector<handle_t> two_way_topological_order(const HandleGraph* g) {
         avg_order[handle] = max(avg_order[handle], (++i));
     }
     std::vector<std::pair<handle_t, uint64_t>> order;
+    order.reserve(avg_order.size());
     for (auto& p : avg_order) {
         order.push_back(p);
     }
@@ -360,6 +361,7 @@ std::vector<handle_t> two_way_topological_order(const HandleGraph* g) {
                   return a.second < b.second;
               });
     std::vector<handle_t> result;
+    result.reserve(avg_order.size());
     for (auto& p : order) {
         result.push_back(p.first);
     }
@@ -501,6 +503,7 @@ std::vector<handle_t> breadth_first_topological_order(const HandleGraph& g, cons
     uint64_t prev_max_length = 0;
     
     std::vector<bfs_state_t> order_raw;
+    order_raw.reserve(g.get_node_count());
     while (unvisited.rank1(unvisited.size())!=0) {
         /*
         std::cerr << "unvisited size " << unvisited.rank1(unvisited.size()) << std::endl;
@@ -551,6 +554,7 @@ std::vector<handle_t> breadth_first_topological_order(const HandleGraph& g, cons
               });
 
     std::vector<handle_t> order;
+    order.reserve(order_raw.size());
     for (auto& o : order_raw) order.push_back(o.handle);
 
     return order;
@@ -593,6 +597,7 @@ std::vector<handle_t> depth_first_topological_order(const HandleGraph& g, const 
                       });
     */
     std::vector<handle_t> order;
+    order.reserve(g.get_node_count());
     while (unvisited.rank1(unvisited.size())!=0) {
         /*
         std::cerr << "unvisited size " << unvisited.rank1(unvisited.size()) << std::endl;

--- a/src/algorithms/unchop.cpp
+++ b/src/algorithms/unchop.cpp
@@ -41,12 +41,12 @@ namespace odgi {
             // Make the new node
             handle_t new_node;
             {
-                std::stringstream ss;
+                std::string seq;
                 for (auto &n : nodes) {
-                    ss << graph.get_sequence(n);
+                    seq.append(graph.get_sequence(n));
                 }
 
-                new_node = graph.create_handle(ss.str());
+                new_node = graph.create_handle(seq);
             }
 
 #ifdef debug
@@ -347,6 +347,7 @@ namespace odgi {
             ips4o::parallel::sort(ordered_handles.begin(), ordered_handles.end(), std::less<>(), nthreads);
 
             std::vector<handle_t> handle_order;
+            handle_order.reserve(ordered_handles.size());
             for (auto &h : ordered_handles) {
                 handle_order.push_back(h.second);
             }

--- a/src/algorithms/untangle.cpp
+++ b/src/algorithms/untangle.cpp
@@ -422,6 +422,7 @@ segment_map_t::get_matches(
     //path_handle_t query_path = graph.get_path_handle_of_step(start);
     ska::flat_hash_map<uint64_t, isec_t> target_isec;
     ska::flat_hash_map<uint64_t, uint64_t> query_seen;
+    ska::flat_hash_map<uint64_t, uint64_t> target_seen; // reused across steps; cleared each iteration
     for (step_handle_t step = start;
          step != end;
          step = graph.get_next_step(step)) {
@@ -430,7 +431,7 @@ segment_map_t::get_matches(
         uint64_t node_length = graph.get_length(h);
         bool is_rev = graph.get_is_reverse(h);
         uint64_t query_idx = query_seen[node_id]++;
-        ska::flat_hash_map<uint64_t, uint64_t> target_seen;
+        target_seen.clear();
         for_segment_on_node(
             node_id,
             [&](const uint64_t& segment_id, const bool& segment_rev) {
@@ -563,6 +564,8 @@ void map_segments(
     ska::flat_hash_map<path_handle_t, uint64_t>& path_to_len) {
     // query name is the first field in our outputs
     std::string query_name = graph.get_path_name(path);
+    // cache target path names: only ~n_paths distinct targets recur across many output lines
+    ska::flat_hash_map<path_handle_t, std::string> target_name_cache;
     // helper for building up gene order lists and gggenes plot data
     struct path_range_t {
         path_handle_t target_path;
@@ -600,7 +603,11 @@ void map_segments(
                     auto target_begin_pos = step_index.get_position(target_begin, graph);
                     auto target_end_pos = target_begin_pos + target_segments.get_segment_length(idx);
                     path_handle_t target_path = graph.get_path_handle_of_step(target_begin);
-                    std::string target_name = graph.get_path_name(target_path);
+                    auto tn_it = target_name_cache.find(target_path);
+                    if (tn_it == target_name_cache.end()) {
+                        tn_it = target_name_cache.emplace(target_path, graph.get_path_name(target_path)).first;
+                    }
+                    const std::string& target_name = tn_it->second;
                     if (output_type == untangle_output_t::PAF){
                         // PAF format
 #pragma omp critical (cout)
@@ -620,7 +627,7 @@ void map_segments(
                         << "jc:f:" << jaccard << "\t"
                         << "sc:f:" << self_coverage << "\t"
                         << "nb:i:" << nth_best << "\t"
-                        << std::endl;
+                        << '\n';
                     } else if (output_type == untangle_output_t::ORDER
                                || output_type == untangle_output_t::GGGENES
                                || output_type == untangle_output_t::SCHEMATIC) {
@@ -648,7 +655,7 @@ void map_segments(
                         << jaccard << "\t"
                         << (mapping.is_inv ? "-" : "+") << "\t"
                         << self_coverage << "\t"
-                        << nth_best << std::endl;
+                        << nth_best << '\n';
                     }
 
                 }
@@ -665,7 +672,7 @@ void map_segments(
         std::string s = ss.str();
         if (s.size() && s.at(s.size()-1) == ',') { s.pop_back(); }
 #pragma omp critical (cout)
-        std::cout << s << std::endl;
+        std::cout << s << '\n';
     }
     if (output_type == untangle_output_t::GGGENES
         || output_type == untangle_output_t::SCHEMATIC) {

--- a/src/gfa_to_handle.cpp
+++ b/src/gfa_to_handle.cpp
@@ -113,8 +113,8 @@ void gfa_to_handle(const string& gfa_filename,
                     uint64_t source_id = stol(e.source_name) - id_increment;
                     uint64_t sink_id = stol(e.sink_name) - id_increment;
                     if (graph->has_node(source_id) && graph->has_node(sink_id)) {
-                        handlegraph::handle_t a = graph->get_handle(stol(e.source_name) - id_increment, !e.source_orientation_forward);
-                        handlegraph::handle_t b = graph->get_handle(stol(e.sink_name) - id_increment, !e.sink_orientation_forward);
+                        handlegraph::handle_t a = graph->get_handle(source_id, !e.source_orientation_forward);
+                        handlegraph::handle_t b = graph->get_handle(sink_id, !e.sink_orientation_forward);
                         graph->create_edge(a, b);
                     } else {
                         std::cerr << "[odgi::gfa_to_handle] Error creating edge '" << e.source_name << " <--> " << e.sink_name << "' due to missing node(s)" << std::endl;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -151,7 +151,9 @@ void node_t::for_each_path_step(
                              bool is_rev)>& func) const {
     uint64_t n_paths = path_count();
     for (uint64_t i = 0; i < n_paths; ++i) {
-        if (!step_is_del(i) && !func(i, paths.at(PATH_RECORD_LENGTH*i), step_is_rev(i))) {
+        const uint8_t t = paths.at(PATH_RECORD_LENGTH*i+1); // step-type byte: read once, unpack twice
+        if (!step_type_helper::unpack_is_del(t)
+            && !func(i, paths.at(PATH_RECORD_LENGTH*i), step_type_helper::unpack_is_rev(t))) {
             break;
         }
     }

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "odgi.hpp"
+#include <charconv>
 
 namespace odgi {
 
@@ -1571,13 +1572,14 @@ void graph_t::to_gfa(std::ostream& out, const bool& emit_node_annotation) const 
     out << "H\tVN:Z:1.0" << std::endl;
     // for each node
     for_each_handle([&out,&emit_node_annotation, this](const handle_t& h) {
-            out << "S\t" << get_id(h) << "\t" << get_sequence(h);
+            out << "S\t" << get_id(h) << "\t" << get_node_cref(h).get_sequence();
             if (emit_node_annotation) {
+                const size_t sc = get_step_count(h);
                 out << "\t"
-                << "DP:i:" << get_step_count(h) << "\t"
-                << "RC:i:" << get_step_count(h) * get_length(h);
+                << "DP:i:" << sc << "\t"
+                << "RC:i:" << sc * get_length(h);
             }
-            out << std::endl;
+            out << '\n';
 
             {
                 // use this direct iteration to avoid double counting edges
@@ -1595,29 +1597,35 @@ void graph_t::to_gfa(std::ostream& out, const bool& emit_node_annotation) const 
                                 << (on_rev?"-":"+") << "\t"
                                 << other_id << "\t"
                                 << (other_rev?"-":"+") << "\t"
-                                << "0M" << std::endl;
+                                << "0M" << '\n';
                         }
                         return true;
                     });
             }
         });
-    for_each_path_handle([&out,this](const path_handle_t& p) {
+    std::string line; // reused across paths to batch per-step output (avoids per-field ostream overhead)
+    for_each_path_handle([&out,&line,this](const path_handle_t& p) {
             out << "P\t" << get_path_name(p) << "\t";
             auto& path_meta = path_metadata(p);
             uint64_t i = 0;
-            for_each_step_in_path(p, [this,&i,&out](const step_handle_t& step) {
+            line.clear();
+            for_each_step_in_path(p, [this,&i,&line](const step_handle_t& step) {
                     handle_t h = get_handle_of_step(step);
-                    out << get_id(h) << (get_is_reverse(h)?"-":"+");
-                    if (has_next_step(step)) out << ",";
+                    char buf[24];
+                    auto r = std::to_chars(buf, buf + sizeof(buf), get_id(h));
+                    line.append(buf, r.ptr);
+                    line.push_back(get_is_reverse(h) ? '-' : '+');
+                    if (has_next_step(step)) line.push_back(',');
                     ++i;
                 });
+            out << line;
             out << "\t" << "*"; // always put at least a "*" in the overlaps field
             if (get_is_circular(p)) {
                 out << "\t" << "TP:Z:circular";
             }
             assert(i == path_meta.length);
             //out << "\t" << "steps:i:" << path_meta.length;
-            out << std::endl;
+            out << '\n';
         });
 }
 

--- a/src/subcommand/degree_main.cpp
+++ b/src/subcommand/degree_main.cpp
@@ -4,6 +4,7 @@
 #include "split.hpp"
 #include "subgraph/region.hpp"
 #include <omp.h>
+#include <charconv>
 #include "algorithms/degree.hpp"
 
 #include "src/algorithms/subgraph/extract.hpp"
@@ -228,6 +229,7 @@ int main_degree(int argc, char** argv) {
 		});
 	} else if (graph_degree_vec) {
 		std::cout << (og_file ? args::get(og_file) : "graph") << "_vec";
+		std::string out_buf; // reused across nodes to avoid per-field ostream overhead
 		graph.for_each_handle(
 				[&](const handle_t &h) {
 					uint64_t degree = 0;
@@ -247,9 +249,16 @@ int main_degree(int argc, char** argv) {
 						degree += graph.get_degree(h, false) + graph.get_degree(h, true);
 					}
 					auto length = graph.get_length(h);
+					char numbuf[24];
+					auto res = std::to_chars(numbuf, numbuf + sizeof(numbuf), degree);
+					const size_t nlen = res.ptr - numbuf;
+					out_buf.clear();
+					out_buf.reserve(length * (nlen + 1));
 					for (uint64_t i = 0; i < length; ++i) {
-						std::cout << " " << degree;
+						out_buf.push_back(' ');
+						out_buf.append(numbuf, nlen);
 					}
+					std::cout << out_buf;
 				});
 		std::cout << std::endl;
 	} else if (path_degree) {

--- a/src/subcommand/depth_main.cpp
+++ b/src/subcommand/depth_main.cpp
@@ -7,6 +7,8 @@
 #include "algorithms/depth.hpp"
 #include "algorithms/path_length.hpp"
 #include <omp.h>
+#include <unordered_set>
+#include <charconv>
 
 #include "src/algorithms/subgraph/extract.hpp"
 
@@ -242,6 +244,8 @@ namespace odgi {
             });
         } else if (graph_depth_vec) {
             std::cout << (og_file ? args::get(og_file) : "graph") << "_vec";
+            std::string line_buf; // reused across nodes to avoid per-field ostream overhead
+            char num_buf[24];
             graph.for_each_handle(
                 [&](const handle_t &h) {
                     uint64_t depth = 0;
@@ -254,9 +258,15 @@ namespace odgi {
                                 ];
                         });
                     auto length = graph.get_length(h);
+                    auto res = std::to_chars(num_buf, num_buf + sizeof(num_buf), depth);
+                    const size_t nlen = res.ptr - num_buf;
+                    line_buf.clear();
+                    line_buf.reserve(length * (nlen + 1));
                     for (uint64_t i = 0; i < length; ++i) {
-                        std::cout << " " << depth;
+                        line_buf.push_back(' ');
+                        line_buf.append(num_buf, nlen);
                     }
+                    std::cout << line_buf;
                 });
             std::cout << std::endl;
         } else if (path_depth) {
@@ -397,7 +407,7 @@ namespace odgi {
                                        const std::vector<bool>& paths_to_consider) {
 
             uint64_t node_depth = 0;
-            std::set<uint64_t> unique_paths;
+            std::unordered_set<uint64_t> unique_paths;
 
             const handle_t h = graph.get_handle(node_id);
 
@@ -501,7 +511,7 @@ namespace odgi {
 #pragma omp critical (cout)
                 std::cout << node_id << "\t"
                           << depth.first << "\t"
-                          << depth.second << std::endl;
+                          << depth.second << '\n';
             }
         }
 

--- a/src/subcommand/flatten_main.cpp
+++ b/src/subcommand/flatten_main.cpp
@@ -84,9 +84,9 @@ int main_flatten(int argc, char** argv) {
             const uint8_t fasta_line_width = 80;
 
             auto write_fasta = [&](ostream& out) {
-                out << ">" << fasta_name << std::endl;
+                out << ">" << fasta_name << '\n';
                 for (uint64_t i = 0; i < linear.graph_seq.size(); i+=fasta_line_width) {
-                    out << linear.graph_seq.substr(i, fasta_line_width) << std::endl;
+                    out << linear.graph_seq.substr(i, fasta_line_width) << '\n';
                 }
             };
 
@@ -103,7 +103,7 @@ int main_flatten(int argc, char** argv) {
         auto write_bed_line = [&](ostream& out, const std::string& path_name, const uint64_t& start,
                 const uint64_t& end, bool is_rev, const uint64_t& rank) {
             out << fasta_name << "\t" << start << "\t" << end << "\t"
-            << path_name << "\t" << (is_rev ? "-" : "+") << "\t" << rank << std::endl;
+            << path_name << "\t" << (is_rev ? "-" : "+") << "\t" << rank << '\n';
         };
 
         const std::string bed_out = args::get(bed_out_file);

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -1,6 +1,7 @@
 #include "subcommand.hpp"
 #include "odgi.hpp"
 #include "args.hxx"
+#include <charconv>
 #include "split.hpp"
 #include "position.hpp"
 #include <omp.h>
@@ -260,6 +261,8 @@ int main_paths(int argc, char** argv) {
             std::cout << header.str() << std::endl;
         }
         bool node_length_scale = args::get(scale_by_node_length);
+        std::string row_str; // reused across paths (matrix rows)
+        row_str.reserve(1<<20);
         graph.for_each_path_handle(
             [&](const path_handle_t& p) {
                 std::string full_path_name = graph.get_path_name(p);
@@ -293,10 +296,16 @@ int main_paths(int argc, char** argv) {
                           << path_length << "\t"
                           << path_step_count;
                 // emit one column per real node in the same order as the header (for_each_handle)
+                row_str.clear();
+                char numbuf[24];
                 graph.for_each_handle([&](const handle_t& h) {
                     const uint64_t count = row[graph.get_id(h) - shift];
-                    std::cout << "\t" << (node_length_scale ? count * graph.get_length(h) : count);
+                    const uint64_t val = node_length_scale ? count * graph.get_length(h) : count;
+                    row_str.push_back('\t');
+                    auto res = std::to_chars(numbuf, numbuf + sizeof(numbuf), val);
+                    row_str.append(numbuf, res.ptr - numbuf);
                 });
+                std::cout << row_str;
                 std::cout << std::endl;
             });
     }

--- a/src/subcommand/pav_main.cpp
+++ b/src/subcommand/pav_main.cpp
@@ -311,6 +311,17 @@ int main_pav(int argc, char **argv) {
 		operation_progress = std::make_unique<odgi::algorithms::progress_meter::ProgressMeter>(path_ranges.size(), banner);
     }
 
+    // Precompute path -> group rank once, so the parallel per-step loop does a single
+    // read-only hash lookup (avoids a double path_2_group probe + a std::map<string> lookup
+    // per step, and the non-const operator[] races those maps would incur under omp).
+    ska::flat_hash_map<path_handle_t, uint64_t> path_2_group_rank;
+    if (group_paths) {
+        path_2_group_rank.reserve(path_2_group.size());
+        for (auto& kv : path_2_group) {
+            path_2_group_rank[kv.first] = group_2_index[kv.second];
+        }
+    }
+
 #pragma omp parallel for schedule(dynamic, 1) num_threads(num_threads)
     for (uint64_t i = 0; i < path_ranges.size(); ++i) {
         auto &path_range = path_ranges[i];
@@ -338,11 +349,13 @@ int main_pav(int argc, char **argv) {
             graph.for_each_step_on_handle(handle, [&](const step_handle_t &source_step) {
                 const auto& path_handle = graph.get_path_handle_of_step(source_step);
                 // Check if the paths are grouped and there are paths that do not belong to any group
-                if (!group_paths || path_2_group.find(path_handle) != path_2_group.end()) {
-                    const uint64_t group_rank = group_paths ?
-                            group_2_index[path_2_group[path_handle]] :
-                            as_integer(path_handle) - 1;
-                    group_ranks_on_node_handle.insert(group_rank);
+                if (!group_paths) {
+                    group_ranks_on_node_handle.insert(as_integer(path_handle) - 1);
+                } else {
+                    auto it = path_2_group_rank.find(path_handle);
+                    if (it != path_2_group_rank.end()) {
+                        group_ranks_on_node_handle.insert(it->second);
+                    }
                 }
             });
 

--- a/src/subcommand/position_main.cpp
+++ b/src/subcommand/position_main.cpp
@@ -153,9 +153,9 @@ int main_position(int argc, char** argv) {
                  cur_step != path_end;
                  cur_step = target_graph.get_next_step(cur_step)) {
                 const handle_t cur_handle = target_graph.get_handle_of_step(cur_step);
-                std::cout << path_name << "\t" 
-                          << target_graph.get_id(cur_handle) << "\t" 
-                          << walked << std::endl;
+                std::cout << path_name << "\t"
+                          << target_graph.get_id(cur_handle) << "\t"
+                          << walked << '\n';
                 walked += target_graph.get_length(cur_handle);
             }
         }
@@ -1023,7 +1023,7 @@ int main_position(int argc, char** argv) {
 			uint8_t path_b = hashed[16];
 
 			cout << ",#" << std::setfill('0') << std::setw(6) << std::hex << (path_r << 16 | path_g << 8 | path_b );
-			std::cout << std::endl;
+			std::cout << '\n';
 		}
 	}
 

--- a/src/subcommand/similarity_main.cpp
+++ b/src/subcommand/similarity_main.cpp
@@ -317,7 +317,9 @@ int main_similarity(int argc, char** argv) {
             local_map = &thread_local_maps[map_id - 1];
             map_mutex = &map_mutexes[map_id];
         }
-        
+
+        // thread-private, reused across nodes (clear keeps bucket capacity)
+        ska::flat_hash_map<uint32_t, uint64_t> local_path_lengths;
 #pragma omp for
         for (uint64_t node_id = min_id; node_id <= max_id; ++node_id) {
             if (!graph.has_node(node_id)) {
@@ -328,7 +330,7 @@ int main_similarity(int argc, char** argv) {
             if (!node_mask[node_id - shift]) {
                 continue;
             }
-            ska::flat_hash_map<uint32_t, uint64_t> local_path_lengths;
+            local_path_lengths.clear();
             size_t l = graph.get_length(h);
             graph.for_each_step_on_handle(
                 h,

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -1245,7 +1245,7 @@ namespace odgi {
 
 		// Compressed-Mode part starts here :)
 		if (compress) {
-			std::map <uint64_t, algorithms::path_info_t> bins;
+			std::unordered_map<uint64_t, algorithms::path_info_t> bins;
 			graph.for_each_path_handle([&](const path_handle_t &path) {
 				graph.for_each_step_in_path(path, [&](const step_handle_t &occ) {
 					handle_t h = graph.get_handle_of_step(occ);
@@ -1411,7 +1411,7 @@ namespace odgi {
 					uint64_t steps = 0;
 					uint64_t rev = 0;
 					uint64_t path_len_to_use = 0;
-					std::map <uint64_t, algorithms::path_info_t> bins;
+					std::unordered_map<uint64_t, algorithms::path_info_t> bins;
 					if (is_aln) {
 						if (
 								_show_strands ||
@@ -1454,9 +1454,10 @@ namespace odgi {
 									for (uint64_t k = 0; k < hl; ++k) {
 										int64_t curr_bin = (p + k) / _bin_width + 1;
 
-										++bins[curr_bin].mean_depth;
+										auto& b = bins[curr_bin];
+										++b.mean_depth;
 										if (is_rev) {
-											++bins[curr_bin].mean_inv;
+											++b.mean_inv;
 										}
 									}
 								} else if (_binned_mode && _color_by_uncalled_bases) {


### PR DESCRIPTION
Correctness-preserving performance work. Every change is byte-identical to `master` (content-identical after sort where thread ordering makes byte output nondeterministic), `odgi test` passes (26,079,805 assertions), and max RSS is unchanged (<0.1%, measured — including the container-type swaps).

## Runtime — synthetic graph (220k nodes, 4120 paths, 15M steps)

| command | before | after | speedup | output |
|---|--:|--:|:--:|---|
| position --all-positions | 19.75s | 3.28s | **6.0x** | byte-identical |
| flatten -b | 21.95s | 5.56s | **3.95x** | byte-identical |
| paths -H | 40.48s | 10.78s | **3.76x** | byte-identical |
| bin -w5000 | 10.05s | 2.98s | **3.37x** | byte-identical |
| view -g | 2.72s | 1.48s | **1.84x** | byte-identical |
| degree -v | 0.98s | 0.61s | **1.61x** | byte-identical |
| depth -v | 0.96s | 0.64s | **1.50x** | byte-identical |
| flatten -f | 0.49s | 0.36s | **1.36x** | byte-identical |
| depth -d | 0.76s | 0.58s | **1.31x** | content-identical |
| untangle | 109.06s | 90.30s | **1.21x** | content-identical |

Confirmed at scale on a real HPRC chr21 pangenome (4M nodes, 100 haplotypes, 113M steps): flatten -b **2.77x**, bin **2.14x**, view -g **1.24x**, all byte-identical.

## Memory (max RSS, measured for the container swaps)

| swap | command | before → after |
|---|---|---|
| set → unordered_set | depth | 239,228 → 239,396 KB (+0.07%) |
| map → unordered_map | viz -b -m | 913,816 → 913,748 KB (−0.01%) |
| map → unordered_map | viz -b -z | 876,560 → 876,104 KB (−0.05%) |

## What changed

- `std::endl` → `'\n'` in per-element output loops (drops one flush/write syscall per line).
- Per-field `ostream <<` in huge loops rebuilt in a reused `std::string` + `std::to_chars`.
- `std::map` bin entry cached; `std::map`→`unordered_map` (viz), `std::set`→`unordered_set` (depth).
- `reserve()` before large `push_back` loops; dead code and redundant per-step lookups removed.

Validation used a pristine-`master` binary run back-to-back with the patched one under identical load.
